### PR TITLE
Migrate to the new go-steputils package.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10
-	github.com/bitrise-io/go-steputils v0.0.0-20210831050118-9a8de76b2f19
-	github.com/bitrise-io/go-utils v0.0.0-20210830144330-49d11743a4fd
+	github.com/bitrise-io/go-steputils v0.0.0-20210924114124-851d30b88892
+	github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d
 	github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,15 @@ github.com/bitrise-io/go-steputils v0.0.0-20210830080834-0208a71cf7f8 h1:U2cAaNc
 github.com/bitrise-io/go-steputils v0.0.0-20210830080834-0208a71cf7f8/go.mod h1:F+FPN4MS73h+m+8DYL1FyqEK4O1PqSdEpA1Pccp1LN0=
 github.com/bitrise-io/go-steputils v0.0.0-20210831050118-9a8de76b2f19 h1:ZLuZ7EqpV2mgxEZTZrWxFjDo8t0F576QQLyschuuJRE=
 github.com/bitrise-io/go-steputils v0.0.0-20210831050118-9a8de76b2f19/go.mod h1:deuDfnw5Hot7Uajr7gsM5hNKAlKS3iIAPpZgfZSDNOk=
+github.com/bitrise-io/go-steputils v0.0.0-20210924114124-851d30b88892 h1:aD5jTvdf5zIngQ5HeR7Idteae4yaXLqJGn8PE4k2xtI=
+github.com/bitrise-io/go-steputils v0.0.0-20210924114124-851d30b88892/go.mod h1:6Y7Dl40gwgW9YG1RAWcjFBk1u9uotuix8g2IkVTXK34=
 github.com/bitrise-io/go-utils v0.0.0-20210824130242-27933dca637a/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/bitrise-io/go-utils v0.0.0-20210830075908-d621a78334fb h1:6jPT4AOQq/PQntTzb+EoyHSj0BwNgQxxCRj7rgP7F0Q=
 github.com/bitrise-io/go-utils v0.0.0-20210830075908-d621a78334fb/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/bitrise-io/go-utils v0.0.0-20210830144330-49d11743a4fd h1:CZIAr+uoOhHS6WfsTXHi3v9CUhOXcKSyRupi9cIcRWc=
 github.com/bitrise-io/go-utils v0.0.0-20210830144330-49d11743a4fd/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
+github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d h1:jU5wvShTLKSo2gYlIBoXONS2MRRL8UwiPOSqi88JF2k=
+github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630 h1:V+xoYqGSkN8aUxCc806zDKjGGpBVUtV0Vytf5OsB3gc=
 github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/xcpretty/xcpretty.go
+++ b/xcpretty/xcpretty.go
@@ -6,10 +6,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/bitrise-io/go-utils/env"
-
-	"github.com/bitrise-io/go-steputils/command/rubycommand"
+	"github.com/bitrise-io/go-steputils/ruby"
 	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/env"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodebuild"
 	version "github.com/hashicorp/go-version"
@@ -103,15 +102,25 @@ func (c CommandModel) Run() (string, error) {
 
 // IsInstalled ...
 func IsInstalled() (bool, error) {
-	return rubycommand.IsGemInstalled("xcpretty", "")
+	locator := env.NewCommandLocator()
+	factory, err := ruby.NewCommandFactory(command.NewFactory(env.NewRepository()), locator)
+	if err != nil {
+		return false, err
+	}
+
+	return ruby.NewEnvironment(factory, locator).IsGemInstalled("xcpretty", "")
 }
 
 // Install ...
 func Install() ([]command.Command, error) {
-	cmds, err := rubycommand.GemInstall("xcpretty", "", false)
+	locator := env.NewCommandLocator()
+	factory, err := ruby.NewCommandFactory(command.NewFactory(env.NewRepository()), locator)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create command model, error: %s", err)
+		return nil, err
 	}
+
+	cmds := factory.CreateGemInstall("xcpretty", "", false, false, nil)
+
 	return cmds, nil
 }
 


### PR DESCRIPTION
Update to the latest version of `go-utils` and `go-steputils` packages.