### PR TITLE
ReadCodesignParameters uses the archive entitlements

### DIFF
--- a/xcarchive/ios_test.go
+++ b/xcarchive/ios_test.go
@@ -384,10 +384,10 @@ func TestIosArchive_ReadCodesignParameters(t *testing.T) {
 						},
 						ProvisioningProfile: profileutil.ProvisioningProfileInfoModel{
 							TeamID: "1234ASDF",
-							Entitlements: map[string]interface{}{
-								"get-task-allow":                        false,
-								"com.apple.security.application-groups": []string{"group.io.bitrise.app"},
-							},
+						},
+						Entitlements: map[string]interface{}{
+							"get-task-allow":                        false,
+							"com.apple.security.application-groups": []string{"group.io.bitrise.app"},
 						},
 					},
 				},


### PR DESCRIPTION
### Context

`IosArchive.ReadCodesignParameters` used to read the code signing requirements of the given project, by analyzing the built XCArchive file.

This PR makes `IosArchive.ReadCodesignParameters` using the archive's entitlements, rather than the embedded Profiles' entitlements.

Given Profile is valid for a target, if the Profile has more capabilities enabled than what is required by the target (for example more icloud containers or additional capabilities).

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- use the archive entitlements in `IosArchive.ReadCodesignParameters`

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
