### PR TITLE
Step 917 xcode project update

### DIFF
--- a/xcodeproject/xcodeproj/target.go
+++ b/xcodeproject/xcodeproj/target.go
@@ -44,17 +44,17 @@ func (t Target) DependentTargets() []Target {
 }
 
 // DependentExecutableProductTargets ...
-func (t Target) DependentExecutableProductTargets(includeUITest bool) []Target {
+func (t Target) DependentExecutableProductTargets() []Target {
 	var targets []Target
 	for _, targetDependency := range t.Dependencies {
 		childTarget := targetDependency.Target
-		if !childTarget.IsExecutableProduct() && (!includeUITest || !childTarget.IsUITestProduct()) {
+		if !childTarget.IsExecutableProduct() {
 			continue
 		}
 
 		targets = append(targets, childTarget)
 
-		childDependentTargets := childTarget.DependentExecutableProductTargets(includeUITest)
+		childDependentTargets := childTarget.DependentExecutableProductTargets()
 		targets = append(targets, childDependentTargets...)
 	}
 

--- a/xcodeproject/xcodeproj/target.go
+++ b/xcodeproject/xcodeproj/target.go
@@ -43,6 +43,17 @@ func (t Target) DependentTargets() []Target {
 	return targets
 }
 
+// DependesOn ...
+func (t Target) DependesOn(targetID string) bool {
+	for _, targetDependency := range t.Dependencies {
+		childTarget := targetDependency.Target
+		if childTarget.ID == targetID {
+			return true
+		}
+	}
+	return false
+}
+
 // DependentExecutableProductTargets ...
 func (t Target) DependentExecutableProductTargets() []Target {
 	var targets []Target

--- a/xcodeproject/xcodeproj/target_test.go
+++ b/xcodeproject/xcodeproj/target_test.go
@@ -74,7 +74,7 @@ func TestTarget_DependentExecutableProductTargets(t *testing.T) {
 				ProductReference:       tt.fields.ProductReference,
 				ProductType:            tt.fields.ProductType,
 			}
-			if got := target.DependentExecutableProductTargets(false); !reflect.DeepEqual(got, tt.want) {
+			if got := target.DependentExecutableProductTargets(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Target.DependentExecutableProductTargets() = %v, want %v", got, tt.want)
 			}
 		})

--- a/xcodeproject/xcodeproj/xcodeproj_test.go
+++ b/xcodeproject/xcodeproj/xcodeproj_test.go
@@ -393,7 +393,7 @@ func TestTargets(t *testing.T) {
 		require.Equal(t, "WatchKitApp", dependentTargets[0].Name)
 		require.Equal(t, "WatchKitApp Extension", dependentTargets[1].Name)
 
-		dependentExecutableTarget := target.DependentExecutableProductTargets(false)
+		dependentExecutableTarget := target.DependentExecutableProductTargets()
 		require.Equal(t, 2, len(dependentExecutableTarget))
 		require.Equal(t, "WatchKitApp", dependentExecutableTarget[0].Name)
 		require.Equal(t, "WatchKitApp Extension", dependentExecutableTarget[1].Name)

--- a/xcodeproject/xcodeproj/xcodeproj_test.go
+++ b/xcodeproject/xcodeproj/xcodeproj_test.go
@@ -420,7 +420,7 @@ func TestTargets(t *testing.T) {
 	}
 
 	{
-		properties, err := project.TargetInformationPropertyList("SubProject", "Debug")
+		properties, _, err := project.ReadTargetInfoplist("SubProject", "Debug")
 		require.NoError(t, err)
 		require.Equal(t, serialized.Object{"CFBundlePackageType": "APPL",
 			"UISupportedInterfaceOrientations":      []interface{}{"UIInterfaceOrientationPortrait", "UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight"},


### PR DESCRIPTION
This PR adds support for iOS Auto Provision step's UITest target signing, see: https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/pull/51

Changes:
- removed invalid `includeUITest` input from `Target.DependentExecutableProductTargets` (the executable target has no dependency on the related UITest targets, it works the other way around)
- new `DependesOn` returns if the target depends on another target
- `InformationPropertyList` renamed to `Infoplist` based on the `INFOPLIST_FILE` env