### PR TITLE
Use cert hash to identify instead of common name.

### DIFF
--- a/autocodesign/projectmanager/projectmanager.go
+++ b/autocodesign/projectmanager/projectmanager.go
@@ -132,7 +132,7 @@ func (p Project) ForceCodesignAssets(distribution autocodesign.DistributionType,
 		log.Printf("  provisioning Profile: %s", profile.Attributes().Name)
 		log.Printf("  certificate: %s", codesignAssets.Certificate.CommonName)
 
-		if err := p.projHelper.XcProj.ForceCodeSign(p.projHelper.Configuration, target.Name, teamID, codesignAssets.Certificate.CommonName, profile.Attributes().UUID); err != nil {
+		if err := p.projHelper.XcProj.ForceCodeSign(p.projHelper.Configuration, target.Name, teamID, codesignAssets.Certificate.SHA1Fingerprint, profile.Attributes().UUID); err != nil {
 			return fmt.Errorf("failed to apply code sign settings for target (%s): %s", target.Name, err)
 		}
 	}
@@ -161,7 +161,7 @@ func (p Project) ForceCodesignAssets(distribution autocodesign.DistributionType,
 			log.Printf("  certificate: %s", devCodesignAssets.Certificate.CommonName)
 
 			for _, c := range uiTestTarget.BuildConfigurationList.BuildConfigurations {
-				if err := p.projHelper.XcProj.ForceCodeSign(c.Name, uiTestTarget.Name, teamID, devCodesignAssets.Certificate.CommonName, profile.Attributes().UUID); err != nil {
+				if err := p.projHelper.XcProj.ForceCodeSign(c.Name, uiTestTarget.Name, teamID, devCodesignAssets.Certificate.SHA1Fingerprint, profile.Attributes().UUID); err != nil {
 					return fmt.Errorf("failed to apply code sign settings for target (%s): %s", uiTestTarget.Name, err)
 				}
 			}


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Apply the same changes as https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/pull/69 in the autocodesign package. As the Step did not use this package yet, the change needs to be applied here too.

Use cert hash to identify instead of common name. This prevents Umlauts in the common name to cause encoding problems.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
