### PR TITLE
Include all export options even if profile is not found.

### DIFF
--- a/exportoptionsgenerator/exportoptionsgenerator.go
+++ b/exportoptionsgenerator/exportoptionsgenerator.go
@@ -422,6 +422,12 @@ func (g ExportOptionsGenerator) generateExportOptions(exportMethod exportoptions
 	}
 
 	exportOpts := generateBaseExportOptions(exportMethod, uploadBitcode, compileBitcode, iCloudContainerEnvironment)
+	if xcodeMajorVersion >= 12 {
+		exportOpts = addDistributionBundleIdentifierFromXcode12(exportOpts, distributionBundleIdentifier)
+	}
+	if xcodeMajorVersion >= 13 {
+		exportOpts = disableManagedBuildNumberFromXcode13(exportOpts)
+	}
 
 	codeSignGroup, err := g.determineCodesignGroup(bundleIDEntitlementsMap, exportMethod, teamID, xcodeManaged)
 	if err != nil {
@@ -476,14 +482,6 @@ func (g ExportOptionsGenerator) generateExportOptions(exportMethod exportoptions
 			options.SigningStyle = manualSigningStyle
 		}
 		exportOpts = options
-	}
-
-	if xcodeMajorVersion >= 12 {
-		exportOpts = addDistributionBundleIdentifierFromXcode12(exportOpts, distributionBundleIdentifier)
-	}
-
-	if xcodeMajorVersion >= 13 {
-		exportOpts = disableManagedBuildNumberFromXcode13(exportOpts)
 	}
 
 	return exportOpts, nil


### PR DESCRIPTION

	
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Include Xcode >12 specific export options even if an available profile/certificate is not found.

- distributionBundleIdentifier is requried for projects including App Clip
- manageAppVersionAndBuildNumber (Xcode>13) is also included for consistency

Due to the Automatic code signing feature it can happen that a given profile/certificate is not yet installed:
For example in xcode-archive Step:
- Archive is built (Xcode manages and downloads development provisioning profile)
- No custom exportOptions plist is provided, so the export options generator is called
	- No Ad-hoc provisioning profile is found (as expected, is not yet downloaded)
- If the distributionBundleIdentifier is not included (a project with App Clip) it will lead to failure:
	`Provide a bundle identifier to select from available reformatters`

Resolves: https://bitrise.atlassian.net/browse/STEP-1795

### Changes

- Moved adding Xcode 12 and 13 export options before detecting codesign groups (certificate + profile + teamID), so it will be included even if no codesign groups are found.

