### PR TITLE
Add resultBunldePath arg to xcodebuild command builder

### DIFF
--- a/xcodebuild/build.go
+++ b/xcodebuild/build.go
@@ -59,9 +59,10 @@ type CommandBuilder struct {
 	customBuildActions []string
 
 	// Options
-	archivePath   string
-	customOptions []string
-	sdk           string
+	archivePath      string
+	customOptions    []string
+	sdk              string
+	resultBundlePath string
 
 	// Archive
 	action Action
@@ -127,6 +128,12 @@ func (c *CommandBuilder) SetCustomBuildAction(buildAction ...string) *CommandBui
 // SetArchivePath ...
 func (c *CommandBuilder) SetArchivePath(archivePath string) *CommandBuilder {
 	c.archivePath = archivePath
+	return c
+}
+
+// SetResultBundlePath ...
+func (c *CommandBuilder) SetResultBundlePath(resultBundlePath string) *CommandBuilder {
+	c.resultBundlePath = resultBundlePath
 	return c
 }
 
@@ -220,6 +227,10 @@ func (c *CommandBuilder) cmdSlice() []string {
 
 	if c.sdk != "" {
 		slice = append(slice, "-sdk", c.sdk)
+	}
+
+	if c.resultBundlePath != "" {
+		slice = append(slice, "-resultBundlePath", c.resultBundlePath)
 	}
 
 	slice = append(slice, c.customOptions...)

--- a/xcodebuild/build_test.go
+++ b/xcodebuild/build_test.go
@@ -24,6 +24,7 @@ func TestCommandBuilder_cmdSlice(t *testing.T) {
 		archivePath                       string
 		customOptions                     []string
 		sdk                               string
+		resultBundlePath                  string
 		action                            Action
 		want                              []string
 	}{
@@ -152,11 +153,14 @@ func TestCommandBuilder_cmdSlice(t *testing.T) {
 			archivePath:                       "",
 			customOptions:                     []string{""},
 			sdk:                               "",
+			resultBundlePath:                  "/tmp/Analyze.xcresult",
 			action:                            AnalyzeAction,
 			want: []string{
 				"xcodebuild",
 				"",
 				"analyze",
+				"-resultBundlePath",
+				"/tmp/Analyze.xcresult",
 				"",
 			},
 		},
@@ -418,6 +422,7 @@ func TestCommandBuilder_cmdSlice(t *testing.T) {
 				archivePath:                       tt.archivePath,
 				customOptions:                     tt.customOptions,
 				sdk:                               tt.sdk,
+				resultBundlePath:                  tt.resultBundlePath,
 				action:                            tt.action,
 			}
 			if got := c.cmdSlice(); !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires **NO** [version update](https://semver.org/)

### Context

Adds `-resultBundlePath` xcodebuild param.

Resolves:https://bitrise.atlassian.net/browse/STEP-1192
