### PR TITLE
Intalling certificate for local codesign assets

### DIFF
--- a/autocodesign/autocodesign.go
+++ b/autocodesign/autocodesign.go
@@ -179,7 +179,6 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 			devPortalDeviceIDs = append(devPortalDeviceIDs, devPortalDevice.ID)
 			devPortalDeviceUDIDs = append(devPortalDeviceUDIDs, devPortalDevice.Attributes.UDID)
 		}
-
 	}
 
 	codesignAssetsByDistributionType := map[DistributionType]AppCodesignAssets{}
@@ -195,6 +194,7 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 			// Did not check if selected certificate is installed yet
 			fmt.Println()
 			log.Infof("Installing certificate")
+			log.Printf("certificate: %s", localCodesignAssets.Certificate.CommonName)
 			if err := m.assetWriter.InstallCertificate(localCodesignAssets.Certificate); err != nil {
 				return nil, fmt.Errorf("failed to install certificate: %w", err)
 			}

--- a/autocodesign/autocodesign.go
+++ b/autocodesign/autocodesign.go
@@ -191,6 +191,14 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 		}
 
 		printExistingCodesignAssets(localCodesignAssets, distrType)
+		if localCodesignAssets != nil {
+			// Did not check if selected certificate is installed yet
+			fmt.Println()
+			log.Infof("Installing certificate")
+			if err := m.assetWriter.InstallCertificate(localCodesignAssets.Certificate); err != nil {
+				return nil, fmt.Errorf("failed to install certificate: %w", err)
+			}
+		}
 
 		finalAssets := localCodesignAssets
 		if missingAppLayout != nil {
@@ -213,7 +221,7 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 
 			// Install new certificates and profiles
 			fmt.Println()
-			log.Infof("Install certificates and profiles")
+			log.Infof("Installing certificates and profiles")
 			if err := m.assetWriter.Write(map[DistributionType]AppCodesignAssets{distrType: *newCodesignAssets}); err != nil {
 				return nil, fmt.Errorf("failed to install codesigning files: %w", err)
 			}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Make sure the certificate is installed when a matching local profile is found.

Resolves: https://bitrise.atlassian.net/browse/STEP-1715

### Changes

* Install certificate for locally found provisioning profiles. An alternative could have been to check weather certificate is already installed in the Keychain, always installing is the easier solution.
There was no check earlier that the selected certificate (or any certificate in the profile) was installed. This could have led to an error:
  - A Step with automatic code signing installs **Profile1**, this induces **Cert1** and **Cert2**. **Cert1** is selected (to be set as signing certificate in the project). **Profile1** is added, **Cert1** is added to the Keychain. (**Cert2** is not added.)
  - `xcodebuild archive` runs successfully
  - Another Step with automatic code signing is run. This time the previously added **Profile1** is found. However now **Cert2** is selected (randomly), it is not installed due to missing check.
   - `xcodebuild archive` fails with error: 
   
 ```
❌  error: No certificate for team 'AAABBBCCC' matching 'dcdcdc' found: Select a different signing certificate for CODE_SIGN_IDENTITY, a team that matches your selected certificate, or switch to automatic provisioning. (...)
```

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
