### PR TITLE
Improve empty passphrase handling

### DIFF
--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -31,15 +31,6 @@ type Config struct {
 
 // ParseConfig validates and parses step inputs related to code signing and returns with a Config
 func ParseConfig(input Input, cmdFactory command.Factory) (Config, error) {
-	if strings.TrimSpace(input.CertificateURLList) == "" {
-		return Config{}, fmt.Errorf("code signing certificate URL: required variable is not present")
-	}
-	if strings.TrimSpace(input.KeychainPath) == "" {
-		return Config{}, fmt.Errorf("keychain path: required variable is not present")
-	}
-	if strings.TrimSpace(string(input.KeychainPassword)) == "" {
-		return Config{}, fmt.Errorf("keychain password: required variable is not present")
-	}
 	certificatesAndPassphrases, err := parseCertificates(input)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to parse certificate URL and passphrase inputs: %s", err)
@@ -59,6 +50,16 @@ func ParseConfig(input Input, cmdFactory command.Factory) (Config, error) {
 
 // parseCertificates returns an array of p12 file URLs and passphrases
 func parseCertificates(input Input) ([]certdownloader.CertificateAndPassphrase, error) {
+	if strings.TrimSpace(input.CertificateURLList) == "" {
+		return nil, fmt.Errorf("code signing certificate URL: required input is not present")
+	}
+	if strings.TrimSpace(input.KeychainPath) == "" {
+		return nil, fmt.Errorf("keychain path: required input is not present")
+	}
+	if strings.TrimSpace(string(input.KeychainPassword)) == "" {
+		return nil, fmt.Errorf("keychain password: required input is not present")
+	}
+
 	pfxURLs, passphrases, err := validateCertificates(input.CertificateURLList, string(input.CertificatePassphraseList))
 	if err != nil {
 		return nil, err
@@ -78,10 +79,10 @@ func parseCertificates(input Input) ([]certdownloader.CertificateAndPassphrase, 
 // validateCertificates validates if the number of certificate URLs matches those of passphrases
 func validateCertificates(certURLList string, certPassphraseList string) ([]string, []string, error) {
 	pfxURLs := splitAndClean(certURLList, "|", true)
-	passphrases := splitAndClean(certPassphraseList, "|", false)
+	passphrases := splitAndClean(certPassphraseList, "|", false) // allow empty items because passphrase can be empty
 
 	if len(pfxURLs) != len(passphrases) {
-		return nil, nil, fmt.Errorf("certificates count (%d) and passphrases count (%d) should match", len(pfxURLs), len(passphrases))
+		return nil, nil, fmt.Errorf("certificate count (%d) and passphrase count (%d) should match", len(pfxURLs), len(passphrases))
 	}
 
 	return pfxURLs, passphrases, nil

--- a/codesign/inputparse_test.go
+++ b/codesign/inputparse_test.go
@@ -1,0 +1,129 @@
+package codesign
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader"
+)
+
+func TestParseCertificates(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   Input
+		want    []certdownloader.CertificateAndPassphrase
+		wantErr bool
+	}{
+		{
+			name: "One certificate and passphrase",
+			input: Input{
+				CertificateURLList:        "https://example.com/storage/development.p12 ",
+				CertificatePassphraseList: "password",
+				KeychainPath:              t.TempDir(),
+				KeychainPassword:          "keychainpassword",
+			},
+			want: []certdownloader.CertificateAndPassphrase{{
+				URL:        "https://example.com/storage/development.p12",
+				Passphrase: "password",
+			}},
+		},
+		{
+			name: "Multiple certificates and passphrases",
+			input: Input{
+				CertificateURLList:        "https://example.com/storage/development.p12|https://example.com/storage/distribution.p12",
+				CertificatePassphraseList: "password|password2",
+				KeychainPath:              t.TempDir(),
+				KeychainPassword:          "keychainpassword",
+			},
+			want: []certdownloader.CertificateAndPassphrase{
+				{
+					URL:        "https://example.com/storage/development.p12",
+					Passphrase: "password",
+				},
+				{
+					URL:        "https://example.com/storage/distribution.p12",
+					Passphrase: "password2",
+				},
+			},
+		},
+		{
+			name: "Empty certificate and passphrase value in lists",
+			input: Input{
+				CertificateURLList:        "https://example.com/storage/development.p12|",
+				CertificatePassphraseList: "password|",
+				KeychainPath:              t.TempDir(),
+				KeychainPassword:          "keychainpassword",
+			},
+			wantErr: true, // Because empty passphrase is a valid value for a no-passphrase-cert, so the list has 2 items
+		},
+		{
+			name: "No certificate nor passphrase",
+			input: Input{
+				CertificateURLList:        "",
+				CertificatePassphraseList: "",
+				KeychainPath:              t.TempDir(),
+				KeychainPassword:          "keychainpassword",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Mismatch in certificate and passphrase count",
+			input: Input{
+				CertificateURLList:        "https://example.com/storage/development.p12|https://example.com/storage/distribution.p12",
+				CertificatePassphraseList: "password",
+				KeychainPath:              t.TempDir(),
+				KeychainPassword:          "keychainpassword",
+			},
+			wantErr: true,
+		},
+		{
+			name: "One certificate without passphrase",
+			input: Input{
+				CertificateURLList:        "https://example.com/storage/development.p12",
+				CertificatePassphraseList: "",
+				KeychainPath:              t.TempDir(),
+				KeychainPassword:          "keychainpassword",
+			},
+			want: []certdownloader.CertificateAndPassphrase{{
+				URL:        "https://example.com/storage/development.p12",
+				Passphrase: "",
+			}},
+		},
+		{
+			name: "Multiple certificates without passphrases",
+			input: Input{
+				CertificateURLList:        "https://example.com/storage/development.p12|https://example.com/storage/distribution.p12|https://example.com/storage/adhoc.p12",
+				CertificatePassphraseList: "||",
+				KeychainPath:              t.TempDir(),
+				KeychainPassword:          "keychainpassword",
+			},
+			want: []certdownloader.CertificateAndPassphrase{
+				{
+					URL:        "https://example.com/storage/development.p12",
+					Passphrase: "",
+				},
+				{
+					URL:        "https://example.com/storage/distribution.p12",
+					Passphrase: "",
+				},
+				{
+					URL:        "https://example.com/storage/adhoc.p12",
+					Passphrase: "",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := parseCertificates(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseConfig() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Context

Trying to clean up and unify the handling of certificates without a passphrase (which we allow uploading at the moment, so we should at least handle these certs consistently across all steps).

Related bug: https://github.com/bitrise-steplib/bitrise-step-manage-ios-code-signing/issues/8

### Changes

First of all, there is no real bug fix in this PR. It turned out that this code in go-xcode already supports parsing of the list inputs with empty passphrase items. The problem is on the step side where we marked the passphrase list input as required, so a single item of empty passphrase is an invalid step input.

This PR improves the following:

- Add tests for input parsing to make it explicit that we support empty passphrases
- Improve log messages here and there 