### PR TITLE
autocodesign: AppClip autocodesign fix

### DIFF
--- a/autocodesign/devportalclient/appstoreconnect/capabilities.go
+++ b/autocodesign/devportalclient/appstoreconnect/capabilities.go
@@ -70,13 +70,13 @@ var ServiceTypeByKey = map[string]CapabilityType{
 	"com.apple.developer.default-data-protection":                              DataProtection,
 	"com.apple.developer.icloud-services":                                      ICloud,
 	"com.apple.developer.authentication-services.autofill-credential-provider": AutofillCredentialProvider,
-	"com.apple.developer.parent-application-identifiers":                       ParentApplicationIdentifiers,
 	"com.apple.developer.networking.wifi-info":                                 AccessWIFIInformation,
 	"com.apple.developer.ClassKit-environment":                                 Classkit,
 	"com.apple.developer.coremedia.hls.low-latency":                            CoremediaHLSLowLatency,
 	// does not appear on developer portal
 	"com.apple.developer.icloud-container-identifiers":   Ignored,
 	"com.apple.developer.ubiquity-container-identifiers": Ignored,
+	"com.apple.developer.parent-application-identifiers": Ignored,
 	// These are entitlements not supported via the API and this step,
 	// profile needs to be manually generated on Apple Developer Portal.
 	"com.apple.developer.contacts.notes":         ProfileAttachedEntitlement,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10
 	github.com/bitrise-io/go-steputils v0.0.0-20210929162140-866a65a1e14a
-	github.com/bitrise-io/go-utils v0.0.0-20210930092040-cceb74a5ac24
+	github.com/bitrise-io/go-utils v0.0.0-20211008161027-fa11986847a0
 	github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/bitrise-io/go-steputils v0.0.0-20210929162140-866a65a1e14a/go.mod h1:
 github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/bitrise-io/go-utils v0.0.0-20210930092040-cceb74a5ac24 h1:T/tR1FSSH2lUYv9gS2US5ICafIlPogHgh4Jo+LoEv2g=
 github.com/bitrise-io/go-utils v0.0.0-20210930092040-cceb74a5ac24/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
+github.com/bitrise-io/go-utils v0.0.0-20211008161027-fa11986847a0 h1:fT81H9m8GHazqZ0WsVq7GE5DfK4xSyXnHGJKyita2BM=
+github.com/bitrise-io/go-utils v0.0.0-20211008161027-fa11986847a0/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630 h1:V+xoYqGSkN8aUxCc806zDKjGGpBVUtV0Vytf5OsB3gc=
 github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Update to latest go-utils and ignore com.apple.developer.parent-application-identifiers project capability.

### Context

This PR applies the [App Clip issue fix](https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/pull/79) for the `autocodesign` package.

Use case: https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/pull/74

### Changes

- Ignore `com.apple.developer.parent-application-identifiers` project capability check

