### PR TITLE
Handle local and remote codesign asssets for one distribution type

### DIFF
--- a/autocodesign/autocodesign.go
+++ b/autocodesign/autocodesign.go
@@ -187,7 +187,7 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 	codesignAssetsByDistributionType := map[DistributionType]AppCodesignAssets{}
 
 	for _, distrType := range distrTypes {
-		localCodesignAssets, missingCodesignAssets, err := m.localCodeSignAssetManager.FindCodesignAssets(appLayout, distrType, certsByType, devPortalDeviceUDIDs, opts.MinProfileValidityDays)
+		localCodesignAssets, missingAppLayout, err := m.localCodeSignAssetManager.FindCodesignAssets(appLayout, distrType, certsByType, devPortalDeviceUDIDs, opts.MinProfileValidityDays)
 		if err != nil {
 			return nil, fmt.Errorf("failed to collect local code signing assets: %w", err)
 		}
@@ -195,11 +195,11 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 		printExistingCodesignAssets(localCodesignAssets, distrType)
 
 		finalAssets := localCodesignAssets
-		if missingCodesignAssets != nil {
-			printMissingCodeSignAssets(missingCodesignAssets)
+		if missingAppLayout != nil {
+			printMissingCodeSignAssets(missingAppLayout)
 
 			// Ensure Profiles
-			newCodesignAssets, err := ensureProfiles(m.devPortalClient, distrType, certsByType, *missingCodesignAssets, devPortalDeviceIDs, opts.MinProfileValidityDays)
+			newCodesignAssets, err := ensureProfiles(m.devPortalClient, distrType, certsByType, *missingAppLayout, devPortalDeviceIDs, opts.MinProfileValidityDays)
 			if err != nil {
 				switch {
 				case errors.As(err, &ErrAppClipAppID{}):

--- a/autocodesign/autocodesign_test.go
+++ b/autocodesign/autocodesign_test.go
@@ -29,7 +29,7 @@ func newDefaultMockAssetWriter() AssetWriter {
 	return mockAssetWriter
 }
 
-func newMockLocalCodeSignAssetManager(assets map[DistributionType]AppCodesignAssets, appLayout AppLayout) LocalCodeSignAssetManager {
+func newMockLocalCodeSignAssetManager(assets *AppCodesignAssets, appLayout AppLayout) LocalCodeSignAssetManager {
 	mockLocalCodeSignAssetManager := new(MockLocalCodeSignAssetManager)
 	mockLocalCodeSignAssetManager.On("FindCodesignAssets", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(assets, &appLayout, nil)
 
@@ -211,7 +211,7 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 				devPortalClient:           checkOnlyDevportalProfile,
 				certificateProvider:       newMockCertificateProvider([]certificateutil.CertificateInfoModel{devCert}),
 				assetWriter:               newDefaultMockAssetWriter(),
-				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(map[DistributionType]AppCodesignAssets{}, appIDAndProfileFoundAppLayout),
+				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(nil, appIDAndProfileFoundAppLayout),
 			},
 			appLayout: appIDAndProfileFoundAppLayout,
 			opts: CodesignAssetsOpts{
@@ -234,7 +234,7 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 				devPortalClient:           checkOnlyDevportalProfile,
 				certificateProvider:       newMockCertificateProvider([]certificateutil.CertificateInfoModel{devCert}),
 				assetWriter:               newDefaultMockAssetWriter(),
-				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(map[DistributionType]AppCodesignAssets{Development: localCodeSignAsset}, appIDAndProfileFoundAppLayout),
+				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(&localCodeSignAsset, appIDAndProfileFoundAppLayout),
 			},
 			appLayout: appIDAndProfileFoundAppLayout2,
 			opts: CodesignAssetsOpts{
@@ -257,7 +257,7 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 			fields: fields{
 				devPortalClient:           devportalWithNoAppID,
 				certificateProvider:       newMockCertificateProvider([]certificateutil.CertificateInfoModel{devCert}),
-				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(map[DistributionType]AppCodesignAssets{}, icloudContainerAppLayout),
+				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(nil, icloudContainerAppLayout),
 			},
 			appLayout: icloudContainerAppLayout,
 			opts: CodesignAssetsOpts{
@@ -305,7 +305,7 @@ func Test_GivenNoValidAppID_WhenEnsureAppClipProfile_ThenItFails(t *testing.T) {
 		},
 	}
 
-	localCodeSignAssetManager := newMockLocalCodeSignAssetManager(map[DistributionType]AppCodesignAssets{}, appLayout)
+	localCodeSignAssetManager := newMockLocalCodeSignAssetManager(nil, appLayout)
 	manager := NewCodesignAssetManager(client, certProvider, assetWriter, localCodeSignAssetManager)
 
 	opts := CodesignAssetsOpts{
@@ -342,7 +342,7 @@ func Test_GivenAppIDWithoutAppleSignIn_WhenEnsureAppClipProfile_ThenItFails(t *t
 		},
 	}
 
-	localCodeSignAssetManager := newMockLocalCodeSignAssetManager(map[DistributionType]AppCodesignAssets{}, appLayout)
+	localCodeSignAssetManager := newMockLocalCodeSignAssetManager(nil, appLayout)
 	manager := NewCodesignAssetManager(client, certProvider, assetWriter, localCodeSignAssetManager)
 
 	opts := CodesignAssetsOpts{

--- a/autocodesign/autocodesign_test.go
+++ b/autocodesign/autocodesign_test.go
@@ -150,9 +150,17 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 		},
 	}
 
+	appIDAndProfileFoundAppLayout2 := AppLayout{
+		Platform: IOS,
+		EntitlementsByArchivableTargetBundleID: map[string]Entitlements{
+			"io.test":             {},
+			"io.test.development": {},
+		},
+	}
+
 	localCodeSignAsset := AppCodesignAssets{
 		ArchivableTargetProfilesByBundleID: map[string]Profile{
-			"io.test.appstore": devProfile,
+			"io.test.development": devProfile,
 		},
 		UITestTargetProfilesByBundleID: map[string]Profile{},
 		Certificate:                    devCert,
@@ -226,21 +234,21 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 				devPortalClient:           checkOnlyDevportalProfile,
 				certificateProvider:       newMockCertificateProvider([]certificateutil.CertificateInfoModel{devCert}),
 				assetWriter:               newDefaultMockAssetWriter(),
-				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(map[DistributionType]AppCodesignAssets{AppStore: localCodeSignAsset}, appIDAndProfileFoundAppLayout),
+				localCodeSignAssetManager: newMockLocalCodeSignAssetManager(map[DistributionType]AppCodesignAssets{Development: localCodeSignAsset}, appIDAndProfileFoundAppLayout),
 			},
-			appLayout: appIDAndProfileFoundAppLayout,
+			appLayout: appIDAndProfileFoundAppLayout2,
 			opts: CodesignAssetsOpts{
 				DistributionType: Development,
 			},
 			want: map[DistributionType]AppCodesignAssets{
 				Development: {
 					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"io.test": devProfile,
+						"io.test":             devProfile,
+						"io.test.development": devProfile,
 					},
 					UITestTargetProfilesByBundleID: map[string]Profile{},
 					Certificate:                    devCert,
 				},
-				AppStore: localCodeSignAsset,
 			},
 			wantErr: nil,
 		},

--- a/autocodesign/localcodesignasset/localcodesignasset_test.go
+++ b/autocodesign/localcodesignasset/localcodesignasset_test.go
@@ -33,25 +33,23 @@ func Test_GiveniOSAppLayoutWithUITestTargets_WhenExistingProfile_ThenFindsIt(t *
 		UITestTargetBundleIDs: []string{"io.ios.valid", "io.ios.valid"},
 	}
 
-	expectedAssets := map[autocodesign.DistributionType]autocodesign.AppCodesignAssets{
-		autocodesign.Development: {
-			ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
-				"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
-			},
-			UITestTargetProfilesByBundleID: map[string]autocodesign.Profile{
-				"io.ios.valid": findProvProfile(t, profiles, "uuid-4"),
-			},
-			Certificate: findCert(t, certsByType, "1"),
+	expectedAssets := autocodesign.AppCodesignAssets{
+		ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
+			"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
 		},
+		UITestTargetProfilesByBundleID: map[string]autocodesign.Profile{
+			"io.ios.valid": findProvProfile(t, profiles, "uuid-4"),
+		},
+		Certificate: findCert(t, certsByType, "1"),
 	}
 
 	// When
-	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, []autocodesign.DistributionType{autocodesign.Development}, certsByType, []string{}, 0)
+	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, autocodesign.Development, certsByType, []string{}, 0)
 
 	// Then
 	assert.NoError(t, err)
 	assert.Nil(t, missingAppLayout)
-	assert.Equal(t, expectedAssets, assets)
+	assert.Equal(t, expectedAssets, *assets)
 }
 
 func Test_GiveniOSAppLayoutWithEntitlements_WhenExistingProfile_ThenFindsIt(t *testing.T) {
@@ -67,23 +65,21 @@ func Test_GiveniOSAppLayoutWithEntitlements_WhenExistingProfile_ThenFindsIt(t *t
 		},
 	}
 
-	expectedAssets := map[autocodesign.DistributionType]autocodesign.AppCodesignAssets{
-		autocodesign.Development: {
-			ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
-				"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
-			},
-			UITestTargetProfilesByBundleID: nil,
-			Certificate:                    findCert(t, certsByType, "1"),
+	expectedAssets := autocodesign.AppCodesignAssets{
+		ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
+			"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
 		},
+		UITestTargetProfilesByBundleID: nil,
+		Certificate:                    findCert(t, certsByType, "1"),
 	}
 
 	// When
-	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, []autocodesign.DistributionType{autocodesign.Development}, certsByType, []string{}, 0)
+	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, autocodesign.Development, certsByType, []string{}, 0)
 
 	// Then
 	assert.NoError(t, err)
 	assert.Nil(t, missingAppLayout)
-	assert.Equal(t, expectedAssets, assets)
+	assert.Equal(t, expectedAssets, *assets)
 }
 
 func Test_GiventvOSAppLayout_WhenExistingProfile_ThenFindsIt(t *testing.T) {
@@ -99,23 +95,21 @@ func Test_GiventvOSAppLayout_WhenExistingProfile_ThenFindsIt(t *testing.T) {
 		},
 	}
 
-	expectedAssets := map[autocodesign.DistributionType]autocodesign.AppCodesignAssets{
-		autocodesign.AppStore: {
-			ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
-				"io.tvos.valid": findProvProfile(t, profiles, "uuid-2"),
-			},
-			UITestTargetProfilesByBundleID: nil,
-			Certificate:                    findCert(t, certsByType, "2"),
+	expectedAssets := autocodesign.AppCodesignAssets{
+		ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
+			"io.tvos.valid": findProvProfile(t, profiles, "uuid-2"),
 		},
+		UITestTargetProfilesByBundleID: nil,
+		Certificate:                    findCert(t, certsByType, "2"),
 	}
 
 	// When
-	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, []autocodesign.DistributionType{autocodesign.AppStore}, certsByType, []string{}, 0)
+	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, autocodesign.AppStore, certsByType, []string{}, 0)
 
 	// Then
 	assert.NoError(t, err)
 	assert.Nil(t, missingAppLayout)
-	assert.Equal(t, expectedAssets, assets)
+	assert.Equal(t, expectedAssets, *assets)
 }
 
 func Test_GiveniOSAppLayout_WhenExpiredProfile_ThenDoesNotFindIt(t *testing.T) {
@@ -132,11 +126,11 @@ func Test_GiveniOSAppLayout_WhenExpiredProfile_ThenDoesNotFindIt(t *testing.T) {
 	}
 
 	// When
-	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, []autocodesign.DistributionType{autocodesign.AppStore}, certsByType, []string{}, 0)
+	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, autocodesign.AppStore, certsByType, []string{}, 0)
 
 	// Then
 	assert.NoError(t, err)
-	assert.Equal(t, assets, map[autocodesign.DistributionType]autocodesign.AppCodesignAssets{})
+	assert.Nil(t, assets)
 	assert.Equal(t, appLayout, *missingAppLayout)
 }
 
@@ -157,11 +151,11 @@ func Test_GiveniOSAppLayoutWithEntitlements_WhenProfileHasMissingEntitlements_Th
 	}
 
 	// When
-	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, []autocodesign.DistributionType{autocodesign.Development}, certsByType, []string{}, 0)
+	assets, missingAppLayout, err := manager.FindCodesignAssets(appLayout, autocodesign.Development, certsByType, []string{}, 0)
 
 	// Then
 	assert.NoError(t, err)
-	assert.Equal(t, assets, map[autocodesign.DistributionType]autocodesign.AppCodesignAssets{})
+	assert.Nil(t, assets)
 	assert.Equal(t, appLayout, *missingAppLayout)
 }
 

--- a/autocodesign/mock_LocalCodeSignAssetManager.go
+++ b/autocodesign/mock_LocalCodeSignAssetManager.go
@@ -4,7 +4,6 @@ package autocodesign
 
 import (
 	appstoreconnect "github.com/bitrise-io/go-xcode/autocodesign/devportalclient/appstoreconnect"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -13,24 +12,24 @@ type MockLocalCodeSignAssetManager struct {
 	mock.Mock
 }
 
-// FindCodesignAssets provides a mock function with given fields: appLayout, distrTypes, certsByType, deviceIDs, minProfileDaysValid
-func (_m *MockLocalCodeSignAssetManager) FindCodesignAssets(appLayout AppLayout, distrTypes []DistributionType, certsByType map[appstoreconnect.CertificateType][]Certificate, deviceIDs []string, minProfileDaysValid int) (map[DistributionType]AppCodesignAssets, *AppLayout, error) {
-	ret := _m.Called(appLayout, distrTypes, certsByType, deviceIDs, minProfileDaysValid)
+// FindCodesignAssets provides a mock function with given fields: appLayout, distrType, certsByType, deviceIDs, minProfileDaysValid
+func (_m *MockLocalCodeSignAssetManager) FindCodesignAssets(appLayout AppLayout, distrType DistributionType, certsByType map[appstoreconnect.CertificateType][]Certificate, deviceIDs []string, minProfileDaysValid int) (*AppCodesignAssets, *AppLayout, error) {
+	ret := _m.Called(appLayout, distrType, certsByType, deviceIDs, minProfileDaysValid)
 
-	var r0 map[DistributionType]AppCodesignAssets
-	if rf, ok := ret.Get(0).(func(AppLayout, []DistributionType, map[appstoreconnect.CertificateType][]Certificate, []string, int) map[DistributionType]AppCodesignAssets); ok {
-		r0 = rf(appLayout, distrTypes, certsByType, deviceIDs, minProfileDaysValid)
+	var r0 *AppCodesignAssets
+	if rf, ok := ret.Get(0).(func(AppLayout, DistributionType, map[appstoreconnect.CertificateType][]Certificate, []string, int) *AppCodesignAssets); ok {
+		r0 = rf(appLayout, distrType, certsByType, deviceIDs, minProfileDaysValid)
 	} else {
 		if ret.Get(0) != nil {
-			r0, ok = ret.Get(0).(map[DistributionType]AppCodesignAssets)
+			r0, ok = ret.Get(0).(*AppCodesignAssets)
 			if !ok {
 			}
 		}
 	}
 
 	var r1 *AppLayout
-	if rf, ok := ret.Get(1).(func(AppLayout, []DistributionType, map[appstoreconnect.CertificateType][]Certificate, []string, int) *AppLayout); ok {
-		r1 = rf(appLayout, distrTypes, certsByType, deviceIDs, minProfileDaysValid)
+	if rf, ok := ret.Get(1).(func(AppLayout, DistributionType, map[appstoreconnect.CertificateType][]Certificate, []string, int) *AppLayout); ok {
+		r1 = rf(appLayout, distrType, certsByType, deviceIDs, minProfileDaysValid)
 	} else {
 		if ret.Get(1) != nil {
 			r1, ok = ret.Get(1).(*AppLayout)
@@ -40,8 +39,8 @@ func (_m *MockLocalCodeSignAssetManager) FindCodesignAssets(appLayout AppLayout,
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(AppLayout, []DistributionType, map[appstoreconnect.CertificateType][]Certificate, []string, int) error); ok {
-		r2 = rf(appLayout, distrTypes, certsByType, deviceIDs, minProfileDaysValid)
+	if rf, ok := ret.Get(2).(func(AppLayout, DistributionType, map[appstoreconnect.CertificateType][]Certificate, []string, int) error); ok {
+		r2 = rf(appLayout, distrType, certsByType, deviceIDs, minProfileDaysValid)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/autocodesign/utils_test.go
+++ b/autocodesign/utils_test.go
@@ -13,123 +13,97 @@ func Test_GivenCodeSignAssets_WhenMergingTwo_ThenValuesAreCorrect(t *testing.T) 
 	dev2Profile := profile("addition", "4")
 	devUITest1Profile := profile("base", "2")
 	devUITest2Profile := profile("addition-uitest", "5")
-	appStore1Profile := profile("base", "3")
 	enterprise1Profile := profile("enterprise", "1")
 	adHoc1Profile := profile("ad-hoc", "1")
 
 	certificate := certificateutil.CertificateInfoModel{}
 	tests := []struct {
 		name     string
-		base     map[DistributionType]AppCodesignAssets
-		addition map[DistributionType]AppCodesignAssets
-		expected map[DistributionType]AppCodesignAssets
+		base     *AppCodesignAssets
+		addition *AppCodesignAssets
+		expected *AppCodesignAssets
 	}{
 		{
 			name: "Two existing assets with overlapping values",
-			base: map[DistributionType]AppCodesignAssets{
-				Development: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"dev-1": dev1Profile,
-					},
-					UITestTargetProfilesByBundleID: map[string]Profile{
-						"dev-uitest-1": devUITest1Profile,
-					},
-					Certificate: certificate,
-				}},
-			addition: map[DistributionType]AppCodesignAssets{
-				Development: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"dev-2": dev2Profile,
-					},
-					UITestTargetProfilesByBundleID: map[string]Profile{
-						"dev-uitest-2": devUITest2Profile,
-					},
-					Certificate: certificate,
+			base: &AppCodesignAssets{
+				ArchivableTargetProfilesByBundleID: map[string]Profile{
+					"dev-1": dev1Profile,
 				},
-				AppStore: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"app-store-1": appStore1Profile,
-					},
-					UITestTargetProfilesByBundleID: nil,
-					Certificate:                    certificate,
+				UITestTargetProfilesByBundleID: map[string]Profile{
+					"dev-uitest-1": devUITest1Profile,
 				},
+				Certificate: certificate,
 			},
-			expected: map[DistributionType]AppCodesignAssets{
-				Development: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"dev-1": dev1Profile,
-						"dev-2": dev2Profile,
-					},
-					UITestTargetProfilesByBundleID: map[string]Profile{
-						"dev-uitest-1": devUITest1Profile,
-						"dev-uitest-2": devUITest2Profile,
-					},
-					Certificate: certificate,
+			addition: &AppCodesignAssets{
+				ArchivableTargetProfilesByBundleID: map[string]Profile{
+					"dev-2": dev2Profile,
 				},
-				AppStore: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"app-store-1": appStore1Profile,
-					},
-					UITestTargetProfilesByBundleID: nil,
-					Certificate:                    certificate,
+				UITestTargetProfilesByBundleID: map[string]Profile{
+					"dev-uitest-2": devUITest2Profile,
 				},
+				Certificate: certificate,
+			},
+			expected: &AppCodesignAssets{
+				ArchivableTargetProfilesByBundleID: map[string]Profile{
+					"dev-1": dev1Profile,
+					"dev-2": dev2Profile,
+				},
+				UITestTargetProfilesByBundleID: map[string]Profile{
+					"dev-uitest-1": devUITest1Profile,
+					"dev-uitest-2": devUITest2Profile,
+				},
+				Certificate: certificate,
 			},
 		},
 		{
 			name: "Base value is empty",
-			base: map[DistributionType]AppCodesignAssets{},
-			addition: map[DistributionType]AppCodesignAssets{
-				Enterprise: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"enterprise-1": enterprise1Profile,
-					},
-					UITestTargetProfilesByBundleID: nil,
-					Certificate:                    certificate,
+			base: nil,
+			addition: &AppCodesignAssets{
+				ArchivableTargetProfilesByBundleID: map[string]Profile{
+					"enterprise-1": enterprise1Profile,
 				},
+				UITestTargetProfilesByBundleID: nil,
+				Certificate:                    certificate,
 			},
-			expected: map[DistributionType]AppCodesignAssets{
-				Enterprise: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"enterprise-1": enterprise1Profile,
-					},
-					UITestTargetProfilesByBundleID: nil,
-					Certificate:                    certificate,
+			expected: &AppCodesignAssets{
+				ArchivableTargetProfilesByBundleID: map[string]Profile{
+					"enterprise-1": enterprise1Profile,
 				},
+				UITestTargetProfilesByBundleID: nil,
+				Certificate:                    certificate,
 			},
 		},
 		{
 			name: "Additional value is empty",
-			base: map[DistributionType]AppCodesignAssets{
-				AdHoc: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"ad-hoc-1": adHoc1Profile,
-					},
-					UITestTargetProfilesByBundleID: nil,
-					Certificate:                    certificate,
+			base: &AppCodesignAssets{
+				ArchivableTargetProfilesByBundleID: map[string]Profile{
+					"ad-hoc-1": adHoc1Profile,
 				},
+				UITestTargetProfilesByBundleID: nil,
+				Certificate:                    certificate,
 			},
-			addition: map[DistributionType]AppCodesignAssets{},
-			expected: map[DistributionType]AppCodesignAssets{
-				AdHoc: {
-					ArchivableTargetProfilesByBundleID: map[string]Profile{
-						"ad-hoc-1": adHoc1Profile,
-					},
-					UITestTargetProfilesByBundleID: nil,
-					Certificate:                    certificate,
+			addition: nil,
+			expected: &AppCodesignAssets{
+				ArchivableTargetProfilesByBundleID: map[string]Profile{
+					"ad-hoc-1": adHoc1Profile,
 				},
+				UITestTargetProfilesByBundleID: nil,
+				Certificate:                    certificate,
 			},
 		},
 		{
 			name:     "Empty values",
-			base:     map[DistributionType]AppCodesignAssets{},
-			addition: map[DistributionType]AppCodesignAssets{},
-			expected: map[DistributionType]AppCodesignAssets{},
+			base:     nil,
+			addition: nil,
+			expected: nil,
 		},
 	}
 
 	for _, test := range tests {
-		merged := mergeCodeSignAssets(test.base, test.addition)
-		assert.Equal(t, test.expected, merged)
+		t.Run(test.name, func(t *testing.T) {
+			merged := mergeCodeSignAssets(test.base, test.addition)
+			assert.Equal(t, test.expected, merged)
+		})
 	}
 }
 


### PR DESCRIPTION
### Context

Merging local and remote assets does not work properly when there are multiple export methods requested (such as development and ad-hoc), because the logic does not differentiate assets based on the export method.

### Changes
- Ensure assets for each export method in a loop
- Thanks to this change, a lot of logic that worked on a `map[DistributionType]AppCodesignAssets` is simplified to a single `AppCodesignAssets` parameter