### PR TITLE
Unlock keychain before other operations

### DIFF
--- a/autocodesign/keychain/keychain.go
+++ b/autocodesign/keychain/keychain.go
@@ -65,6 +65,10 @@ func (k Keychain) InstallCertificate(cert certificateutil.CertificateInfoModel, 
 		return err
 	}
 
+	if err := k.unlock(); err != nil {
+		return err
+	}
+
 	if err := k.importCertificate(pth, "bitrise"); err != nil {
 		return err
 	}
@@ -85,11 +89,7 @@ func (k Keychain) InstallCertificate(cert certificateutil.CertificateInfoModel, 
 		return err
 	}
 
-	if err := k.setAsDefault(); err != nil {
-		return err
-	}
-
-	return k.unlock()
+	return k.setAsDefault()
 }
 
 func runSecurityCmd(factory command.Factory, args ...interface{}) error {


### PR DESCRIPTION
Make sure keychain is unlocked before doing other keychain operations. Importing a certificate into a locked keychain could hang the command without any error.

Proof that it works: https://github.com/bitrise-steplib/steps-xcode-build-for-test/pull/29