### PR TITLE
Returning error upon missing dSYM removed

### DIFF
--- a/xcarchive/xcarchive.go
+++ b/xcarchive/xcarchive.go
@@ -1,7 +1,6 @@
 package xcarchive
 
 import (
-	"errors"
 	"path/filepath"
 	"strings"
 
@@ -10,10 +9,6 @@ import (
 	"github.com/bitrise-io/go-utils/ziputil"
 	"github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-io/go-xcode/utility"
-)
-
-var (
-	errNoDsymFound = errors.New("no dsym found")
 )
 
 // IsMacOS try to find the Contents dir under the .app/.
@@ -87,9 +82,6 @@ func findDSYMs(archivePath string) ([]string, []string, error) {
 		} else {
 			frameworkDSYMs = append(frameworkDSYMs, dsym)
 		}
-	}
-	if len(appDSYMs) == 0 && len(frameworkDSYMs) == 0 {
-		return []string{}, []string{}, errNoDsymFound
 	}
 
 	return appDSYMs, frameworkDSYMs, nil

--- a/xcarchive/xcarchive_test.go
+++ b/xcarchive/xcarchive_test.go
@@ -86,6 +86,11 @@ func Test_GivenArchiveWithMultipleAppAndFrameworkDSYMs_WhenFindDSYMsCalled_ThenE
 			numberOfAppDSYMs:       0,
 			numberOfFrameworkDSYMs: 1,
 		},
+		{
+			name:                   "7. Given archive without any dSYM when FindDSYMs called then expect no dSYM to be returned",
+			numberOfAppDSYMs:       0,
+			numberOfFrameworkDSYMs: 0,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -102,14 +107,6 @@ func Test_GivenArchiveWithMultipleAppAndFrameworkDSYMs_WhenFindDSYMsCalled_ThenE
 			assert.Equal(t, testCase.numberOfFrameworkDSYMs, len(frameworkDSYMs))
 		})
 	}
-}
-
-func Test_GivenArchiveWithNoDSYMs_WhenFindDSYMsCalled_ThenExpectAnError(t *testing.T) {
-	archivePath, err := createArchiveWithAppAndFrameworkDSYMs("archives/ios.nodsyms.xcarchive", 0, 0)
-	assert.NoError(t, err)
-
-	_, _, err = findDSYMs(archivePath)
-	assert.Error(t, errNoDsymFound, err)
 }
 
 func createArchiveWithAppAndFrameworkDSYMs(archivePath string, numberOfAppDSYMs, numberOfFrameworkDSYMs int) (string, error) {


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-303

### Context
Based on [this](https://developer.apple.com/documentation/xcode/building_your_app_to_include_debugging_information#3403353) document the generation of the build symbols is optional, so there is no need to return an error if there is not any dSYM found.