### PR TITLE
using `CODE_SIGNING_ALLOWED=NO` for disabling code signing

### DIFF
--- a/xcodebuild/build.go
+++ b/xcodebuild/build.go
@@ -174,11 +174,7 @@ func (c *CommandBuilder) cmdSlice() []string {
 	}
 
 	if c.disableCodesign {
-		slice = append(slice, "CODE_SIGN_IDENTITY=")
-		slice = append(slice, "CODE_SIGNING_REQUIRED=NO")
-		slice = append(slice, "PROVISIONING_PROFILE_SPECIFIER=")
-		slice = append(slice, "PROVISIONING_PROFILE=")
-		slice = append(slice, "DEVELOPMENT_TEAM=")
+		slice = append(slice, "CODE_SIGNING_ALLOWED=NO")
 	} else {
 		if c.forceDevelopmentTeam != "" {
 			slice = append(slice, fmt.Sprintf("DEVELOPMENT_TEAM=%s", c.forceDevelopmentTeam))

--- a/xcodebuild/build_test.go
+++ b/xcodebuild/build_test.go
@@ -393,11 +393,7 @@ func TestCommandBuilder_cmdSlice(t *testing.T) {
 			action:                            BuildAction,
 			want: []string{
 				"xcodebuild",
-				"CODE_SIGN_IDENTITY=",
-				"CODE_SIGNING_REQUIRED=NO",
-				"PROVISIONING_PROFILE_SPECIFIER=",
-				"PROVISIONING_PROFILE=",
-				"DEVELOPMENT_TEAM=",
+				"CODE_SIGNING_ALLOWED=NO",
 				"",
 				"build",
 				"",


### PR DESCRIPTION
using `CODE_SIGNING_ALLOWED=NO` instead of `CODE_SIGNING_REQUIRED=NO & CODE_SIGN_IDENTITY= & PROVISIONING_PROFILE_SPECIFIER= & PROVISIONING_PROFILE= & DEVELOPMENT_TEAM=` for disable code signing