### PR TITLE
Add workaround for simulator boot failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _tmp/
-.vscode/*
+.vscode/
+/.idea/

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -313,11 +313,20 @@ func BootSimulator(simulator InfoModel, xcodebuildVersion models.XcodebuildVersi
 // - https://stackoverflow.com/questions/2182040/the-application-cannot-be-opened-because-its-executable-is-missing/16546673#16546673
 // - https://ss64.com/osx/lsregister.html
 func simulatorBootWorkaround(simulatorAppPath string) {
-	cmdString := "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
-	cmd := command.New(cmdString, "-f", simulatorAppPath)
-
-	outStr, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	cmd := command.New("sw_vers", "-productVersion")
+	macOSVersion, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		log.Warnf("failed to reset launch services database, output: %s, error: %s", outStr, err)
+		log.Warnf("failed to determine macOS version, error: %s", err)
+	}
+
+	if strings.HasPrefix(macOSVersion, "11.") { // It's Big Sur
+		cmdString := "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+		cmd := command.New(cmdString, "-f", simulatorAppPath)
+
+		log.Debugf(cmdString)
+		outStr, err := cmd.RunAndReturnTrimmedCombinedOutput()
+		if err != nil {
+			log.Warnf("failed to reset launch services database, output: %s, error: %s", outStr, err)
+		}
 	}
 }

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -293,6 +293,17 @@ func BootSimulator(simulator InfoModel, xcodebuildVersion models.XcodebuildVersi
 	}
 	simulatorAppFullPath := filepath.Join(xcodeDevDirPth, "Applications", simulatorApp+".app")
 
+	// https://ss64.com/osx/lsregister.html
+	// reset launch services database to avoid Big Sur's sporadic failure to find the Simulator App
+	resetLaunchServicesDBCommand := command.New("/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister", "-f", simulatorAppFullPath)
+
+	log.Printf("$ %s", resetLaunchServicesDBCommand.PrintableCommandArgs())
+
+	outStr, err := resetLaunchServicesDBCommand.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		fmt.Errorf("failed to reset launch services database, output: %s, error: %s", outStr, err)
+	}
+
 	openCmd := command.New("open", simulatorAppFullPath, "--args", "-CurrentDeviceUDID", simulator.ID)
 
 	log.Printf("$ %s", openCmd.PrintableCommandArgs())


### PR DESCRIPTION
Big Sur sometimes fails to open the Simulator App. This workaround reregisters the app in launch services database.

The workaround only runs on Big Sur to limit the blast radius of a future change.

