### PR TITLE
Better ISO 8601 time parsing

### DIFF
--- a/autocodesign/devportalclient/appstoreconnect/time.go
+++ b/autocodesign/devportalclient/appstoreconnect/time.go
@@ -1,6 +1,7 @@
 package appstoreconnect
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -11,10 +12,35 @@ type Time time.Time
 // UnmarshalJSON ...
 func (t *Time) UnmarshalJSON(b []byte) error {
 	timeStr := strings.Trim(string(b), `"`)
-	parsed, err := time.Parse("2006-01-02T15:04:05.000-0700", timeStr)
-	if err != nil {
-		return err
+	var errors []error
+
+	for _, timeFormat := range timeFormats() {
+		parsed, err := time.Parse(timeFormat, timeStr)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		*t = Time(parsed)
+		return nil
 	}
-	*t = Time(parsed)
-	return nil
+
+	return fmt.Errorf("%s", errors)
+}
+
+func timeFormats() []string {
+	// Apple is using an ISO 8601 time format (https://en.wikipedia.org/wiki/ISO_8601). In this format the offset from
+	// the UTC time can have the following equivalent and interchangeable formats:
+	// * [+/-]07:00
+	// * [+/-]0700
+	// * [+/-]07
+	// (* also if there is no UTC offset then [+0000, +00:00, +00] are the same as adding a Z after the seconds)
+	//
+	// Go has built in support for ISO 8601 but only for the zero offset UTC and the [+/-]07:00 format under time.RFC3339.
+	// We still need to check for the other two.
+	return []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.000-0700",
+		"2006-01-02T15:04:05.000-07",
+	}
 }

--- a/autocodesign/devportalclient/appstoreconnect/time_test.go
+++ b/autocodesign/devportalclient/appstoreconnect/time_test.go
@@ -1,6 +1,8 @@
 package appstoreconnect
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestTime_UnmarshalJSON(t *testing.T) {
 
@@ -10,8 +12,15 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 		t       *Time
 		wantErr bool
 	}{
-		{name: "without quotation mark", b: []byte("2021-05-19T08:07:47.000+0000"), wantErr: false},
-		{name: "with quotation mark", b: []byte(`"2021-05-19T08:07:47.000+0000"`), wantErr: false},
+		{name: "without quotation mark", b: []byte("2021-05-19T08:07:47.000+00:00"), wantErr: false},
+		{name: "with quotation mark", b: []byte(`"2021-05-19T08:07:47.000+00:00"`), wantErr: false},
+		{name: "Positive offset", b: []byte("2021-05-19T08:07:47.000+05:30"), wantErr: false},
+		{name: "Alternate positive offset", b: []byte("2021-05-19T08:07:47.000+0530"), wantErr: false},
+		{name: "Alternate negative offset", b: []byte("2021-05-19T08:07:47.000-0400"), wantErr: false},
+		{name: "Single hour positive offset", b: []byte("2021-05-19T08:07:47.000+03"), wantErr: false},
+		{name: "Single hour negative offset", b: []byte("2021-05-19T08:07:47.000-02"), wantErr: false},
+		{name: "Zero offset UTC", b: []byte("2021-05-19T08:07:47.000Z"), wantErr: false},
+		{name: "unsupported format", b: []byte("2021-12-17T10:44:00Z00:00"), wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
We had an issue reported about failing to parse provisioning profiles: 
https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/issues/92

A quick fix was deployed to mitigate the error and this is a follow up improvement.

At first look the cause was that the returned time format has changed from 
```
2006-01-02T15:04:05.000-0700
```
to
```
2006-01-02T15:04:05.000-07:00
```
(there is an extra `:` delimiter).

The root cause is actually different. The returned dates are in the ISO 8601 format. In this standard some formats are interchangeable and equivalent to each other. The best example is this:
- 2006-01-02T15:04:05.000Z
- 2006-01-02T15:04:05.000+00:00
- 2006-01-02T15:04:05.000+0000
- 2006-01-02T15:04:05.000+00

represent the same date. The time parser needs to handle all of them because (based on the standard description) they can be interchanged freely. It can happen that a time library / framework written in one language sends one format and one written in another language uses a different format. 

Go has inbuilt support for this via `time.RFC3339` but that only handles the zero time offset (Z) and the `[+/-]07:00` formats which means we need to manually try to parse the dates with the other formats as well.