### PR TITLE
Add distributionBundleIdentifier property to the exportOptions structs.

### DIFF
--- a/exportoptions/appstore_options.go
+++ b/exportoptions/appstore_options.go
@@ -14,6 +14,7 @@ type AppStoreOptionsModel struct {
 	InstallerSigningCertificate        string
 	SigningStyle                       string
 	ICloudContainerEnvironment         ICloudContainerEnvironment
+	DistributionBundleIdentifier       string
 
 	// for app-store exports
 	UploadBitcode bool
@@ -43,6 +44,9 @@ func (options AppStoreOptionsModel) Hash() map[string]interface{} {
 	}
 	if options.ICloudContainerEnvironment != "" {
 		hash[ICloudContainerEnvironmentKey] = options.ICloudContainerEnvironment
+	}
+	if options.DistributionBundleIdentifier != "" {
+		hash[DistributionBundleIdentifier] = options.DistributionBundleIdentifier
 	}
 	if len(options.BundleIDProvisioningProfileMapping) > 0 {
 		hash[ProvisioningProfilesKey] = options.BundleIDProvisioningProfileMapping

--- a/exportoptions/non_appstore_options.go
+++ b/exportoptions/non_appstore_options.go
@@ -14,6 +14,7 @@ type NonAppStoreOptionsModel struct {
 	SigningCertificate                 string
 	SigningStyle                       string
 	ICloudContainerEnvironment         ICloudContainerEnvironment
+	DistributionBundleIdentifier       string
 
 	// for non app-store exports
 	CompileBitcode                           bool
@@ -50,6 +51,9 @@ func (options NonAppStoreOptionsModel) Hash() map[string]interface{} {
 	}
 	if options.ICloudContainerEnvironment != "" {
 		hash[ICloudContainerEnvironmentKey] = options.ICloudContainerEnvironment
+	}
+	if options.DistributionBundleIdentifier != "" {
+		hash[DistributionBundleIdentifier] = options.DistributionBundleIdentifier
 	}
 	if !options.Manifest.IsEmpty() {
 		hash[ManifestKey] = options.Manifest.ToHash()

--- a/exportoptions/properties.go
+++ b/exportoptions/properties.go
@@ -27,6 +27,9 @@ const (
 // ICloudContainerEnvironment ...
 type ICloudContainerEnvironment string
 
+// DistributionBundleIdentifier ...
+const DistributionBundleIdentifier = "distributionBundleIdentifier"
+
 // ManifestKey ...
 const ManifestKey = "manifest"
 


### PR DESCRIPTION
This PR adds support to `distributionBundleIdentifier` export options property introduced in Xcode 12.


```
xcodebuild -h

....
	distributionBundleIdentifier : String

		Reformat archive to focus on eligible target bundle identifier.
....
```