### PR TITLE
Improved minimum profile validity, added Team ID for codesign package

### DIFF
--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -35,6 +35,7 @@ const (
 type Opts struct {
 	AuthType                   AuthType
 	ShouldConsiderXcodeSigning bool
+	TeamID                     string
 
 	ExportMethod      autocodesign.DistributionType
 	XcodeMajorVersion int
@@ -240,8 +241,7 @@ func (m *Manager) downloadAndInstallCertificates() error {
 		panic(fmt.Sprintf("no valid certificate provided for distribution type: %s", m.opts.ExportMethod))
 	}
 
-	teamID := ""
-	typeToLocalCerts, err := autocodesign.GetValidLocalCertificates(certificates, teamID)
+	typeToLocalCerts, err := autocodesign.GetValidLocalCertificates(certificates, m.opts.TeamID)
 	if err != nil {
 		return err
 	}
@@ -250,6 +250,7 @@ func (m *Manager) downloadAndInstallCertificates() error {
 		if certificateType == appstoreconnect.IOSDevelopment {
 			return fmt.Errorf("no valid development type certificate uploaded")
 		}
+
 		log.Warnf("no valid %s type certificate uploaded", certificateType)
 	}
 
@@ -301,6 +302,10 @@ func (m *Manager) prepareCodeSigningWithBitrise(credentials appleauth.Credential
 	appLayout, err := project.GetAppLayout(m.opts.SignUITests)
 	if err != nil {
 		return err
+	}
+
+	if m.opts.TeamID != "" {
+		appLayout.TeamID = m.opts.TeamID
 	}
 
 	devPortalClient, err := m.devPortalClientFactory.Create(credentials, appLayout.TeamID)

--- a/codesign/codesign_test.go
+++ b/codesign/codesign_test.go
@@ -17,12 +17,13 @@ import (
 
 func Test_manager_selectCodeSigningStrategy(t *testing.T) {
 	tests := []struct {
-		name              string
-		project           Project
-		credentials       appleauth.Credentials
-		XcodeMajorVersion int
-		want              codeSigningStrategy
-		wantErr           bool
+		name                   string
+		project                Project
+		credentials            appleauth.Credentials
+		XcodeMajorVersion      int
+		minDaysProfileValidity int
+		want                   codeSigningStrategy
+		wantErr                bool
 	}{
 		{
 			name: "Apple ID",
@@ -51,13 +52,23 @@ func Test_manager_selectCodeSigningStrategy(t *testing.T) {
 			want:              codeSigningBitriseAPIKey,
 		},
 		{
-			name: "API Key, Xcode 13, Xcode managed signing",
+			name: "API Key, Xcode 13, Xcode managed signing, custom features",
 			credentials: appleauth.Credentials{
 				APIKey: &devportalservice.APIKeyConnection{},
 			},
 			XcodeMajorVersion: 13,
 			project:           newMockProject(true, nil),
 			want:              codeSigningXcode,
+		},
+		{
+			name: "API Key, Xcode 13, Xcode managed signing, no custom features",
+			credentials: appleauth.Credentials{
+				APIKey: &devportalservice.APIKeyConnection{},
+			},
+			XcodeMajorVersion:      13,
+			minDaysProfileValidity: 5,
+			project:                newMockProject(true, nil),
+			want:                   codeSigningBitriseAPIKey,
 		},
 		{
 			name: "API Key, Xcode 13, can not determine if project automtic",
@@ -77,6 +88,7 @@ func Test_manager_selectCodeSigningStrategy(t *testing.T) {
 				opts: Opts{
 					XcodeMajorVersion:          tt.XcodeMajorVersion,
 					ShouldConsiderXcodeSigning: true,
+					MinDaysProfileValidity:     tt.minDaysProfileValidity,
 				},
 			}
 


### PR DESCRIPTION
If custom minimum profile validity is set, will use Bitrise-managed code signing assets.

Added support for setting Team ID, used for Apple ID authentication and filtering certificates used by codesigning.


Resolves: https://linear.app/bitrise/issue/MOB-230/xcode-archive-step-integrate-the-autocodesign-lib