### PR TITLE
[STEP-192]: FindDSYMs returns all of the app dsyms

### DIFF
--- a/xcarchive/ios.go
+++ b/xcarchive/ios.go
@@ -3,7 +3,6 @@ package xcarchive
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-xcode/plistutil"
@@ -377,22 +376,6 @@ func (archive IosArchive) BundleIDProfileInfoMap() map[string]profileutil.Provis
 }
 
 // FindDSYMs ...
-func (archive IosArchive) FindDSYMs() (string, []string, error) {
-	dsymsDirPth := filepath.Join(archive.Path, "dSYMs")
-	dsyms, err := utility.ListEntries(dsymsDirPth, utility.ExtensionFilter(".dsym", true))
-	if err != nil {
-		return "", []string{}, err
-	}
-
-	appDSYM := ""
-	frameworkDSYMs := []string{}
-	for _, dsym := range dsyms {
-		if strings.HasSuffix(dsym, ".app.dSYM") {
-			appDSYM = dsym
-		} else {
-			frameworkDSYMs = append(frameworkDSYMs, dsym)
-		}
-	}
-
-	return appDSYM, frameworkDSYMs, nil
+func (archive IosArchive) FindDSYMs() ([]string, []string, error) {
+	return findDSYMs(archive.Path)
 }

--- a/xcarchive/ios_test.go
+++ b/xcarchive/ios_test.go
@@ -20,7 +20,7 @@ func sampleRepoPath(t *testing.T) string {
 		dir = tmpDir
 	} else {
 		var err error
-		dir, err = pathutil.NormalizedOSTempDirPath("__artifacts__")
+		dir, err = pathutil.NormalizedOSTempDirPath(tempDirName)
 		require.NoError(t, err)
 		sampleArtifactsGitURI := "https://github.com/bitrise-samples/sample-artifacts.git"
 		cmd := command.New("git", "clone", sampleArtifactsGitURI, dir)
@@ -155,7 +155,6 @@ func TestFindDSYMs(t *testing.T) {
 	appDsym, _, err = archive.FindDSYMs()
 	require.NoError(t, err)
 	require.Empty(t, appDsym)
-
 }
 
 func Test_applicationFromArchive(t *testing.T) {

--- a/xcarchive/ios_test.go
+++ b/xcarchive/ios_test.go
@@ -133,7 +133,7 @@ func TestBundleIDProfileInfoMap(t *testing.T) {
 
 func TestFindDSYMs(t *testing.T) {
 	// base case: dsyms for app and frameworks
-	iosArchivePth := filepath.Join(sampleRepoPath(t), "archives/ios.xcarchive")
+	iosArchivePth := filepath.Join(sampleRepoPath(t), "archives/Fruta.xcarchive")
 	archive, err := NewIosArchive(iosArchivePth)
 	require.NoError(t, err)
 

--- a/xcarchive/ios_test.go
+++ b/xcarchive/ios_test.go
@@ -132,14 +132,14 @@ func TestBundleIDProfileInfoMap(t *testing.T) {
 }
 
 func TestFindDSYMs(t *testing.T) {
-	// base case: dsyms for app and frameworks
+	// base case: dsyms for apps and frameworks
 	iosArchivePth := filepath.Join(sampleRepoPath(t), "archives/Fruta.xcarchive")
 	archive, err := NewIosArchive(iosArchivePth)
 	require.NoError(t, err)
 
 	appDsym, otherDsyms, err := archive.FindDSYMs()
 	require.NoError(t, err)
-	require.NotEmpty(t, appDsym)
+	require.Equal(t, 2, len(appDsym))
 	require.Equal(t, 2, len(otherDsyms))
 
 	// no app dsym case: something has changed since the

--- a/xcarchive/macos.go
+++ b/xcarchive/macos.go
@@ -3,7 +3,6 @@ package xcarchive
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-io/go-xcode/profileutil"
@@ -236,25 +235,6 @@ func (archive MacosArchive) BundleIDProfileInfoMap() map[string]profileutil.Prov
 }
 
 // FindDSYMs ...
-func (archive MacosArchive) FindDSYMs() (string, []string, error) {
-	dsymsDirPth := filepath.Join(archive.Path, "dSYMs")
-	dsyms, err := utility.ListEntries(dsymsDirPth, utility.ExtensionFilter(".dsym", true))
-	if err != nil {
-		return "", []string{}, err
-	}
-
-	appDSYM := ""
-	frameworkDSYMs := []string{}
-	for _, dsym := range dsyms {
-		if strings.HasSuffix(dsym, ".app.dSYM") {
-			appDSYM = dsym
-		} else {
-			frameworkDSYMs = append(frameworkDSYMs, dsym)
-		}
-	}
-	if appDSYM == "" && len(frameworkDSYMs) == 0 {
-		return "", []string{}, fmt.Errorf("no dsym found")
-	}
-
-	return appDSYM, frameworkDSYMs, nil
+func (archive MacosArchive) FindDSYMs() ([]string, []string, error) {
+	return findDSYMs(archive.Path)
 }

--- a/xcarchive/macos_test.go
+++ b/xcarchive/macos_test.go
@@ -73,6 +73,6 @@ func TestMacosFindDSYMs(t *testing.T) {
 
 	appDsym, otherDsyms, err := archive.FindDSYMs()
 	require.NoError(t, err)
-	require.NotEmpty(t, appDsym)
+	require.Equal(t, 1, len(appDsym))
 	require.Equal(t, 1, len(otherDsyms))
 }

--- a/xcarchive/xcarchive.go
+++ b/xcarchive/xcarchive.go
@@ -1,7 +1,7 @@
 package xcarchive
 
 import (
-	"fmt"
+	"errors"
 	"path/filepath"
 	"strings"
 
@@ -10,6 +10,10 @@ import (
 	"github.com/bitrise-io/go-utils/ziputil"
 	"github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-io/go-xcode/utility"
+)
+
+var (
+	errNoDsymFound = errors.New("no dsym found")
 )
 
 // IsMacOS try to find the Contents dir under the .app/.
@@ -85,7 +89,7 @@ func findDSYMs(archivePath string) ([]string, []string, error) {
 		}
 	}
 	if len(appDSYMs) == 0 && len(frameworkDSYMs) == 0 {
-		return []string{}, []string{}, fmt.Errorf("no dsym found")
+		return []string{}, []string{}, errNoDsymFound
 	}
 
 	return appDSYMs, frameworkDSYMs, nil

--- a/xcarchive/xcarchive.go
+++ b/xcarchive/xcarchive.go
@@ -1,7 +1,9 @@
 package xcarchive
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -64,4 +66,27 @@ func GetEmbeddedInfoPlistPath(xcarchivePth string) (string, error) {
 
 func getAppSubfolder(basepth string) string {
 	return filepath.Join(basepth, "Products", "Applications")
+}
+
+func findDSYMs(archivePath string) ([]string, []string, error) {
+	dsymsDirPth := filepath.Join(archivePath, "dSYMs")
+	dsyms, err := utility.ListEntries(dsymsDirPth, utility.ExtensionFilter(".dsym", true))
+	if err != nil {
+		return []string{}, []string{}, err
+	}
+
+	appDSYMs := []string{}
+	frameworkDSYMs := []string{}
+	for _, dsym := range dsyms {
+		if strings.HasSuffix(dsym, ".app.dSYM") {
+			appDSYMs = append(appDSYMs, dsym)
+		} else {
+			frameworkDSYMs = append(frameworkDSYMs, dsym)
+		}
+	}
+	if len(appDSYMs) == 0 && len(frameworkDSYMs) == 0 {
+		return []string{}, []string{}, fmt.Errorf("no dsym found")
+	}
+
+	return appDSYMs, frameworkDSYMs, nil
 }

--- a/xcarchive/xcarchive_test.go
+++ b/xcarchive/xcarchive_test.go
@@ -1,8 +1,19 @@
 package xcarchive
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	tempDirName  = "__artifacts__"
+	DSYMSDirName = "dSYMs"
 )
 
 func TestIsMacOS(t *testing.T) {
@@ -37,4 +48,123 @@ func TestIsMacOS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_GivenArchiveWithMultipleAppAndFrameworkDSYMs_WhenFindDSYMsCalled_ThenExpectAllDSYMsToBeReturned(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		numberOfAppDSYMs       int
+		numberOfFrameworkDSYMs int
+	}{
+		{
+			name:                   "1. Given archive with multiple app and framework dSYMs when FindDSYMs called then expect all dSYMs to be returned",
+			numberOfAppDSYMs:       2,
+			numberOfFrameworkDSYMs: 2,
+		},
+		{
+			name:                   "2. Given archive with singe app and framework dSYMs when FindDSYMs called then expect both dSYMs to be returned",
+			numberOfAppDSYMs:       1,
+			numberOfFrameworkDSYMs: 1,
+		},
+		{
+			name:                   "3. Given archive with multiple app dSYMs when FindDSYMs called then expect all app dSYMs to be returned",
+			numberOfAppDSYMs:       2,
+			numberOfFrameworkDSYMs: 0,
+		},
+		{
+			name:                   "4. Given archive with multiple framework dSYMs when FindDSYMs called then expect all framework dSYMs to be returned",
+			numberOfAppDSYMs:       0,
+			numberOfFrameworkDSYMs: 2,
+		},
+		{
+			name:                   "5. Given archive with single app dSYM when FindDSYMs called then expect the app dSYM to be returned",
+			numberOfAppDSYMs:       1,
+			numberOfFrameworkDSYMs: 0,
+		},
+		{
+			name:                   "6. Given archive with single framework dSYM when FindDSYMs called then expect the framework dSYM to be returned",
+			numberOfAppDSYMs:       0,
+			numberOfFrameworkDSYMs: 1,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			archivePath, err := createArchiveWithAppAndFrameworkDSYMs(
+				"archives/ios.dsyms.xcarchive",
+				testCase.numberOfAppDSYMs,
+				testCase.numberOfFrameworkDSYMs,
+			)
+			assert.NoError(t, err)
+
+			appDSYMs, frameworkDSYMs, err := findDSYMs(archivePath)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.numberOfAppDSYMs, len(appDSYMs))
+			assert.Equal(t, testCase.numberOfFrameworkDSYMs, len(frameworkDSYMs))
+		})
+	}
+}
+
+func Test_GivenArchiveWithNoDSYMs_WhenFindDSYMsCalled_ThenExpectAnError(t *testing.T) {
+	archivePath, err := createArchiveWithAppAndFrameworkDSYMs("archives/ios.nodsyms.xcarchive", 0, 0)
+	assert.NoError(t, err)
+
+	_, _, err = findDSYMs(archivePath)
+	assert.Error(t, errNoDsymFound, err)
+}
+
+func createArchiveWithAppAndFrameworkDSYMs(archivePath string, numberOfAppDSYMs, numberOfFrameworkDSYMs int) (string, error) {
+	archivePath, err := createArchive(archivePath)
+	if err != nil {
+		return "", err
+	}
+
+	err = createAppDSYMs(archivePath, numberOfAppDSYMs)
+	if err != nil {
+		return "", err
+	}
+
+	err = createFrameworkDSYMs(archivePath, numberOfFrameworkDSYMs)
+	if err != nil {
+		return "", err
+	}
+
+	return archivePath, nil
+}
+
+func createAppDSYMs(archivePath string, numberOfDSYMs int) error {
+	return createDSYMs(archivePath, "app", numberOfDSYMs)
+}
+
+func createFrameworkDSYMs(archivePath string, numberOfDSYMs int) error {
+	return createDSYMs(archivePath, "framework", numberOfDSYMs)
+}
+
+func createDSYMs(archivePath, dSYMType string, numberOfDSYMs int) error {
+	for i := 0; i < numberOfDSYMs; i++ {
+		err := ioutil.WriteFile(createDSYMFilePath(archivePath, dSYMType, i), nil, 0777)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createDSYMFilePath(archivePath, dSYMType string, index int) string {
+	return filepath.Join(archivePath, DSYMSDirName, fmt.Sprintf("ios-%d.%s.dSYM", index, dSYMType))
+}
+
+func createArchive(archivePath string) (string, error) {
+	tempDirPath, err := pathutil.NormalizedOSTempDirPath(tempDirName)
+	if err != nil {
+		return "", err
+	}
+
+	archivePath = filepath.Join(tempDirPath, archivePath)
+	err = os.MkdirAll(filepath.Join(archivePath, DSYMSDirName), 0755)
+	if err != nil {
+		return "", err
+	}
+
+	return archivePath, nil
 }


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-192

### What?
`FindDSYMs` method of the archives (iOS and MacOS) returns all of the app `dSYM`s. The duplicated logic was also extracted.

### Why?
It is possible to have multiple `dSYM`s for a project, due to the different targets (like one for the regular app and another for app clip). Previously only the last found `dSYM` file was returned by the `FindDSYMs` method, making it impossible to automatically export all of them for further usage. 

### How?
All of the `dSYM` files are collected and during iterating through the content of `BITRISE_DSYM_DIR_PATH`.