### PR TITLE
Remove project team ID detection

### DIFF
--- a/autocodesign/autocodesign.go
+++ b/autocodesign/autocodesign.go
@@ -97,7 +97,6 @@ type LocalCodeSignAssetManager interface {
 
 // AppLayout contains codesigning related settings that are needed to ensure codesigning files
 type AppLayout struct {
-	TeamID                                 string
 	Platform                               Platform
 	EntitlementsByArchivableTargetBundleID map[string]Entitlements
 	UITestTargetBundleIDs                  []string
@@ -161,7 +160,6 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 		m.devPortalClient,
 		certs,
 		opts.DistributionType,
-		appLayout.TeamID,
 		signUITestTargets,
 		opts.VerboseLog,
 	)

--- a/autocodesign/autocodesign_test.go
+++ b/autocodesign/autocodesign_test.go
@@ -290,7 +290,6 @@ func Test_GivenNoValidAppID_WhenEnsureAppClipProfile_ThenItFails(t *testing.T) {
 	assetWriter := newDefaultMockAssetWriter()
 
 	appLayout := AppLayout{
-		TeamID:   teamID,
 		Platform: IOS,
 		EntitlementsByArchivableTargetBundleID: map[string]Entitlements{
 			"io.bitrise.appclip": {"com.apple.developer.parent-application-identifiers": []string{"io.bitrise.app"}},
@@ -324,7 +323,6 @@ func Test_GivenAppIDWithoutAppleSignIn_WhenEnsureAppClipProfile_ThenItFails(t *t
 	assetWriter := newDefaultMockAssetWriter()
 
 	appLayout := AppLayout{
-		TeamID:   teamID,
 		Platform: IOS,
 		EntitlementsByArchivableTargetBundleID: map[string]Entitlements{
 			appClipBundleID: {
@@ -400,7 +398,6 @@ func Test_GivenProfileExpired_WhenProfilesInconsistent_ThenItRetries(t *testing.
 
 	assetWriter := newDefaultMockAssetWriter()
 	appLayout := AppLayout{
-		TeamID:   teamID,
 		Platform: IOS,
 		EntitlementsByArchivableTargetBundleID: map[string]Entitlements{
 			"io.test": {},

--- a/autocodesign/certificates_test.go
+++ b/autocodesign/certificates_test.go
@@ -129,7 +129,6 @@ func TestGetValidCertificates(t *testing.T) {
 		localCertificates        []certificateutil.CertificateInfoModel
 		client                   DevPortalClient
 		requiredCertificateTypes map[appstoreconnect.CertificateType]bool
-		teamID                   string
 	}
 	tests := []struct {
 		name    string
@@ -145,7 +144,6 @@ func TestGetValidCertificates(t *testing.T) {
 				},
 				client:                   newMockCertClient(map[appstoreconnect.CertificateType][]Certificate{}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
-				teamID:                   "",
 			},
 			want:    map[appstoreconnect.CertificateType][]Certificate{},
 			wantErr: true,
@@ -165,7 +163,6 @@ func TestGetValidCertificates(t *testing.T) {
 					}},
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
-				teamID:                   "",
 			},
 			want: map[appstoreconnect.CertificateType][]Certificate{
 				appstoreconnect.IOSDevelopment: {{
@@ -181,7 +178,6 @@ func TestGetValidCertificates(t *testing.T) {
 				localCertificates:        []certificateutil.CertificateInfoModel{},
 				client:                   newMockCertClient(map[appstoreconnect.CertificateType][]Certificate{}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
-				teamID:                   "",
 			},
 			want:    map[appstoreconnect.CertificateType][]Certificate{},
 			wantErr: true,
@@ -194,7 +190,6 @@ func TestGetValidCertificates(t *testing.T) {
 				},
 				client:                   newMockCertClient(map[appstoreconnect.CertificateType][]Certificate{}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
-				teamID:                   "",
 			},
 			want:    map[appstoreconnect.CertificateType][]Certificate{},
 			wantErr: true,
@@ -212,7 +207,6 @@ func TestGetValidCertificates(t *testing.T) {
 					}},
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
-				teamID:                   "",
 			},
 			want: map[appstoreconnect.CertificateType][]Certificate{
 				appstoreconnect.IOSDevelopment: {{
@@ -236,7 +230,6 @@ func TestGetValidCertificates(t *testing.T) {
 					}},
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
-				teamID:                   "",
 			},
 			want: map[appstoreconnect.CertificateType][]Certificate{
 				appstoreconnect.IOSDevelopment: {{
@@ -265,7 +258,6 @@ func TestGetValidCertificates(t *testing.T) {
 					},
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
-				teamID:                   "",
 			},
 			want:    map[appstoreconnect.CertificateType][]Certificate{},
 			wantErr: true,
@@ -287,7 +279,6 @@ func TestGetValidCertificates(t *testing.T) {
 					appstoreconnect.IOSDevelopment:  true,
 					appstoreconnect.IOSDistribution: true,
 				},
-				teamID: "",
 			},
 			want:    map[appstoreconnect.CertificateType][]Certificate{},
 			wantErr: true,
@@ -314,7 +305,6 @@ func TestGetValidCertificates(t *testing.T) {
 					},
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
-				teamID:                   "",
 			},
 			want: map[appstoreconnect.CertificateType][]Certificate{
 				appstoreconnect.IOSDevelopment: {{
@@ -331,7 +321,7 @@ func TestGetValidCertificates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getValidCertificates(tt.args.localCertificates, tt.args.client, tt.args.requiredCertificateTypes, tt.args.teamID, true)
+			got, err := getValidCertificates(tt.args.localCertificates, tt.args.client, tt.args.requiredCertificateTypes, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetValidCertificates() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/autocodesign/errors.go
+++ b/autocodesign/errors.go
@@ -36,12 +36,11 @@ func (e *DetailedError) Error() string {
 
 // missingCertificateError ...
 type missingCertificateError struct {
-	Type   appstoreconnect.CertificateType
-	TeamID string
+	Type appstoreconnect.CertificateType
 }
 
 func (e missingCertificateError) Error() string {
-	return fmt.Sprintf("no valid %s type certificates uploaded with Team ID (%s)\n ", e.Type, e.TeamID)
+	return fmt.Sprintf("no valid %s type certificates uploaded\n ", e.Type)
 }
 
 // NonmatchingProfileError is returned when a profile/bundle ID does not match project requirements

--- a/autocodesign/localcodesignasset/localcodesignasset_test.go
+++ b/autocodesign/localcodesignasset/localcodesignasset_test.go
@@ -25,7 +25,6 @@ func Test_GiveniOSAppLayoutWithUITestTargets_WhenExistingProfile_ThenFindsIt(t *
 	manager, profiles := createTestObjects(t)
 
 	appLayout := autocodesign.AppLayout{
-		TeamID:   teamID,
 		Platform: autocodesign.IOS,
 		EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 			"io.ios.valid": entitlements(),
@@ -60,7 +59,6 @@ func Test_GiveniOSAppLayoutWithEntitlements_WhenExistingProfile_ThenFindsIt(t *t
 	manager, profiles := createTestObjects(t)
 
 	appLayout := autocodesign.AppLayout{
-		TeamID:   teamID,
 		Platform: autocodesign.IOS,
 		EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 			"io.ios.valid": entitlements(),
@@ -92,7 +90,6 @@ func Test_GiventvOSAppLayout_WhenExistingProfile_ThenFindsIt(t *testing.T) {
 	manager, profiles := createTestObjects(t)
 
 	appLayout := autocodesign.AppLayout{
-		TeamID:   teamID,
 		Platform: autocodesign.TVOS,
 		EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 			"io.tvos.valid": nil,
@@ -124,7 +121,6 @@ func Test_GiveniOSAppLayout_WhenExpiredProfile_ThenDoesNotFindIt(t *testing.T) {
 	manager, _ := createTestObjects(t)
 
 	appLayout := autocodesign.AppLayout{
-		TeamID:   teamID,
 		Platform: autocodesign.TVOS,
 		EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 			"io.tvos.expired": nil,
@@ -149,7 +145,6 @@ func Test_GiveniOSAppLayoutWithEntitlements_WhenProfileHasMissingEntitlements_Th
 	entitlements["main"] = "$(build-setting)"
 
 	appLayout := autocodesign.AppLayout{
-		TeamID:   teamID,
 		Platform: autocodesign.IOS,
 		EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 			"io.ios.valid": entitlements,

--- a/autocodesign/projectmanager/projectmanager.go
+++ b/autocodesign/projectmanager/projectmanager.go
@@ -83,13 +83,6 @@ func (p Project) MainTargetBundleID() (string, error) {
 func (p Project) GetAppLayout(uiTestTargets bool) (autocodesign.AppLayout, error) {
 	log.Printf("Configuration: %s", p.projHelper.Configuration)
 
-	teamID, err := p.projHelper.ProjectTeamID(p.projHelper.Configuration)
-	if err != nil {
-		return autocodesign.AppLayout{}, fmt.Errorf("failed to read project team ID: %s", err)
-	}
-
-	log.Printf("Project team ID: %s", teamID)
-
 	platform, err := p.projHelper.Platform(p.projHelper.Configuration)
 	if err != nil {
 		return autocodesign.AppLayout{}, fmt.Errorf("failed to read project platform: %s", err)
@@ -126,7 +119,6 @@ func (p Project) GetAppLayout(uiTestTargets bool) (autocodesign.AppLayout, error
 	}
 
 	return autocodesign.AppLayout{
-		TeamID:                                 teamID,
 		Platform:                               platform,
 		EntitlementsByArchivableTargetBundleID: archivableTargetBundleIDToEntitlements,
 		UITestTargetBundleIDs:                  uiTestTargetBundleIDs,

--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -261,7 +261,7 @@ func (m *Manager) downloadAndInstallCertificates() error {
 		panic(fmt.Sprintf("no valid certificate provided for distribution type: %s", m.opts.ExportMethod))
 	}
 
-	typeToLocalCerts, err := autocodesign.GetValidLocalCertificates(certificates, m.opts.TeamID)
+	typeToLocalCerts, err := autocodesign.GetValidLocalCertificates(certificates)
 	if err != nil {
 		return err
 	}
@@ -314,11 +314,7 @@ func (m *Manager) prepareCodeSigningWithBitrise(credentials appleauth.Credential
 		return err
 	}
 
-	if m.opts.TeamID != "" {
-		appLayout.TeamID = m.opts.TeamID
-	}
-
-	devPortalClient, err := m.devPortalClientFactory.Create(credentials, appLayout.TeamID)
+	devPortalClient, err := m.devPortalClientFactory.Create(credentials, m.opts.TeamID)
 	if err != nil {
 		return err
 	}

--- a/xcarchive/ios.go
+++ b/xcarchive/ios.go
@@ -402,11 +402,6 @@ func (archive IosArchive) ReadCodesignParameters() (*autocodesign.AppLayout, err
 		return nil, err
 	}
 
-	teamID, err := archive.TeamID()
-	if err != nil {
-		return nil, err
-	}
-
 	bundleIDEntitlementsMap := archive.BundleIDEntitlementsMap()
 
 	entitlementsMap := map[string]autocodesign.Entitlements{}
@@ -416,7 +411,6 @@ func (archive IosArchive) ReadCodesignParameters() (*autocodesign.AppLayout, err
 
 	return &autocodesign.AppLayout{
 		Platform:                               platform,
-		TeamID:                                 teamID,
 		EntitlementsByArchivableTargetBundleID: entitlementsMap,
 		UITestTargetBundleIDs:                  nil,
 	}, nil

--- a/xcarchive/ios_test.go
+++ b/xcarchive/ios_test.go
@@ -279,7 +279,6 @@ func TestIosArchive_ReadCodesignParameters(t *testing.T) {
 				},
 			},
 			want: &autocodesign.AppLayout{
-				TeamID:   "1234ASDF",
 				Platform: autocodesign.IOS,
 				EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 					"io.bitrise.app": nil,
@@ -361,7 +360,6 @@ func TestIosArchive_ReadCodesignParameters(t *testing.T) {
 				},
 			},
 			want: &autocodesign.AppLayout{
-				TeamID:   "1234ASDF",
 				Platform: autocodesign.IOS,
 				EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 					"io.bitrise.app":          nil,
@@ -393,7 +391,6 @@ func TestIosArchive_ReadCodesignParameters(t *testing.T) {
 				},
 			},
 			want: &autocodesign.AppLayout{
-				TeamID:   "1234ASDF",
 				Platform: autocodesign.IOS,
 				EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 					"io.bitrise.app": {


### PR DESCRIPTION
### Context

Detecting team ID from the project settings takes considerable time, especially for large projects with many targets. The team ID is only used for:

- Apple ID based code signing and only if the authenticated account belongs to multiple teams
- Filtering local certificates found on the VM for the project's team ID. But even without this filtering, the next phase is to match local certs to ones downloaded from the Developer Portal, and those all belong to the correct team ID.

For the Apple ID based code path, users will be able to use the existing team ID step input if necessary.

### Changes
- Remove team ID detection from `autocodesign/projectmanager`
- Remove `TeamID` field from `autocodesign.AppLayout`, the return type of `projectmanager`
- Remove team ID parameter from certificate processing functions
- When creating a dev portal client, use the explicit team ID that is coming from step inputs