### PR TITLE
Read archive codesign parameters

### DIFF
--- a/xcarchive/ios.go
+++ b/xcarchive/ios.go
@@ -380,6 +380,7 @@ func (archive IosArchive) FindDSYMs() ([]string, []string, error) {
 	return findDSYMs(archive.Path)
 }
 
+// ReadCodesignParameters ...
 func (archive IosArchive) ReadCodesignParameters() (*autocodesign.AppLayout, error) {
 	var teamID string
 	entitlementsMap := map[string]autocodesign.Entitlements{}

--- a/xcarchive/ios.go
+++ b/xcarchive/ios.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-xcode/autocodesign"
 	"github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-io/go-xcode/profileutil"
 )
@@ -377,4 +378,38 @@ func (archive IosArchive) BundleIDProfileInfoMap() map[string]profileutil.Provis
 // FindDSYMs ...
 func (archive IosArchive) FindDSYMs() ([]string, []string, error) {
 	return findDSYMs(archive.Path)
+}
+
+func (archive IosArchive) ReadCodesignParameters() (*autocodesign.AppLayout, error) {
+	var teamID string
+	entitlementsMap := map[string]autocodesign.Entitlements{}
+
+	bundleIDProfileInfoMap := archive.BundleIDProfileInfoMap()
+	for bundleIdentifier, provisioningProfile := range bundleIDProfileInfoMap {
+		if teamID == "" {
+			teamID = provisioningProfile.TeamID
+		}
+
+		entitlementsMap[bundleIdentifier] = autocodesign.Entitlements(provisioningProfile.Entitlements)
+	}
+
+	var platform autocodesign.Platform
+
+	platformName := archive.Application.InfoPlist["DTPlatformName"]
+	switch platformName {
+	case "iphoneos":
+		platform = autocodesign.IOS
+	case "appletvos":
+		platform = autocodesign.TVOS
+	default:
+		return nil, fmt.Errorf("unsupported platform found: %s", platformName)
+	}
+
+	codesignParameters := autocodesign.AppLayout{
+		TeamID:                                 teamID,
+		Platform:                               platform,
+		EntitlementsByArchivableTargetBundleID: entitlementsMap,
+		UITestTargetBundleIDs:                  nil,
+	}
+	return &codesignParameters, nil
 }


### PR DESCRIPTION
### Context

We are about to introduce automatic codesigning to xcodebuild related steps.
The current autocodesign package offers functionality to read the codesigning requirements from an iOS project.
In the case of the `Export iOS and tvOS Xcode archive` an iOS project is not given, but a `.xcarchive` file.

This PR adds a new function to `xcarchive` package (IosArchive.ReadCodesignParameters) to read codesigning requirements from an archive file. The return value can be passed to the autocodesign lib.

The archive file does not have any information about the project's UITest targets, so the `UITestTargetBundleIDs` property of the `autocodesign.AppLayout` return value will be nil always. This means `Export iOS and tvOS Xcode archive` step can not automatically codesign the project's UITest targets.

### Changes

- Add `IosArchive.ReadCodesignParameters` function to the `xcarchive` package.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
