### PR TITLE
Adds resolvePackageDependencies command, logs elapsed time for showBuildSettings

### DIFF
--- a/xcodebuild/resolve_package_deps.go
+++ b/xcodebuild/resolve_package_deps.go
@@ -1,9 +1,13 @@
 package xcodebuild
 
 import (
+	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/errorutil"
+	"github.com/bitrise-io/go-utils/log"
 )
 
 // ResolvePackagesCommandModel is a command builder
@@ -48,4 +52,25 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 func (m *ResolvePackagesCommandModel) Command() command.Model {
 	cmdSlice := m.cmdSlice()
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
+}
+
+func (m *ResolvePackagesCommandModel) Run() error {
+	var (
+		cmd   = m.Command()
+		start = time.Now()
+	)
+
+	log.Printf("Resolving package dependencies...")
+
+	log.TDonef("$ %s", cmd.PrintableCommandArgs())
+	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
+		if errorutil.IsExitStatusError(err) {
+			return fmt.Errorf("failed to resolve package dependencies, output: %s", out)
+		}
+		return fmt.Errorf("failed to run command: %s", err)
+	}
+
+	log.Printf("Resolved package dependencies in %s.", time.Since(start).Round(time.Second))
+
+	return nil
 }

--- a/xcodebuild/resolve_package_deps.go
+++ b/xcodebuild/resolve_package_deps.go
@@ -42,5 +42,5 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 
 func (m *ResolvePackagesCommandModel) Command() command.Model {
 	cmdSlice := m.cmdSlice()
-	return *command.New(cmdSlice[0], cmdSlice[1:]...)
+	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
 }

--- a/xcodebuild/resolve_package_deps.go
+++ b/xcodebuild/resolve_package_deps.go
@@ -1,0 +1,46 @@
+package xcodebuild
+
+import (
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/command"
+)
+
+type ResolvePackagesCommandModel struct {
+	projectPath string
+
+	customOptions []string
+}
+
+func NewResolvePackagesCommandModel(projectPath string) *ResolvePackagesCommandModel {
+	return &ResolvePackagesCommandModel{
+		projectPath: projectPath,
+	}
+}
+
+func (m *ResolvePackagesCommandModel) SetCustomOptions(customOptions []string) *ResolvePackagesCommandModel {
+	m.customOptions = customOptions
+	return m
+}
+
+func (m *ResolvePackagesCommandModel) cmdSlice() []string {
+	slice := []string{toolName}
+
+	if m.projectPath != "" {
+		if filepath.Ext(m.projectPath) == ".xcworkspace" {
+			slice = append(slice, "-workspace", m.projectPath)
+		} else {
+			slice = append(slice, "-project", m.projectPath)
+		}
+	}
+
+	slice = append(slice, "-resolvePackageDependencies")
+	slice = append(slice, m.customOptions...)
+
+	return slice
+}
+
+func (m *ResolvePackagesCommandModel) Command() command.Model {
+	cmdSlice := m.cmdSlice()
+	return *command.New(cmdSlice[0], cmdSlice[1:]...)
+}

--- a/xcodebuild/resolve_package_deps.go
+++ b/xcodebuild/resolve_package_deps.go
@@ -13,15 +13,19 @@ import (
 // ResolvePackagesCommandModel is a command builder
 // used to create `xcodebuild -resolvePackageDependencies` command
 type ResolvePackagesCommandModel struct {
-	projectPath string
+	projectPath   string
+	scheme        string
+	configuration string
 
 	customOptions []string
 }
 
 // NewResolvePackagesCommandModel returns a new ResolvePackagesCommandModel
-func NewResolvePackagesCommandModel(projectPath string) *ResolvePackagesCommandModel {
+func NewResolvePackagesCommandModel(projectPath, scheme, configuration string) *ResolvePackagesCommandModel {
 	return &ResolvePackagesCommandModel{
-		projectPath: projectPath,
+		projectPath:   projectPath,
+		scheme:        scheme,
+		configuration: configuration,
 	}
 }
 
@@ -42,6 +46,14 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 		}
 	}
 
+	if m.scheme != "" {
+		slice = append(slice, "-scheme", m.scheme)
+	}
+
+	if m.configuration != "" {
+		slice = append(slice, "-configuration", m.configuration)
+	}
+
 	slice = append(slice, "-resolvePackageDependencies")
 	slice = append(slice, m.customOptions...)
 
@@ -49,14 +61,14 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 }
 
 // Command returns the executable command
-func (m *ResolvePackagesCommandModel) Command() command.Model {
+func (m *ResolvePackagesCommandModel) command() command.Model {
 	cmdSlice := m.cmdSlice()
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
 }
 
 func (m *ResolvePackagesCommandModel) Run() error {
 	var (
-		cmd   = m.Command()
+		cmd   = m.command()
 		start = time.Now()
 	)
 

--- a/xcodebuild/resolve_package_deps.go
+++ b/xcodebuild/resolve_package_deps.go
@@ -6,18 +6,22 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 )
 
+// ResolvePackagesCommandModel is a command builder
+// used to create `xcodebuild -resolvePackageDependencies` command
 type ResolvePackagesCommandModel struct {
 	projectPath string
 
 	customOptions []string
 }
 
+// NewResolvePackagesCommandModel returns a new ResolvePackagesCommandModel
 func NewResolvePackagesCommandModel(projectPath string) *ResolvePackagesCommandModel {
 	return &ResolvePackagesCommandModel{
 		projectPath: projectPath,
 	}
 }
 
+// SetCustomOptions sets custom options
 func (m *ResolvePackagesCommandModel) SetCustomOptions(customOptions []string) *ResolvePackagesCommandModel {
 	m.customOptions = customOptions
 	return m
@@ -40,6 +44,7 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 	return slice
 }
 
+// Command returns the executable command
 func (m *ResolvePackagesCommandModel) Command() command.Model {
 	cmdSlice := m.cmdSlice()
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)

--- a/xcodebuild/resolve_package_deps.go
+++ b/xcodebuild/resolve_package_deps.go
@@ -66,6 +66,7 @@ func (m *ResolvePackagesCommandModel) command() command.Model {
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
 }
 
+// Run runs the command and logs elapsed time
 func (m *ResolvePackagesCommandModel) Run() error {
 	var (
 		cmd   = m.command()

--- a/xcodebuild/resolve_package_deps.go
+++ b/xcodebuild/resolve_package_deps.go
@@ -63,9 +63,9 @@ func (m *ResolvePackagesCommandModel) Run() error {
 	log.Printf("Resolving package dependencies...")
 
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
-	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
+	if err := cmd.Run(); err != nil {
 		if errorutil.IsExitStatusError(err) {
-			return fmt.Errorf("failed to resolve package dependencies, output: %s", out)
+			return fmt.Errorf("failed to resolve package dependencies")
 		}
 		return fmt.Errorf("failed to run command: %s", err)
 	}

--- a/xcodebuild/resolve_package_deps_test.go
+++ b/xcodebuild/resolve_package_deps_test.go
@@ -1,0 +1,54 @@
+package xcodebuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePackagesCommandModel_cmdSlice(t *testing.T) {
+	type fields struct {
+		projectPath   string
+		customOptions []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			name: "workspace",
+			fields: fields{
+				projectPath: "test.xcworkspace",
+			},
+			want: []string{
+				"xcodebuild",
+				"-workspace", "test.xcworkspace",
+				"-resolvePackageDependencies",
+			},
+		},
+		{
+			name: "project",
+			fields: fields{
+				projectPath: "test.xcodeproj",
+			},
+			want: []string{
+				"xcodebuild",
+				"-project", "test.xcodeproj",
+				"-resolvePackageDependencies",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ResolvePackagesCommandModel{
+				projectPath:   tt.fields.projectPath,
+				customOptions: tt.fields.customOptions,
+			}
+
+			got := m.cmdSlice()
+
+			require.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/xcodebuild/resolve_package_deps_test.go
+++ b/xcodebuild/resolve_package_deps_test.go
@@ -9,6 +9,8 @@ import (
 func TestResolvePackagesCommandModel_cmdSlice(t *testing.T) {
 	type fields struct {
 		projectPath   string
+		scheme        string
+		configuration string
 		customOptions []string
 	}
 	tests := []struct {
@@ -30,11 +32,15 @@ func TestResolvePackagesCommandModel_cmdSlice(t *testing.T) {
 		{
 			name: "project",
 			fields: fields{
-				projectPath: "test.xcodeproj",
+				projectPath:   "test.xcodeproj",
+				scheme:        "Test",
+				configuration: "Debug",
 			},
 			want: []string{
 				"xcodebuild",
 				"-project", "test.xcodeproj",
+				"-scheme", "Test",
+				"-configuration", "Debug",
 				"-resolvePackageDependencies",
 			},
 		},
@@ -43,6 +49,8 @@ func TestResolvePackagesCommandModel_cmdSlice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &ResolvePackagesCommandModel{
 				projectPath:   tt.fields.projectPath,
+				scheme:        tt.fields.scheme,
+				configuration: tt.fields.configuration,
 				customOptions: tt.fields.customOptions,
 			}
 

--- a/xcodebuild/show_build_settings.go
+++ b/xcodebuild/show_build_settings.go
@@ -119,7 +119,8 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
 	cmd := c.Command()
-	log.TDonef("%s", cmd.PrintableCommandArgs())
+	log.TPrintf("Reading build settings:")
+	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {

--- a/xcodebuild/show_build_settings.go
+++ b/xcodebuild/show_build_settings.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 )
 
@@ -118,6 +119,7 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
 	cmd := c.Command()
+	log.TDonef("%s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {
@@ -125,6 +127,7 @@ func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object
 		}
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
+	log.TPrintf("Finished reading target settings.")
 
 	return parseBuildSettings(out)
 }

--- a/xcodebuild/show_build_settings.go
+++ b/xcodebuild/show_build_settings.go
@@ -119,17 +119,22 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
-	cmd := c.Command()
-	log.Printf("Reading build settings:")
-	start := time.Now()
+	var (
+		cmd   = c.Command()
+		start = time.Now()
+	)
+
+	log.Printf("Reading build settings...")
+
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {
-			return nil, fmt.Errorf("%s command failed: output: %s", cmd.PrintableCommandArgs(), out)
+			return nil, fmt.Errorf("%s command failed, output: %s", cmd.PrintableCommandArgs(), out)
 		}
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
+
 	log.Printf("Read target settings in %s.", time.Since(start).Round(time.Second))
 
 	return parseBuildSettings(out)

--- a/xcodebuild/show_build_settings.go
+++ b/xcodebuild/show_build_settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -119,7 +120,8 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
 	cmd := c.Command()
-	log.TPrintf("Reading build settings:")
+	log.Printf("Reading build settings:")
+	start := time.Now()
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
@@ -128,7 +130,7 @@ func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object
 		}
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
-	log.TPrintf("Finished reading target settings.")
+	log.Printf("Read target settings in %s.", time.Since(start).Round(time.Second))
 
 	return parseBuildSettings(out)
 }


### PR DESCRIPTION
## Context
Want to improve visibility of how much time resolving Swift packages takes; as part of the `-showBuildSettings` command especially.

## Changes
* Added a `-resolvePackageDependencies` command builder
* Log elapsed time in the `-showBuildSettings` command