### PR TITLE
Add Recreate Shared Schemes feature

### DIFF
--- a/xcodeproject/xcodeproj/recreate_schemes.go
+++ b/xcodeproject/xcodeproj/recreate_schemes.go
@@ -20,6 +20,8 @@ const (
 	launcherID                  = "Xcode.DebuggerFoundation.Launcher.LLDB"
 )
 
+// SaveSharedScheme saves or overwrites a shared Scheme in the Project
+// The file name will be determined using the Name field of the Scheme
 func (p XcodeProj) SaveSharedScheme(scheme xcscheme.Scheme) error {
 	dir := filepath.Join(p.Path, "xcshareddata", "xcschemes")
 	path := filepath.Join(dir, fmt.Sprintf("%s.xcscheme", scheme.Name))

--- a/xcodeproject/xcodeproj/recreate_schemes_test.go
+++ b/xcodeproject/xcodeproj/recreate_schemes_test.go
@@ -1,0 +1,146 @@
+package xcodeproj
+
+import (
+	"testing"
+
+	plist "github.com/bitrise-io/go-plist"
+	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
+	"github.com/bitrise-io/go-xcode/xcodeproject/xcscheme"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXcodeProj_ReCreateSchemes(t *testing.T) {
+	var raw serialized.Object
+	_, err := plist.Unmarshal([]byte(rawProj), &raw)
+	require.NoError(t, err)
+
+	proj, err := parseProj("BA3CBE6D19F7A93800CED4D5", raw)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		proj     Proj
+		projPath string
+		want     []xcscheme.Scheme
+	}{
+		{
+			name:     "simple",
+			proj:     proj,
+			projPath: "test_path/test.xcodeproj",
+			want: []xcscheme.Scheme{
+				{
+					LastUpgradeVersion: "1240",
+					Version:            "1.3",
+					BuildAction: xcscheme.BuildAction{
+						ParallelizeBuildables:     "YES",
+						BuildImplicitDependencies: "YES",
+						BuildActionEntries: []xcscheme.BuildActionEntry{
+							{
+								BuildForTesting:   "YES",
+								BuildForRunning:   "YES",
+								BuildForProfiling: "YES",
+								BuildForArchiving: "YES",
+								BuildForAnalyzing: "YES",
+								BuildableReference: xcscheme.BuildableReference{
+									BuildableIdentifier: "primary",
+									BlueprintIdentifier: "BA3CBE7419F7A93800CED4D5",
+									BuildableName:       "ios-simple-objc.app",
+									BlueprintName:       "ios-simple-objc",
+									ReferencedContainer: "container:test.xcodeproj",
+								},
+							},
+						},
+					},
+					TestAction: xcscheme.TestAction{
+						BuildConfiguration:           "Debug",
+						SelectedDebuggerIdentifier:   "Xcode.DebuggerFoundation.Debugger.LLDB",
+						SelectedLauncherIdentifier:   "Xcode.DebuggerFoundation.Launcher.LLDB",
+						ShouldUseLaunchSchemeArgsEnv: "YES",
+						Testables: []xcscheme.TestableReference{
+							{
+								Skipped: "NO",
+								BuildableReference: xcscheme.BuildableReference{
+									BuildableIdentifier: "primary",
+									BlueprintIdentifier: "BA3CBE9019F7A93900CED4D5",
+									BuildableName:       "ios-simple-objcTests.xctest",
+									BlueprintName:       "ios-simple-objcTests",
+									ReferencedContainer: "container:test.xcodeproj",
+								},
+							},
+						},
+						MacroExpansion: xcscheme.MacroExpansion{
+							BuildableReference: xcscheme.BuildableReference{
+								BuildableIdentifier: "primary",
+								BlueprintIdentifier: "BA3CBE7419F7A93800CED4D5",
+								BuildableName:       "ios-simple-objc.app",
+								BlueprintName:       "ios-simple-objc",
+								ReferencedContainer: "container:test.xcodeproj",
+							},
+						},
+						AdditionalOptions: xcscheme.AdditionalOptions{},
+					},
+					LaunchAction: xcscheme.LaunchAction{
+						BuildConfiguration:             "Debug",
+						SelectedDebuggerIdentifier:     "Xcode.DebuggerFoundation.Debugger.LLDB",
+						SelectedLauncherIdentifier:     "Xcode.DebuggerFoundation.Launcher.LLDB",
+						LaunchStyle:                    "0",
+						UseCustomWorkingDirectory:      "NO",
+						IgnoresPersistentStateOnLaunch: "NO",
+						DebugDocumentVersioning:        "YES",
+						DebugServiceExtension:          "internal",
+						AllowLocationSimulation:        "YES",
+						BuildableProductRunnable: xcscheme.BuildableProductRunnable{
+							RunnableDebuggingMode: "0",
+							BuildableReference: xcscheme.BuildableReference{
+								BuildableIdentifier: "primary",
+								BlueprintIdentifier: "BA3CBE7419F7A93800CED4D5",
+								BuildableName:       "ios-simple-objc.app",
+								BlueprintName:       "ios-simple-objc",
+								ReferencedContainer: "container:test.xcodeproj",
+							},
+						},
+						AdditionalOptions: xcscheme.AdditionalOptions{},
+					},
+					ProfileAction: xcscheme.ProfileAction{
+						BuildConfiguration:           "Release",
+						ShouldUseLaunchSchemeArgsEnv: "YES",
+						SavedToolIdentifier:          "",
+						UseCustomWorkingDirectory:    "NO",
+						DebugDocumentVersioning:      "YES",
+						BuildableProductRunnable: xcscheme.BuildableProductRunnable{
+							RunnableDebuggingMode: "0",
+							BuildableReference: xcscheme.BuildableReference{
+								BuildableIdentifier: "primary",
+								BlueprintIdentifier: "BA3CBE7419F7A93800CED4D5",
+								BuildableName:       "ios-simple-objc.app",
+								BlueprintName:       "ios-simple-objc",
+								ReferencedContainer: "container:test.xcodeproj",
+							},
+						},
+					},
+					AnalyzeAction: xcscheme.AnalyzeAction{
+						BuildConfiguration: "Debug",
+					},
+					ArchiveAction: xcscheme.ArchiveAction{
+						BuildConfiguration:       "Release",
+						RevealArchiveInOrganizer: "YES",
+					},
+					Name:     "ios-simple-objc",
+					Path:     "",
+					IsShared: false,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := XcodeProj{
+				Proj: tt.proj,
+				Path: tt.projPath,
+			}
+			got := p.ReCreateSchemes()
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/xcodeproject/xcodeproj/scheme.go
+++ b/xcodeproject/xcodeproj/scheme.go
@@ -1,0 +1,93 @@
+package xcodeproj
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-xcode/xcodeproject/xcscheme"
+)
+
+const (
+	yes         = "YES"
+	no          = "NO"
+	buildableID = "primary"
+)
+
+func (p XcodeProj) saveSharedScheme(scheme xcscheme.Scheme) error {
+	dir := filepath.Join(p.Path, "xcshareddata", "xcschemes")
+	path := filepath.Join(dir, fmt.Sprintf("%s.xcscheme", scheme.Name))
+
+	contents, err := scheme.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal Scheme: %v", err)
+	}
+
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	if err := ioutil.WriteFile(path, contents, 0600); err != nil {
+		return fmt.Errorf("failed to write Scheme file (%s): %v", path, err)
+	}
+
+	return nil
+}
+
+// ReCreateSharedSchemes creates new shared schemes based on Targets
+func (p XcodeProj) ReCreateSharedSchemes() error {
+	for _, target := range p.Proj.Targets {
+		if !target.IsExecutableProduct() {
+			continue
+		}
+
+		var uiTestTargets []Target
+		for _, target := range p.Proj.Targets {
+			if target.IsUITestProduct() && target.DependesOn(target.ID) {
+				uiTestTargets = append(uiTestTargets, target)
+			}
+		}
+
+		scheme := newScheme(target, uiTestTargets, filepath.Base(p.Name))
+		if err := p.saveSharedScheme(scheme); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func newScheme(buildTarget Target, testTargets []Target, projectname string) xcscheme.Scheme {
+	return xcscheme.Scheme{
+		LastUpgradeVersion: "1240",
+		Version:            "1.3",
+		BuildAction:        newBuildAction(buildTarget, projectname),
+		Name:               buildTarget.Name,
+		// Path: ,
+	}
+}
+
+func newBuildAction(target Target, projectName string) xcscheme.BuildAction {
+	return xcscheme.BuildAction{
+		ParallelizeBuildables:     yes,
+		BuildImplicitDependencies: yes,
+		BuildActionEntries: []xcscheme.BuildActionEntry{
+			{
+				BuildForTesting:   yes,
+				BuildForRunning:   yes,
+				BuildForProfiling: yes,
+				BuildForArchiving: yes,
+				BuildForAnalyzing: yes,
+				BuildableReference: xcscheme.BuildableReference{
+					BuildableIdentifier: buildableID,
+					BlueprintIdentifier: target.ID,
+					BuildableName:       path.Base(target.ProductReference.Path),
+					BlueprintName:       target.Name,
+					ReferencedContainer: fmt.Sprintf("container:%s", projectName),
+				},
+			},
+		},
+	}
+}

--- a/xcodeproject/xcodeproj/target.go
+++ b/xcodeproject/xcodeproj/target.go
@@ -87,6 +87,14 @@ func (t Target) IsExecutableProduct() bool {
 	return t.IsAppProduct() || t.IsAppExtensionProduct()
 }
 
+// IsTest identifies test targets
+// Based on https://github.com/CocoaPods/Xcodeproj/blob/907c81763a7660978fda93b2f38f05de0cbb51ad/lib/xcodeproj/project/object/native_target.rb#L470
+func (t Target) IsTest() bool {
+	return t.IsTestProduct() ||
+		t.IsUITestProduct() ||
+		t.ProductType == "com.apple.product-type.bundle" // OCTest bundle
+}
+
 // IsTestProduct ...
 func (t Target) IsTestProduct() bool {
 	return filepath.Ext(t.ProductType) == ".unit-test"

--- a/xcodeproject/xcscheme/util.go
+++ b/xcodeproject/xcscheme/util.go
@@ -20,13 +20,24 @@ func FindSchemesIn(root string) (schemes []Scheme, err error) {
 		return nil, err
 	}
 
-	for _, pth := range append(sharedPths, userPths...) {
-		scheme, err := Open(pth)
-		if err != nil {
-			return nil, err
+	for _, schemePaths := range []struct {
+		schemes  []string
+		isShared bool
+	}{
+		{sharedPths, true},
+		{userPths, false},
+	} {
+		for _, pth := range schemePaths.schemes {
+			scheme, err := Open(pth)
+			if err != nil {
+				return nil, err
+			}
+
+			scheme.IsShared = schemePaths.isShared
+			schemes = append(schemes, scheme)
 		}
-		schemes = append(schemes, scheme)
 	}
+
 	return
 }
 

--- a/xcodeproject/xcscheme/xcscheme.go
+++ b/xcodeproject/xcscheme/xcscheme.go
@@ -13,6 +13,7 @@ import (
 
 // BuildableReference ...
 type BuildableReference struct {
+	BuildableIdentifier string `xml:"BuildableIdentifier,attr"`
 	BlueprintIdentifier string `xml:"BlueprintIdentifier,attr"`
 	BuildableName       string `xml:"BuildableName,attr"`
 	BlueprintName       string `xml:"BlueprintName,attr"`
@@ -39,14 +40,20 @@ func (r BuildableReference) ReferencedContainerAbsPath(schemeContainerDir string
 
 // BuildActionEntry ...
 type BuildActionEntry struct {
-	BuildForTesting    string `xml:"buildForTesting,attr"`
-	BuildForArchiving  string `xml:"buildForArchiving,attr"`
+	BuildForTesting   string `xml:"buildForTesting,attr"`
+	BuildForRunning   string `xml:"buildForRunning,attr"`
+	BuildForProfiling string `xml:"buildForProfiling,attr"`
+	BuildForArchiving string `xml:"buildForArchiving,attr"`
+	BuildForAnalyzing string `xml:"buildForAnalyzing,attr"`
+
 	BuildableReference BuildableReference
 }
 
 // BuildAction ...
 type BuildAction struct {
-	BuildActionEntries []BuildActionEntry `xml:"BuildActionEntries>BuildActionEntry"`
+	ParallelizeBuildables     string             `xml:"parallelizeBuildables,attr"`
+	BuildImplicitDependencies string             `xml:"buildImplicitDependencies,attr"`
+	BuildActionEntries        []BuildActionEntry `xml:"BuildActionEntries>BuildActionEntry"`
 }
 
 // TestableReference ...
@@ -55,22 +62,41 @@ type TestableReference struct {
 	BuildableReference BuildableReference
 }
 
+// MacroExpansion ...
+type MacroExpansion struct {
+	BuildableReference BuildableReference
+}
+
+// AdditionalOptions ...
+type AdditionalOptions struct {
+}
+
 // TestAction ...
 type TestAction struct {
-	Testables          []TestableReference `xml:"Testables>TestableReference"`
-	BuildConfiguration string              `xml:"buildConfiguration,attr"`
+	BuildConfiguration           string `xml:"buildConfiguration,attr"`
+	SelectedDebuggerIdentifier   string `xml:"selectedDebuggerIdentifier,attr"`
+	SelectedLauncherIdentifier   string `xml:"selectedLauncherIdentifier,attr"`
+	ShouldUseLaunchSchemeArgsEnv string `xml:"shouldUseLaunchSchemeArgsEnv,attr"`
+
+	Testables         []TestableReference `xml:"Testables>TestableReference"`
+	MacroExpansion    MacroExpansion
+	AdditionalOptions AdditionalOptions
 }
 
 // ArchiveAction ...
 type ArchiveAction struct {
-	BuildConfiguration string `xml:"buildConfiguration,attr"`
+	BuildConfiguration       string `xml:"buildConfiguration,attr"`
+	RevealArchiveInOrganizer string `xml:"revealArchiveInOrganizer,attr"`
 }
 
 // Scheme ...
 type Scheme struct {
+	LastUpgradeVersion string `xml:"LastUpgradeVersion,attr"`
+	Version            string `xml:"version,attr"`
+
 	BuildAction   BuildAction
-	ArchiveAction ArchiveAction
 	TestAction    TestAction
+	ArchiveAction ArchiveAction
 
 	Name string `xml:"-"`
 	Path string `xml:"-"`
@@ -111,6 +137,7 @@ func (s Scheme) Write(pth string) error {
 	}
 
 	contentsNewline := strings.ReplaceAll(string(contents), "><", ">\n<")
+	// Place XML Attributes on separate lines
 	contentsNewline = strings.ReplaceAll(contentsNewline, " ", "\n")
 
 	var contentsIndented string

--- a/xcodeproject/xcscheme/xcscheme.go
+++ b/xcodeproject/xcscheme/xcscheme.go
@@ -98,8 +98,9 @@ type Scheme struct {
 	TestAction    TestAction
 	ArchiveAction ArchiveAction
 
-	Name string `xml:"-"`
-	Path string `xml:"-"`
+	Name     string `xml:"-"`
+	Path     string `xml:"-"`
+	IsShared bool   `xml:"-"`
 }
 
 // Open ...

--- a/xcodeproject/xcscheme/xcscheme.go
+++ b/xcodeproject/xcscheme/xcscheme.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/fileutil"
@@ -141,8 +142,10 @@ func (s Scheme) Marshal() ([]byte, error) {
 	}
 
 	contentsNewline := strings.ReplaceAll(string(contents), "><", ">\n<")
+
 	// Place XML Attributes on separate lines
-	contentsNewline = strings.ReplaceAll(contentsNewline, " ", "\n")
+	re := regexp.MustCompile(`\s([^=<>/]*)\s?=\s?"([^=<>/]*)"`)
+	contentsNewline = re.ReplaceAllString(contentsNewline, "\n$1 = \"$2\"")
 
 	var contentsIndented string
 
@@ -153,10 +156,6 @@ func (s Scheme) Marshal() ([]byte, error) {
 			currentLine = XMLEnd
 		} else if strings.HasPrefix(line, "<") {
 			currentLine = XMLStart
-		}
-
-		if currentLine == XMLAttribute {
-			line = strings.Replace(line, "=", " = ", 1)
 		}
 
 		if currentLine == XMLEnd && indent != 0 {

--- a/xcodeproject/xcscheme/xcscheme.go
+++ b/xcodeproject/xcscheme/xcscheme.go
@@ -83,6 +83,42 @@ type TestAction struct {
 	AdditionalOptions AdditionalOptions
 }
 
+// BuildableProductRunnable ...
+type BuildableProductRunnable struct {
+	RunnableDebuggingMode string `xml:"runnableDebuggingMode,attr"`
+	BuildableReference    BuildableReference
+}
+
+// LaunchAction ...
+type LaunchAction struct {
+	BuildConfiguration             string `xml:"buildConfiguration,attr"`
+	SelectedDebuggerIdentifier     string `xml:"selectedDebuggerIdentifier,attr"`
+	SelectedLauncherIdentifier     string `xml:"selectedLauncherIdentifier,attr"`
+	LaunchStyle                    string `xml:"launchStyle,attr"`
+	UseCustomWorkingDirectory      string `xml:"useCustomWorkingDirectory,attr"`
+	IgnoresPersistentStateOnLaunch string `xml:"ignoresPersistentStateOnLaunch,attr"`
+	DebugDocumentVersioning        string `xml:"debugDocumentVersioning,attr"`
+	DebugServiceExtension          string `xml:"debugServiceExtension,attr"`
+	AllowLocationSimulation        string `xml:"allowLocationSimulation,attr"`
+	BuildableProductRunnable       BuildableProductRunnable
+	AdditionalOptions              AdditionalOptions
+}
+
+// ProfileAction ...
+type ProfileAction struct {
+	BuildConfiguration           string `xml:"buildConfiguration,attr"`
+	ShouldUseLaunchSchemeArgsEnv string `xml:"shouldUseLaunchSchemeArgsEnv,attr"`
+	SavedToolIdentifier          string `xml:"savedToolIdentifier,attr"`
+	UseCustomWorkingDirectory    string `xml:"useCustomWorkingDirectory,attr"`
+	DebugDocumentVersioning      string `xml:"debugDocumentVersioning,attr"`
+	BuildableProductRunnable     BuildableProductRunnable
+}
+
+// AnalyzeAction ...
+type AnalyzeAction struct {
+	BuildConfiguration string `xml:"buildConfiguration,attr"`
+}
+
 // ArchiveAction ...
 type ArchiveAction struct {
 	BuildConfiguration       string `xml:"buildConfiguration,attr"`
@@ -96,6 +132,9 @@ type Scheme struct {
 
 	BuildAction   BuildAction
 	TestAction    TestAction
+	LaunchAction  LaunchAction
+	ProfileAction ProfileAction
+	AnalyzeAction AnalyzeAction
 	ArchiveAction ArchiveAction
 
 	Name     string `xml:"-"`

--- a/xcodeproject/xcscheme/xcscheme.go
+++ b/xcodeproject/xcscheme/xcscheme.go
@@ -127,8 +127,10 @@ type ArchiveAction struct {
 
 // Scheme ...
 type Scheme struct {
+	// The last known Xcode version.
 	LastUpgradeVersion string `xml:"LastUpgradeVersion,attr"`
-	Version            string `xml:"version,attr"`
+	// The version of `.xcscheme` files supported.
+	Version string `xml:"version,attr"`
 
 	BuildAction   BuildAction
 	TestAction    TestAction

--- a/xcodeproject/xcscheme/xcscheme_test.go
+++ b/xcodeproject/xcscheme/xcscheme_test.go
@@ -69,6 +69,17 @@ func TestAppTestActionEntry(t *testing.T) {
 	require.False(t, scheme.TestAction.Testables[1].BuildableReference.IsAppReference())
 }
 
+func TestScheme_Marshal(t *testing.T) {
+	pth := testhelper.CreateTmpFile(t, "ios-simple-objc.xcscheme", schemeContent)
+	scheme, err := Open(pth)
+	require.NoError(t, err)
+
+	content, err := scheme.Marshal()
+	require.NoError(t, err)
+
+	require.Equal(t, schemeContent, string(content))
+}
+
 const schemeContent = `<?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"


### PR DESCRIPTION
### Context

Add support to write Schemes and the feature to recreate Schemes from Targets.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

- Add Marshal method to Scheme: This Marshals a usual XML file but modifies it to match the format used by Xcode
- Support all fields for Scheme (including LaunchAction, ProfileAction and ArchiveAction)
- Adding ReCreateSchemes function


### Decisions

<!-- Please list decisions that were made for this change. -->



