### PR TITLE
Added NewIosArchive for API compatibility

### DIFF
--- a/xcarchive/ios.go
+++ b/xcarchive/ios.go
@@ -2,6 +2,7 @@ package xcarchive
 
 import (
 	"fmt"
+
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
 	"github.com/bitrise-io/go-xcode/xcarchive"
 )
@@ -9,6 +10,15 @@ import (
 // IosArchive ...
 type IosArchive struct {
 	xcarchive.IosArchive
+}
+
+// NewIosArchive ...
+func NewIosArchive(path string) (IosArchive, error) {
+	archive, err := xcarchive.NewIosArchive(path)
+
+	return IosArchive{
+		IosArchive: archive,
+	}, err
 }
 
 // Platform ...


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Fixes an API incompatibility encountered in the export-xcarchive-step:

```
./main.go:204:32: cannot use a (type "github.com/bitrise-io/go-xcode/xcarchive".IosArchive) as type "github.com/bitrise-io/go-xcode/v2/xcarchive".IosArchive in argument to codesign.NewArchive
```
(needed for https://github.com/bitrise-steplib/steps-export-xcarchive/pull/38)
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Resolves: https://bitrise.atlassian.net/browse/STEP-1788

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
