### PR TITLE
[NOJIRA] Add support for time format returned by Spaceship with SPACESHIP_AVOID_XCODE_API=true

### DIFF
--- a/autocodesign/autocodesign_test.go
+++ b/autocodesign/autocodesign_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	devportaltime "github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
+
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/certificateutil"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
@@ -93,7 +95,7 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 		attributes: appstoreconnect.ProfileAttributes{
 			Name:           profileName(appstoreconnect.IOSAppDevelopment, "io.test"),
 			ProfileState:   appstoreconnect.Active,
-			ExpirationDate: appstoreconnect.Time(expiry),
+			ExpirationDate: devportaltime.Time(expiry),
 		},
 		certificates: []string{"dev1"},
 	})
@@ -365,7 +367,7 @@ func Test_GivenProfileExpired_WhenProfilesInconsistent_ThenItRetries(t *testing.
 		attributes: appstoreconnect.ProfileAttributes{
 			Name:           profileName(appstoreconnect.IOSAppDevelopment, "io.test"),
 			ProfileState:   appstoreconnect.Active,
-			ExpirationDate: appstoreconnect.Time(time.Now().AddDate(0, -1, 0)),
+			ExpirationDate: devportaltime.Time(time.Now().AddDate(0, -1, 0)),
 		},
 		certificates: []string{"dev1"},
 	})
@@ -373,7 +375,7 @@ func Test_GivenProfileExpired_WhenProfilesInconsistent_ThenItRetries(t *testing.
 		attributes: appstoreconnect.ProfileAttributes{
 			Name:           profileName(appstoreconnect.IOSAppDevelopment, "io.test"),
 			ProfileState:   appstoreconnect.Active,
-			ExpirationDate: appstoreconnect.Time(expiry),
+			ExpirationDate: devportaltime.Time(expiry),
 		},
 		certificates: []string{"dev1"},
 	})
@@ -438,7 +440,7 @@ func Test_GivenLocalProfile_WhenCertificateIsMissing_ThenInstalled(t *testing.T)
 		attributes: appstoreconnect.ProfileAttributes{
 			Name:           profileName(appstoreconnect.IOSAppDevelopment, "io.test"),
 			ProfileState:   appstoreconnect.Active,
-			ExpirationDate: appstoreconnect.Time(expiry),
+			ExpirationDate: devportaltime.Time(expiry),
 		},
 		certificates: []string{"dev1", "dev2"},
 	})

--- a/autocodesign/devportalclient/appstoreconnect/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnect/profiles.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 )
 
@@ -85,7 +86,7 @@ type ProfileAttributes struct {
 	CreatedDate    string           `json:"createdDate"`
 	ProfileState   ProfileState     `json:"profileState"`
 	ProfileType    ProfileType      `json:"profileType"`
-	ExpirationDate Time             `json:"expirationDate"`
+	ExpirationDate time.Time        `json:"expirationDate"`
 }
 
 // Profile ...

--- a/autocodesign/devportalclient/appstoreconnect/time.go
+++ b/autocodesign/devportalclient/appstoreconnect/time.go
@@ -42,5 +42,6 @@ func timeFormats() []string {
 		time.RFC3339,
 		"2006-01-02T15:04:05.000-0700",
 		"2006-01-02T15:04:05.000-07",
+		"2006-01-02 15:04:05 UTC", // Returned by Spaceship with SPACESHIP_AVOID_XCODE_API=true
 	}
 }

--- a/autocodesign/devportalclient/spaceship/profiles.go
+++ b/autocodesign/devportalclient/spaceship/profiles.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
+	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
 )
 
 const (
@@ -82,7 +83,7 @@ type ProfileInfo struct {
 	UUID         string                           `json:"uuid"`
 	Name         string                           `json:"name"`
 	Status       appstoreconnect.ProfileState     `json:"status"`
-	Expiry       appstoreconnect.Time             `json:"expiry"`
+	Expiry       time.Time                        `json:"expiry"`
 	Platform     appstoreconnect.BundleIDPlatform `json:"platform"`
 	Content      string                           `json:"content"`
 	AppID        string                           `json:"app_id"`
@@ -104,7 +105,7 @@ func newProfile(p ProfileInfo) (autocodesign.Profile, error) {
 			ProfileState:   appstoreconnect.ProfileState(p.Status),
 			ProfileContent: contents,
 			Platform:       p.Platform,
-			ExpirationDate: appstoreconnect.Time(p.Expiry),
+			ExpirationDate: time.Time(p.Expiry),
 		},
 		id:             p.ID,
 		bundleID:       p.BundleID,

--- a/autocodesign/devportalclient/spaceship/profiles.go
+++ b/autocodesign/devportalclient/spaceship/profiles.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
@@ -83,7 +82,7 @@ type ProfileInfo struct {
 	UUID         string                           `json:"uuid"`
 	Name         string                           `json:"name"`
 	Status       appstoreconnect.ProfileState     `json:"status"`
-	Expiry       time.Time                        `json:"expiry"`
+	Expiry       appstoreconnect.Time             `json:"expiry"`
 	Platform     appstoreconnect.BundleIDPlatform `json:"platform"`
 	Content      string                           `json:"content"`
 	AppID        string                           `json:"app_id"`

--- a/autocodesign/devportalclient/time/time.go
+++ b/autocodesign/devportalclient/time/time.go
@@ -1,4 +1,4 @@
-package appstoreconnect
+package time
 
 import (
 	"fmt"
@@ -29,6 +29,14 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 }
 
 func timeFormats() []string {
+	formats := []string{time.RFC3339}
+	formats = append(formats, appleKeyAuthTimeFormats()...)
+	formats = append(formats, appleIDAuthTimeFormats()...)
+
+	return formats
+}
+
+func appleKeyAuthTimeFormats() []string {
 	// Apple is using an ISO 8601 time format (https://en.wikipedia.org/wiki/ISO_8601). In this format the offset from
 	// the UTC time can have the following equivalent and interchangeable formats:
 	// * [+/-]07:00
@@ -39,9 +47,15 @@ func timeFormats() []string {
 	// Go has built in support for ISO 8601 but only for the zero offset UTC and the [+/-]07:00 format under time.RFC3339.
 	// We still need to check for the other two.
 	return []string{
-		time.RFC3339,
 		"2006-01-02T15:04:05.000-0700",
 		"2006-01-02T15:04:05.000-07",
-		"2006-01-02 15:04:05 UTC", // Returned by Spaceship with SPACESHIP_AVOID_XCODE_API=true
+	}
+}
+
+func appleIDAuthTimeFormats() []string {
+	// Spaceship returns this time format when setting SPACESHIP_AVOID_XCODE_API=true. This is needed because Apple's
+	// API started to return an error for the old spaceship implementation.
+	return []string{
+		"2006-01-02 15:04:05 UTC",
 	}
 }

--- a/autocodesign/devportalclient/time/time_test.go
+++ b/autocodesign/devportalclient/time/time_test.go
@@ -1,4 +1,4 @@
-package appstoreconnect
+package time
 
 import (
 	"testing"
@@ -20,6 +20,7 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 		{name: "Single hour positive offset", b: []byte("2021-05-19T08:07:47.000+03"), wantErr: false},
 		{name: "Single hour negative offset", b: []byte("2021-05-19T08:07:47.000-02"), wantErr: false},
 		{name: "Zero offset UTC", b: []byte("2021-05-19T08:07:47.000Z"), wantErr: false},
+		{name: "Custom spaceship time format", b: []byte("2022-04-01 12:45:25 UTC"), wantErr: false},
 		{name: "unsupported format", b: []byte("2021-12-17T10:44:00Z00:00"), wantErr: true},
 	}
 	for _, tt := range tests {

--- a/autocodesign/localcodesignasset/localcodesignasset_test.go
+++ b/autocodesign/localcodesignasset/localcodesignasset_test.go
@@ -1,15 +1,17 @@
 package localcodesignasset
 
 import (
-	"github.com/bitrise-io/go-xcode/v2/autocodesign/localcodesignasset/mocks"
 	"testing"
 	"time"
+
+	devportaltime "github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
 
 	"github.com/bitrise-io/go-xcode/certificateutil"
 	"github.com/bitrise-io/go-xcode/exportoptions"
 	"github.com/bitrise-io/go-xcode/profileutil"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
+	"github.com/bitrise-io/go-xcode/v2/autocodesign/localcodesignasset/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -208,7 +210,7 @@ func profileFromModel(profileInfo profileutil.ProvisioningProfileInfoModel) auto
 			UUID:           profileInfo.UUID,
 			ProfileContent: []byte{},
 			Platform:       getBundleIDPlatform(profileInfo.Type),
-			ExpirationDate: appstoreconnect.Time(profileInfo.ExpirationDate),
+			ExpirationDate: devportaltime.Time(profileInfo.ExpirationDate),
 		},
 		id:             "",
 		bundleID:       profileInfo.BundleID,

--- a/autocodesign/localcodesignasset/profileconverter.go
+++ b/autocodesign/localcodesignasset/profileconverter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bitrise-io/go-xcode/profileutil"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
+	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
 )
 
 // ProvisioningProfileConverter ...
@@ -38,7 +39,7 @@ func (c provisioningProfileConverter) ProfileInfoToProfile(info profileutil.Prov
 			UUID:           info.UUID,
 			ProfileContent: content,
 			Platform:       getBundleIDPlatform(info.Type),
-			ExpirationDate: appstoreconnect.Time(info.ExpirationDate),
+			ExpirationDate: time.Time(info.ExpirationDate),
 		},
 		id:             "", // only in case of Developer Portal Profiles
 		bundleID:       info.BundleID,

--- a/autocodesign/profiles_test.go
+++ b/autocodesign/profiles_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	devportaltime "github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
+
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
 	"github.com/stretchr/testify/require"
 )
@@ -213,25 +215,25 @@ func Test_IsProfileExpired(t *testing.T) {
 		{
 			name:                "no days set - profile expiry date after current time",
 			minProfileDaysValid: 0,
-			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: appstoreconnect.Time(time.Now().Add(5 * time.Hour))}}),
+			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: devportaltime.Time(time.Now().Add(5 * time.Hour))}}),
 			want:                false,
 		},
 		{
 			name:                "no days set - profile expiry date before current time",
 			minProfileDaysValid: 0,
-			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: appstoreconnect.Time(time.Now().Add(-5 * time.Hour))}}),
+			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: devportaltime.Time(time.Now().Add(-5 * time.Hour))}}),
 			want:                true,
 		},
 		{
 			name:                "days set - profile expiry date after current time + days set",
 			minProfileDaysValid: 2,
-			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: appstoreconnect.Time(time.Now().Add(5 * 24 * time.Hour))}}),
+			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: devportaltime.Time(time.Now().Add(5 * 24 * time.Hour))}}),
 			want:                false,
 		},
 		{
 			name:                "days set - profile expiry date before current time + days set",
 			minProfileDaysValid: 2,
-			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: appstoreconnect.Time(time.Now().Add(1 * 24 * time.Hour))}}),
+			prof:                newMockProfile(profileArgs{attributes: appstoreconnect.ProfileAttributes{ExpirationDate: devportaltime.Time(time.Now().Add(1 * 24 * time.Hour))}}),
 			want:                true,
 		},
 	}

--- a/autocodesign/utils_test.go
+++ b/autocodesign/utils_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bitrise-io/go-xcode/certificateutil"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
+	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -114,7 +115,7 @@ func profile(name, id string) Profile {
 			UUID:           id,
 			ProfileContent: []byte{},
 			Platform:       "",
-			ExpirationDate: appstoreconnect.Time{},
+			ExpirationDate: time.Time{},
 		},
 		id:           id,
 		appID:        appstoreconnect.BundleID{},


### PR DESCRIPTION
There is a few cases when Apple ID login does not work (`Please update to Xcode 7.3` https://github.com/bitrise-steplib/steps-xcode-archive/issues/287). Setting `SPACESHIP_AVOID_XCODE_API=true` can be used as a workaround, but that can only succeed with recognizing a different timestamp format in the listed profiles.

https://github.com/bitrise-steplib/steps-xcode-archive/issues/288