### PR TITLE
Fix Xcode version parsing when output has warnings

### DIFF
--- a/utility/utility.go
+++ b/utility/utility.go
@@ -15,8 +15,20 @@ func getXcodeVersionFromXcodebuildOutput(outStr string) (models.XcodebuildVersio
 		return models.XcodebuildVersionModel{}, fmt.Errorf("failed to parse xcodebuild version output (%s)", outStr)
 	}
 
-	xcodebuildVersion := split[0]
-	buildVersion := split[1]
+	firstLineIndex := -1
+	for i, line := range split {
+		if strings.HasPrefix(line, "Xcode ") {
+			firstLineIndex = i
+			break
+		}
+	}
+
+	if firstLineIndex < 0 {
+		return models.XcodebuildVersionModel{}, fmt.Errorf("couldn't find Xcode version in output: %s", outStr)
+	}
+
+	xcodebuildVersion := split[firstLineIndex]
+	buildVersion := split[firstLineIndex+1]
 
 	split = strings.Split(xcodebuildVersion, " ")
 	if len(split) != 2 {

--- a/utility/utility_test.go
+++ b/utility/utility_test.go
@@ -7,20 +7,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testXcodebuildVersionOutput = `Xcode 8.2.1
-Build version 8C1002`
-
 func TestGetXcodeVersionFromXcodebuildOutput(t *testing.T) {
-	t.Log("GetXcodeVersionFromXcodebuildOutput")
-	{
-		expectedVersion := models.XcodebuildVersionModel{
-			Version:      "Xcode 8.2.1",
-			BuildVersion: "Build version 8C1002",
-			MajorVersion: 8,
-		}
+	tests := []struct {
+		name          string
+		output        string
+		wantedVersion models.XcodebuildVersionModel
+	}{
+		{
+			name:   "Plain output",
+			output: "Xcode 8.2.1\nBuild version 8C1002",
+			wantedVersion: models.XcodebuildVersionModel{
+				Version:      "Xcode 8.2.1",
+				BuildVersion: "Build version 8C1002",
+				MajorVersion: 8,
+			},
+		},
+		{
+			name: "Warnings in output (Xcode 13.2.1 bug)",
+			output: `objc[82434]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libauthinstall.dylib (0x212da2b90) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1046dc2c8). One of the two will be used. Which one is undefined.
+objc[82434]: Class AMSupportURLSession is implemented in both /usr/lib/libauthinstall.dylib (0x212da2be0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1046dc318). One of the two will be used. Which one is undefined.
+Xcode 13.2.1
+Build version 13C100`,
+			wantedVersion: models.XcodebuildVersionModel{
+				Version:      "Xcode 13.2.1",
+				BuildVersion: "Build version 13C100",
+				MajorVersion: 13,
+			},
+		},
+	}
 
-		currentVersion, err := getXcodeVersionFromXcodebuildOutput(testXcodebuildVersionOutput)
+	for _, tt := range tests {
+		currentVersion, err := getXcodeVersionFromXcodebuildOutput(tt.output)
 		require.NoError(t, err)
-		require.Equal(t, expectedVersion, currentVersion)
+		require.Equal(t, tt.wantedVersion, currentVersion)
 	}
 }


### PR DESCRIPTION
### Context

Xcode 13.2.1 has a known issue: https://developer.apple.com/forums/thread/698628

The additional lines in output breaks the version parsing.

### Changes

- Make the version parsing more robust
- Add more tests

