### PR TITLE
Fix parsing of macOS profile types

### DIFF
--- a/profileutil/info_model_test.go
+++ b/profileutil/info_model_test.go
@@ -3,6 +3,8 @@ package profileutil
 import (
 	"testing"
 
+	"github.com/fullsailor/pkcs7"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,3 +38,166 @@ func TestIsXcodeManaged(t *testing.T) {
 		require.Equal(t, false, IsXcodeManaged(profileName))
 	}
 }
+
+func TestProvisioningProfilePlatform(t *testing.T) {
+	tests := []struct {
+		name           string
+		profileContent string
+		want           ProfileType
+	}{
+		{
+			name:           "iOS",
+			profileContent: iosProfileContent,
+			want:           ProfileTypeIos,
+		},
+		{
+			name:           "macOS",
+			profileContent: macosProfileContent,
+			want:           ProfileTypeMacOs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profilePkcs7 := pkcs7.PKCS7{Content: []byte(tt.profileContent)}
+			got, err := NewProvisioningProfileInfo(profilePkcs7)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got.Type)
+		})
+	}
+}
+
+const iosProfileContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppIDName</key>
+	<string>Bitrise Test</string>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+	<string>9NS44DLTN7</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2016-09-22T11:28:46Z</date>
+	<key>Platform</key>
+	<array>
+		<string>iOS</string>
+	</array>
+	<key>DeveloperCertificates</key>
+	<array>
+		<data></data>
+	</array>
+	<key>Entitlements</key>
+	<dict>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>9NS44DLTN7.*</string>
+		</array>
+		<key>get-task-allow</key>
+		<true/>
+		<key>application-identifier</key>
+		<string>9NS44DLTN7.*</string>
+		<key>com.apple.developer.team-identifier</key>
+		<string>9NS44DLTN7</string>
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2017-09-22T11:28:46Z</date>
+	<key>Name</key>
+	<string>Bitrise Test Development</string>
+	<key>ProvisionedDevices</key>
+	<array>
+		<string>b13813075ad9b298cb9a9f28555c49573d8bc322</string>
+	</array>
+	<key>TeamIdentifier</key>
+	<array>
+		<string>9NS44DLTN7</string>
+	</array>
+	<key>TeamName</key>
+	<string>Some Dude</string>
+	<key>TimeToLive</key>
+	<integer>365</integer>
+	<key>UUID</key>
+	<string>4b617a5f-e31e-4edc-9460-718a5abacd05</string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>`
+
+const macosProfileContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppIDName</key>
+	<string>XC io bitrise mobile ios QuickActionsTodayExtension</string>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+	<string>72SA8V3WYL</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2022-02-28T10:35:39Z</date>
+	<key>Platform</key>
+	<array>
+			<string>OSX</string>
+	</array>
+	<key>IsXcodeManaged</key>
+	<false/>
+	<key>DeveloperCertificates</key>
+	<array>
+		<data></data>
+	</array>
+
+	<key>DER-Encoded-Profile</key>
+	<data></data>
+														
+	<key>Entitlements</key>
+	<dict>
+				
+				<key>com.apple.developer.game-center</key>
+		<true/>
+				
+				<key>com.apple.security.application-groups</key>
+		<array>
+				<string>group.io.bitrise.statistics</string>
+		</array>
+				
+				<key>application-identifier</key>
+		<string>72SA8V3WYL.io.bitrise.mobile.ios.QuickActionsTodayExtension</string>
+				
+				<key>com.apple.application-identifier</key>
+		<string>72SA8V3WYL.io.bitrise.mobile.ios.QuickActionsTodayExtension</string>
+				
+				<key>keychain-access-groups</key>
+		<array>
+				<string>72SA8V3WYL.*</string>
+				<string>com.apple.token</string>
+		</array>
+				
+				<key>get-task-allow</key>
+		<true/>
+				
+				<key>com.apple.developer.team-identifier</key>
+		<string>72SA8V3WYL</string>
+
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2023-02-28T10:35:39Z</date>
+	<key>Name</key>
+	<string>_profile_bug_type_catalyst</string>
+	<key>ProvisionedDevices</key>
+	<array>
+		<string>BA0EC799-F254-5574-B335-E70B8A2FA5E7</string>
+	</array>
+	<key>TeamIdentifier</key>
+	<array>
+		<string>72SA8V3WYL</string>
+	</array>
+	<key>TeamName</key>
+	<string>BITFALL FEJLESZTO KORLATOLT FELELOSSEGU TARSASAG</string>
+	<key>TimeToLive</key>
+	<integer>365</integer>
+	<key>UUID</key>
+	<string>dea6a48c-d7d3-4624-9f6b-e0c3b3ce517d</string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>`

--- a/profileutil/util.go
+++ b/profileutil/util.go
@@ -15,7 +15,7 @@ type ProfileType string
 const ProfileTypeIos ProfileType = "ios"
 
 // ProfileTypeMacOs ...
-const ProfileTypeMacOs ProfileType = "macos"
+const ProfileTypeMacOs ProfileType = "osx"
 
 // ProfileTypeTvOs ...
 const ProfileTypeTvOs ProfileType = "tvos"


### PR DESCRIPTION
### Context

There is a latent bug in parsing provisioning profiles that only affects macOS profiles. The profile type string value should have always been `osx` instead of `macos`, all the profiles I tested contain `osx` as the platform value.

This bug had been hidden by the parsing logic until we changed that: https://github.com/bitrise-io/go-xcode/pull/135/files#diff-bce396a3a6fcf20dea5ebb455b48500d48eb91b11baef46a7506c217d72b82b2

Note that the old code assigned macOS as the platform type by default and only changed it to iOS if it matched that platform. The new code does proper pattern matching for every possible platform, so it with `unknown platform type: macos` when parsing a macOS profile.

This is the root cause of https://github.com/bitrise-steplib/steps-export-xcarchive-mac/issues/13, because we recently bumped `go-xcode` in the step despite a failing CI check: https://github.com/bitrise-steplib/steps-export-xcarchive-mac/pull/12

It also affects the `xcode-archive-mac` step as `go-xcode` was bumped there too: https://github.com/bitrise-steplib/steps-xcode-archive-mac/pull/42