### PR TITLE
Local codesign assets issue

### DIFF
--- a/autocodesign/localcodesignasset/localcodesignasset.go
+++ b/autocodesign/localcodesignasset/localcodesignasset.go
@@ -65,7 +65,12 @@ func (m Manager) FindCodesignAssets(appLayout autocodesign.AppLayout, distrTypes
 		}
 
 		if distrType == autocodesign.Development {
-			for i, bundleID := range appLayout.UITestTargetBundleIDs {
+			bundleIDs := map[string]bool{}
+			for _, bundleID := range appLayout.UITestTargetBundleIDs {
+				bundleIDs[bundleID] = true // profile missing?
+			}
+
+			for bundleID := range bundleIDs {
 				wildcardBundleID, err := autocodesign.CreateWildcardBundleID(bundleID)
 				if err != nil {
 					return nil, nil, fmt.Errorf("could not create wildcard bundle id: %s", err)
@@ -98,8 +103,17 @@ func (m Manager) FindCodesignAssets(appLayout autocodesign.AppLayout, distrTypes
 					asset.UITestTargetProfilesByBundleID = profileByUITestTargetBundleID
 				}
 
-				appLayout.UITestTargetBundleIDs = remove(appLayout.UITestTargetBundleIDs, i)
+				bundleIDs[bundleID] = false
 			}
+
+			var uiTestTargetBundleIDs []string
+			for bundleID, missing := range bundleIDs {
+				if missing {
+					uiTestTargetBundleIDs = append(uiTestTargetBundleIDs, bundleID)
+				}
+			}
+
+			appLayout.UITestTargetBundleIDs = uiTestTargetBundleIDs
 		}
 
 		if asset != nil {

--- a/autocodesign/localcodesignasset/localcodesignasset_test.go
+++ b/autocodesign/localcodesignasset/localcodesignasset_test.go
@@ -38,8 +38,10 @@ func Test_GiveniOSAppLayoutWithUITestTargets_WhenExistingProfile_ThenFindsIt(t *
 			ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
 				"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
 			},
-			UITestTargetProfilesByBundleID: nil,
-			Certificate:                    findCert(t, certsByType, "1"),
+			UITestTargetProfilesByBundleID: map[string]autocodesign.Profile{
+				"io.ios.valid": findProvProfile(t, profiles, "uuid-4"),
+			},
+			Certificate: findCert(t, certsByType, "1"),
 		},
 	}
 
@@ -227,21 +229,6 @@ func profileFromModel(profileInfo profileutil.ProvisioningProfileInfoModel) auto
 }
 
 func profiles(t *testing.T) []profileutil.ProvisioningProfileInfoModel {
-	iosWildcardDevProfile := profileutil.ProvisioningProfileInfoModel{
-		UUID:                  "uuid-1",
-		Name:                  "Valid wildcard development profile",
-		TeamName:              teamName,
-		TeamID:                teamID,
-		BundleID:              "io.ios.*",
-		ExportType:            exportoptions.MethodDevelopment,
-		ProvisionedDevices:    []string{"device-1", "device-2", "device-3"},
-		DeveloperCertificates: []certificateutil.CertificateInfoModel{devCert(t, dateRelativeToNow(1, 0, 0))},
-		CreationDate:          dateRelativeToNow(0, -1, 0),
-		ExpirationDate:        dateRelativeToNow(0, 1, 0),
-		Entitlements:          entitlements(),
-		ProvisionsAllDevices:  false,
-		Type:                  profileutil.ProfileTypeIos,
-	}
 	iosDevProfile := profileutil.ProvisioningProfileInfoModel{
 		UUID:                  "uuid-1",
 		Name:                  "Valid development profile",
@@ -287,8 +274,23 @@ func profiles(t *testing.T) []profileutil.ProvisioningProfileInfoModel {
 		ProvisionsAllDevices:  true,
 		Type:                  profileutil.ProfileTypeIos,
 	}
+	iosWildcardDevProfile := profileutil.ProvisioningProfileInfoModel{
+		UUID:                  "uuid-4",
+		Name:                  "Valid wildcard development profile",
+		TeamName:              teamName,
+		TeamID:                teamID,
+		BundleID:              "io.ios.*",
+		ExportType:            exportoptions.MethodDevelopment,
+		ProvisionedDevices:    []string{"device-1", "device-2", "device-3"},
+		DeveloperCertificates: []certificateutil.CertificateInfoModel{devCert(t, dateRelativeToNow(1, 0, 0))},
+		CreationDate:          dateRelativeToNow(0, -1, 0),
+		ExpirationDate:        dateRelativeToNow(0, 1, 0),
+		Entitlements:          entitlements(),
+		ProvisionsAllDevices:  false,
+		Type:                  profileutil.ProfileTypeIos,
+	}
 
-	return []profileutil.ProvisioningProfileInfoModel{iosWildcardDevProfile, iosDevProfile, tvosDistProfile, iosExpiredProfile}
+	return []profileutil.ProvisioningProfileInfoModel{iosDevProfile, tvosDistProfile, iosExpiredProfile, iosWildcardDevProfile}
 }
 
 func entitlements() map[string]interface{} {

--- a/autocodesign/localcodesignasset/localcodesignasset_test.go
+++ b/autocodesign/localcodesignasset/localcodesignasset_test.go
@@ -19,6 +19,39 @@ const (
 	teamName = "Testing team"
 )
 
+func Test_GiveniOSAppLayoutWithUITestTargets_WhenExistingProfile_ThenFindsIt(t *testing.T) {
+	// Given
+	certsByType := certsByType(t)
+	manager, profiles := createTestObjects(t)
+
+	appLayout := autocodesign.AppLayout{
+		TeamID:   teamID,
+		Platform: autocodesign.IOS,
+		EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
+			"io.ios.valid": entitlements(),
+		},
+		UITestTargetBundleIDs: []string{"io.ios.valid", "io.ios.valid"},
+	}
+
+	expectedAssets := map[autocodesign.DistributionType]autocodesign.AppCodesignAssets{
+		autocodesign.Development: {
+			ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
+				"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
+			},
+			UITestTargetProfilesByBundleID: nil,
+			Certificate:                    findCert(t, certsByType, "1"),
+		},
+	}
+
+	// When
+	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, []autocodesign.DistributionType{autocodesign.Development}, certsByType, []string{}, 0)
+
+	// Then
+	assert.NoError(t, err)
+	assert.Nil(t, missingAppLayout)
+	assert.Equal(t, expectedAssets, assets)
+}
+
 func Test_GiveniOSAppLayoutWithEntitlements_WhenExistingProfile_ThenFindsIt(t *testing.T) {
 	// Given
 	certsByType := certsByType(t)
@@ -194,6 +227,21 @@ func profileFromModel(profileInfo profileutil.ProvisioningProfileInfoModel) auto
 }
 
 func profiles(t *testing.T) []profileutil.ProvisioningProfileInfoModel {
+	iosWildcardDevProfile := profileutil.ProvisioningProfileInfoModel{
+		UUID:                  "uuid-1",
+		Name:                  "Valid wildcard development profile",
+		TeamName:              teamName,
+		TeamID:                teamID,
+		BundleID:              "io.ios.*",
+		ExportType:            exportoptions.MethodDevelopment,
+		ProvisionedDevices:    []string{"device-1", "device-2", "device-3"},
+		DeveloperCertificates: []certificateutil.CertificateInfoModel{devCert(t, dateRelativeToNow(1, 0, 0))},
+		CreationDate:          dateRelativeToNow(0, -1, 0),
+		ExpirationDate:        dateRelativeToNow(0, 1, 0),
+		Entitlements:          entitlements(),
+		ProvisionsAllDevices:  false,
+		Type:                  profileutil.ProfileTypeIos,
+	}
 	iosDevProfile := profileutil.ProvisioningProfileInfoModel{
 		UUID:                  "uuid-1",
 		Name:                  "Valid development profile",
@@ -240,7 +288,7 @@ func profiles(t *testing.T) []profileutil.ProvisioningProfileInfoModel {
 		Type:                  profileutil.ProfileTypeIos,
 	}
 
-	return []profileutil.ProvisioningProfileInfoModel{iosDevProfile, tvosDistProfile, iosExpiredProfile}
+	return []profileutil.ProvisioningProfileInfoModel{iosWildcardDevProfile, iosDevProfile, tvosDistProfile, iosExpiredProfile}
 }
 
 func entitlements() map[string]interface{} {

--- a/autocodesign/localcodesignasset/utils.go
+++ b/autocodesign/localcodesignasset/utils.go
@@ -17,11 +17,6 @@ func certificateSerials(certsByType map[appstoreconnect.CertificateType][]autoco
 	return serials
 }
 
-func remove(slice []string, i int) []string {
-	copy(slice[i:], slice[i+1:])
-	return slice[:len(slice)-1]
-}
-
 func contains(array []string, element string) bool {
 	for _, item := range array {
 		if item == element {


### PR DESCRIPTION
This PR fixes a slice indexing issue around uitest target profile search:

```
panic: runtime error: slice bounds out of range [2:1]
goroutine 1 [running]:
github.com/bitrise-io/go-xcode/autocodesign/localcodesignasset.remove(...)
	/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/bitrise939296912/step_src/vendor/github.com/bitrise-io/go-xcode/autocodesign/localcodesignasset/utils.go:21
github.com/bitrise-io/go-xcode/autocodesign/localcodesignasset.Manager.FindCodesignAssets(0x15ad340, 0x185df48, 0x15ad320, 0x185df48, 0xc000488947, 0xa, 0xc00012529c, 0x3, 0xc00033e2a0, 0xc00013c7e0, ...)
	/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/bitrise939296912/step_src/vendor/github.com/bitrise-io/go-xcode/autocodesign/localcodesignasset/localcodesignasset.go:101 +0xecd
github.com/bitrise-io/go-xcode/autocodesign.codesignAssetManager.EnsureCodesignAssets(0x15b8ca8, 0xc00053f920, 0x15ad280, 0xc00038db80, 0x15b0fc0, 0xc000485560, 0x15ad300, 0xc00038dba0, 0xc000488947, 0xa, ...)
	/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/bitrise939296912/step_src/vendor/github.com/bitrise-io/go-xcode/autocodesign/autocodesign.go:187 +0x476
github.com/bitrise-io/go-xcode/codesign.(*Manager).prepareCodeSigningWithBitrise(0xc000539b40, 0xc00035b980, 0x0, 0xc000467740, 0x1)
	/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/bitrise939296912/step_src/vendor/github.com/bitrise-io/go-xcode/codesign/codesign.go:330 +0x4ac
github.com/bitrise-io/go-xcode/codesign.(*Manager).PrepareCodesigning(0xc00020bb40, 0x3, 0x1527712, 0x36)
	/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/bitrise939296912/step_src/vendor/github.com/bitrise-io/go-xcode/codesign/codesign.go:145 +0x1c8
main.main()
	/var/folders/g2/xnd8hpjs50v433gfrybz2nxh0000gn/T/bitrise939296912/step_src/main.go:174 +0x7a5
```