### PR TITLE
Fix for device registration regression

### DIFF
--- a/autocodesign/devices.go
+++ b/autocodesign/devices.go
@@ -66,7 +66,8 @@ func registerMissingTestDevices(client DevPortalClient, testDevices []devportals
 			var registrationError appstoreconnect.DeviceRegistrationError
 			if errors.As(err, &registrationError) {
 				log.Warnf("Failed to register device (can be caused by invalid UDID or trying to register a Mac device): %s", registrationError.Reason)
-				return nil, nil
+
+				continue
 			}
 
 			return nil, err

--- a/autocodesign/devices_test.go
+++ b/autocodesign/devices_test.go
@@ -60,20 +60,21 @@ func Test_registerMissingDevices_invalidUDID(t *testing.T) {
 		DeviceID:   "invalid-udid",
 		DeviceType: "models.IOS",
 	}
-	bitriseDevices := []devportalservice.TestDevice{bitriseDevice, bitriseInvalidDevice}
+	bitriseDevices := []devportalservice.TestDevice{bitriseInvalidDevice, bitriseDevice}
 
-	devportalDevice := appstoreconnect.Device{
+	registeredDevice := appstoreconnect.Device{
 		Attributes: appstoreconnect.DeviceAttributes{
 			UDID: "71153a920968f2842d360",
 		},
 		ID: "12",
 	}
-	devportalDevices := []appstoreconnect.Device{devportalDevice}
+	devportalDevices := []appstoreconnect.Device{}
 
-	want := []appstoreconnect.Device(nil)
+	want := []appstoreconnect.Device{registeredDevice}
 
 	client := new(MockDevPortalClient)
 	client.On("RegisterDevice", bitriseInvalidDevice).Return(nil, appstoreconnect.DeviceRegistrationError{}).Once()
+	client.On("RegisterDevice", bitriseDevice).Return(&registeredDevice, nil).Once()
 
 	got, err := registerMissingTestDevices(client, bitriseDevices, devportalDevices)
 

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -64,9 +64,9 @@ func (d *DeviceClient) RegisterDevice(testDevice devportalservice.TestDevice) (*
 
 	registeredDevice, err := d.client.Provisioning.RegisterNewDevice(req)
 	if err != nil {
-		rerr := &appstoreconnect.ErrorResponse{}
-		if ok := errors.As(err, &rerr); ok {
-			if rerr.Response != nil && rerr.Response.StatusCode == http.StatusConflict {
+		var respErr *appstoreconnect.ErrorResponse
+		if ok := errors.As(err, &respErr); ok {
+			if respErr.Response != nil && respErr.Response.StatusCode == http.StatusConflict {
 				return nil, appstoreconnect.DeviceRegistrationError{
 					Reason: fmt.Sprintf("%v", err),
 				}

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -64,7 +64,7 @@ func (d *DeviceClient) RegisterDevice(testDevice devportalservice.TestDevice) (*
 
 	registeredDevice, err := d.client.Provisioning.RegisterNewDevice(req)
 	if err != nil {
-		rerr := appstoreconnect.ErrorResponse{}
+		rerr := &appstoreconnect.ErrorResponse{}
 		if ok := errors.As(err, &rerr); ok {
 			if rerr.Response != nil && rerr.Response.StatusCode == http.StatusConflict {
 				return nil, appstoreconnect.DeviceRegistrationError{

--- a/autocodesign/devportalclient/appstoreconnectclient/devices_test.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices_test.go
@@ -1,0 +1,51 @@
+package appstoreconnectclient
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/bitrise-io/go-xcode/autocodesign/devportalclient/appstoreconnect"
+	"github.com/bitrise-io/go-xcode/devportalservice"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type MockDeviceClient struct {
+	mock.Mock
+}
+
+func (c MockDeviceClient) Do(req *http.Request) (*http.Response, error) {
+	fmt.Printf("do called: %#v - %#v\n", req.Method, req.URL.Path)
+
+	switch {
+	case req.URL.Path == "/v1/devices" && req.Method == "POST":
+		return c.RegisterDevice(req)
+	}
+
+	return nil, fmt.Errorf("invalid endpoint called: %s, method: %s", req.URL.Path, req.Method)
+}
+
+func (c *MockDeviceClient) RegisterDevice(req *http.Request) (*http.Response, error) {
+	args := c.Called(req)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+func TestDeviceClient_RegisterDevice_WhenInvaludUUID(t *testing.T) {
+	mockClient := MockDeviceClient{}
+	mockClient.On("RegisterDevice", mock.Anything).Return(&http.Response{}, &appstoreconnect.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusConflict,
+		},
+	})
+
+	client := appstoreconnect.NewClient(mockClient, "keyID", "issueID", []byte("privateKey"))
+	deviceClient := NewDeviceClient(client)
+
+	got, err := deviceClient.RegisterDevice(devportalservice.TestDevice{
+		DeviceID: "aadd",
+	})
+
+	require.IsType(t, appstoreconnect.DeviceRegistrationError{}, err)
+	require.Nil(t, got)
+}

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -344,7 +344,7 @@ func (c *ProfileClient) SyncBundleID(bundleID appstoreconnect.BundleID, appEntit
 }
 
 func wrapInProfileError(err error) error {
-	respErr := appstoreconnect.ErrorResponse{}
+	respErr := &appstoreconnect.ErrorResponse{}
 	if ok := errors.As(err, &respErr); ok {
 		if respErr.Response != nil && respErr.Response.StatusCode == http.StatusNotFound {
 			return autocodesign.NewProfilesInconsistentError(err)

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -145,7 +145,7 @@ func (c *ProfileClient) FindProfile(name string, profileType appstoreconnect.Pro
 // DeleteProfile ...
 func (c *ProfileClient) DeleteProfile(id string) error {
 	if err := c.client.Provisioning.DeleteProfile(id); err != nil {
-		var respErr appstoreconnect.ErrorResponse
+		var respErr *appstoreconnect.ErrorResponse
 		if ok := errors.As(err, &respErr); ok {
 			if respErr.Response != nil && respErr.Response.StatusCode == http.StatusNotFound {
 				return nil
@@ -344,7 +344,7 @@ func (c *ProfileClient) SyncBundleID(bundleID appstoreconnect.BundleID, appEntit
 }
 
 func wrapInProfileError(err error) error {
-	respErr := &appstoreconnect.ErrorResponse{}
+	var respErr *appstoreconnect.ErrorResponse
 	if ok := errors.As(err, &respErr); ok {
 		if respErr.Response != nil && respErr.Response.StatusCode == http.StatusNotFound {
 			return autocodesign.NewProfilesInconsistentError(err)

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -100,7 +100,7 @@ func (p APIProfile) DeviceIDs() ([]string, error) {
 func (p APIProfile) BundleID() (appstoreconnect.BundleID, error) {
 	bundleIDresp, err := p.client.Provisioning.BundleID(p.profile.Relationships.BundleID.Links.Related)
 	if err != nil {
-		return appstoreconnect.BundleID{}, err
+		return appstoreconnect.BundleID{}, wrapInProfileError(err)
 	}
 
 	return bundleIDresp.Data, nil

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles_test.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles_test.go
@@ -215,11 +215,7 @@ func Test_wrapInProfileError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := wrapInProfileError(tt.err)
-			if tt.wantErrType == nil {
-				require.NoError(t, err)
-			} else {
-				require.IsType(t, tt.wantErrType, err)
-			}
+			require.IsType(t, tt.wantErrType, err)
 		})
 	}
 }

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles_test.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles_test.go
@@ -8,11 +8,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-
 	"github.com/bitrise-io/go-xcode/autocodesign"
 	"github.com/bitrise-io/go-xcode/autocodesign/devportalclient/appstoreconnect"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_checkBundleIDEntitlements(t *testing.T) {
@@ -190,4 +189,37 @@ func newResponse(t *testing.T, status int, body map[string]interface{}) *http.Re
 	}
 
 	return &resp
+}
+
+func Test_wrapInProfileError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantErrType error
+	}{
+		{
+			err: appstoreconnect.ErrorResponse{
+				Errors: []appstoreconnect.ErrorResponseError{{}},
+			},
+			wantErrType: appstoreconnect.ErrorResponse{},
+		},
+		{
+			err: &appstoreconnect.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusNotFound,
+				},
+			},
+			wantErrType: autocodesign.ProfilesInconsistentError{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := wrapInProfileError(tt.err)
+			if tt.wantErrType == nil {
+				require.NoError(t, err)
+			} else {
+				require.IsType(t, tt.wantErrType, err)
+			}
+		})
+	}
 }

--- a/xcodecache/swiftpm_cache_test.go
+++ b/xcodecache/swiftpm_cache_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-utils/env"
+	"github.com/bitrise-io/go-utils/pathutil"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/command/git"
@@ -189,8 +190,14 @@ func resolveProject(t *testing.T, projectPath, cacheDir, xcodeProjSourceDir stri
 	if err != nil {
 		t.Fatalf("failed to get project DerivedData path, error: %s", err)
 	}
+	t.Logf("Per-project DerivedData path: %s", projectDerivedData)
+
 	if err := os.RemoveAll(projectDerivedData); err != nil {
 		t.Fatalf("setup: failed to remove project DerivedData dir, err: %s", err)
+	}
+	// Remove per-user swift cache
+	if err := os.RemoveAll(filepath.Join(pathutil.UserHomeDir(), "Library", "Caches", "org.swift.swiftpm")); err != nil {
+		t.Fatalf("setup: failed to remove per-user Swift cache dir, err: %s", err)
 	}
 
 	// Simulate the cache-pull step by restoring cached folder

--- a/xcodecache/swiftpm_cache_test.go
+++ b/xcodecache/swiftpm_cache_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-utils/env"
-	"github.com/bitrise-io/go-utils/pathutil"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/command/git"
@@ -190,14 +189,8 @@ func resolveProject(t *testing.T, projectPath, cacheDir, xcodeProjSourceDir stri
 	if err != nil {
 		t.Fatalf("failed to get project DerivedData path, error: %s", err)
 	}
-	t.Logf("Per-project DerivedData path: %s", projectDerivedData)
-
 	if err := os.RemoveAll(projectDerivedData); err != nil {
 		t.Fatalf("setup: failed to remove project DerivedData dir, err: %s", err)
-	}
-	// Remove per-user swift cache
-	if err := os.RemoveAll(filepath.Join(pathutil.UserHomeDir(), "Library", "Caches", "org.swift.swiftpm")); err != nil {
-		t.Fatalf("setup: failed to remove per-user Swift cache dir, err: %s", err)
 	}
 
 	// Simulate the cache-pull step by restoring cached folder


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context

errors.As was incorrectly used:
```
	rerr := appstoreconnect.ErrorResponse{} <-- & missing
		if ok := errors.As(err, &rerr); ok {
```

Resolves: https://bitrise.atlassian.net/browse/STEP-1731

### Changes

- Correctly detect  appstoreconnect.ErrorResponse.
- Fixed a bug when an incorrect device is encountered, other devices still sill be registered instead of returning early.
- Added retry for fetching a Bundle ID from a profile, if the profile has been removed.
