### PR TITLE
Apply existing device processing logic for device registration response

### DIFF
--- a/autocodesign/devportalclient/spaceship/spaceship/devices.rb
+++ b/autocodesign/devportalclient/spaceship/spaceship/devices.rb
@@ -24,7 +24,17 @@ end
 
 def register_device(udid, name)
   device = Spaceship::Portal.device.create!(name: name, udid: udid)
-  { device: device }
+  {
+    device: {
+        id: device.id,
+        udid: device.udid,
+        name: device.name,
+        model: device.model,
+        status: map_device_status_to_api_status(device.status),
+        platform: map_device_platform_to_api_platform(device.platform),
+        class: map_device_class_to_api_class(device.device_type)
+    }
+  }
 rescue Spaceship::UnexpectedResponse, Spaceship::BasicPreferredInfoError => e
   message = preferred_error_message(e)
   { warnings: ["Failed to register device with name: #{name} udid: #{udid} error: #{message}"] }


### PR DESCRIPTION
We have received user complaint about the device registration failing the build. If you are using an Apple ID based connection and want to register a new device the autocodesign logic throws this error:
```
failed to manage code signing: failed to ensure test devices: failed to register Bitrise Test device on Apple Developer Portal: failed to unmarshal response: json: cannot unmarshal string into Go struct field .data.device of type spaceship.DeviceInfo
```

It is happening because 
```
{ device: device }
```
returns the following format
```
{
"device":"<Spaceship::Portal::Device id="ABCDEFG", name="Test name", udid="00000001-00000000000001", platform="ios", status="c", model="Test model", device_type="iphone">"
}
```
and the Go code expects a valid json and also different field names for some of them (like the `device_type `). Here is a link to the Go struct: https://github.com/bitrise-io/go-xcode/blob/a8f24205effe4374f97a1ace69ec388b0ec4aa39/autocodesign/devportalclient/spaceship/devices.go#L25

The `list_devices` function uses this object transformation and applying it solved the issue. 