### PR TITLE
Xcode14 test target signing

### DIFF
--- a/autocodesign/autocodesign.go
+++ b/autocodesign/autocodesign.go
@@ -30,7 +30,7 @@ type Profile interface {
 // AppCodesignAssets is the result of ensuring codesigning assets
 type AppCodesignAssets struct {
 	ArchivableTargetProfilesByBundleID map[string]Profile
-	UITestTargetProfilesByBundleID     map[string]Profile
+	TestTargetProfilesByBundleID       map[string]Profile
 	Certificate                        certificateutil.CertificateInfoModel
 }
 
@@ -101,7 +101,7 @@ type LocalCodeSignAssetManager interface {
 type AppLayout struct {
 	Platform                               Platform
 	EntitlementsByArchivableTargetBundleID map[string]Entitlements
-	UITestTargetBundleIDs                  []string
+	TestTargetBundleIDs                    []string
 }
 
 // CertificateProvider returns codesigning certificates (with private key)
@@ -156,12 +156,12 @@ func NewCodesignAssetManager(devPortalClient DevPortalClient, assetWriter AssetW
 
 // EnsureCodesignAssets is the main entry point of the codesigning logic
 func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts CodesignAssetsOpts) (map[DistributionType]AppCodesignAssets, error) {
-	signUITestTargets := len(appLayout.UITestTargetBundleIDs) > 0
+	signTestTargets := len(appLayout.TestTargetBundleIDs) > 0
 	certsByType, distrTypes, err := selectCertificatesAndDistributionTypes(
 		m.devPortalClient,
 		opts.TypeToLocalCertificates,
 		opts.DistributionType,
-		signUITestTargets,
+		signTestTargets,
 		opts.VerboseLog,
 	)
 	if err != nil {

--- a/autocodesign/autocodesign_test.go
+++ b/autocodesign/autocodesign_test.go
@@ -155,8 +155,8 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 		ArchivableTargetProfilesByBundleID: map[string]Profile{
 			"io.test.development": devProfile,
 		},
-		UITestTargetProfilesByBundleID: map[string]Profile{},
-		Certificate:                    devCert,
+		TestTargetProfilesByBundleID: map[string]Profile{},
+		Certificate:                  devCert,
 	}
 
 	icloudContainerAppLayout := AppLayout{
@@ -216,8 +216,8 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 					ArchivableTargetProfilesByBundleID: map[string]Profile{
 						"io.test": devProfile,
 					},
-					UITestTargetProfilesByBundleID: map[string]Profile{},
-					Certificate:                    devCert,
+					TestTargetProfilesByBundleID: map[string]Profile{},
+					Certificate:                  devCert,
 				},
 			},
 			wantErr: nil,
@@ -242,8 +242,8 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 						"io.test":             devProfile,
 						"io.test.development": devProfile,
 					},
-					UITestTargetProfilesByBundleID: map[string]Profile{},
-					Certificate:                    devCert,
+					TestTargetProfilesByBundleID: map[string]Profile{},
+					Certificate:                  devCert,
 				},
 			},
 			wantErr: nil,

--- a/autocodesign/certificates.go
+++ b/autocodesign/certificates.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
 )
 
-func selectCertificatesAndDistributionTypes(certificateSource DevPortalClient, typeToLocalCerts LocalCertificates, distribution DistributionType, signUITestTargets bool, verboseLog bool) (map[appstoreconnect.CertificateType][]Certificate, []DistributionType, error) {
+func selectCertificatesAndDistributionTypes(certificateSource DevPortalClient, typeToLocalCerts LocalCertificates, distribution DistributionType, signTestTargets bool, verboseLog bool) (map[appstoreconnect.CertificateType][]Certificate, []DistributionType, error) {
 	certType, ok := CertificateTypeByDistribution[distribution]
 	if !ok {
 		panic(fmt.Sprintf("no valid certificate provided for distribution type: %s", distribution))
@@ -20,8 +20,8 @@ func selectCertificatesAndDistributionTypes(certificateSource DevPortalClient, t
 	if distribution != Development {
 		distrTypes = append(distrTypes, Development)
 
-		if signUITestTargets {
-			log.Warnf("UITest target requires development code signing in addition to the specified %s code signing", distribution)
+		if signTestTargets {
+			log.Warnf("Test target requires development code signing in addition to the specified %s code signing", distribution)
 			requiredCertTypes[appstoreconnect.IOSDevelopment] = true
 		} else {
 			requiredCertTypes[appstoreconnect.IOSDevelopment] = false

--- a/autocodesign/codesignasset/writer.go
+++ b/autocodesign/codesignasset/writer.go
@@ -53,7 +53,7 @@ func (w Writer) Write(codesignAssetsByDistributionType map[autocodesign.Distribu
 			}
 		}
 
-		for _, profile := range codesignAssets.UITestTargetProfilesByBundleID {
+		for _, profile := range codesignAssets.TestTargetProfilesByBundleID {
 			log.Printf("- %s", profile.Attributes().Name)
 
 			if err := w.InstallProfile(profile); err != nil {

--- a/autocodesign/localcodesignasset/localcodesignasset.go
+++ b/autocodesign/localcodesignasset/localcodesignasset.go
@@ -63,7 +63,7 @@ func (m Manager) FindCodesignAssets(appLayout autocodesign.AppLayout, distrType 
 
 	if distrType == autocodesign.Development {
 		bundleIDs := map[string]bool{}
-		for _, bundleID := range appLayout.UITestTargetBundleIDs {
+		for _, bundleID := range appLayout.TestTargetBundleIDs {
 			bundleIDs[bundleID] = true // profile missing?
 		}
 
@@ -73,7 +73,7 @@ func (m Manager) FindCodesignAssets(appLayout autocodesign.AppLayout, distrType 
 				return nil, nil, fmt.Errorf("could not create wildcard bundle id: %s", err)
 			}
 
-			// Capabilities are not supported for UITest targets.
+			// Capabilities are not supported for Test targets.
 			profileInfo := findProfile(profiles, appLayout.Platform, distrType, wildcardBundleID, nil, minProfileDaysValid, certSerials, deviceIDs)
 			if profileInfo == nil {
 				continue
@@ -86,31 +86,31 @@ func (m Manager) FindCodesignAssets(appLayout autocodesign.AppLayout, distrType 
 
 			if asset == nil {
 				asset = &autocodesign.AppCodesignAssets{
-					UITestTargetProfilesByBundleID: map[string]autocodesign.Profile{
+					TestTargetProfilesByBundleID: map[string]autocodesign.Profile{
 						bundleID: profile,
 					},
 				}
 			} else {
-				profileByUITestTargetBundleID := asset.UITestTargetProfilesByBundleID
-				if profileByUITestTargetBundleID == nil {
-					profileByUITestTargetBundleID = map[string]autocodesign.Profile{}
+				profileByTestTargetBundleID := asset.TestTargetProfilesByBundleID
+				if profileByTestTargetBundleID == nil {
+					profileByTestTargetBundleID = map[string]autocodesign.Profile{}
 				}
 
-				profileByUITestTargetBundleID[bundleID] = profile
-				asset.UITestTargetProfilesByBundleID = profileByUITestTargetBundleID
+				profileByTestTargetBundleID[bundleID] = profile
+				asset.TestTargetProfilesByBundleID = profileByTestTargetBundleID
 			}
 
 			bundleIDs[bundleID] = false
 		}
 
-		var uiTestTargetBundleIDs []string
+		var testTargetBundleIDs []string
 		for bundleID, missing := range bundleIDs {
 			if missing {
-				uiTestTargetBundleIDs = append(uiTestTargetBundleIDs, bundleID)
+				testTargetBundleIDs = append(testTargetBundleIDs, bundleID)
 			}
 		}
 
-		appLayout.UITestTargetBundleIDs = uiTestTargetBundleIDs
+		appLayout.TestTargetBundleIDs = testTargetBundleIDs
 	}
 
 	if asset != nil {
@@ -124,7 +124,7 @@ func (m Manager) FindCodesignAssets(appLayout autocodesign.AppLayout, distrType 
 		asset.Certificate = certificate.CertificateInfo
 	}
 
-	if len(appLayout.EntitlementsByArchivableTargetBundleID) == 0 && len(appLayout.UITestTargetBundleIDs) == 0 {
+	if len(appLayout.EntitlementsByArchivableTargetBundleID) == 0 && len(appLayout.TestTargetBundleIDs) == 0 {
 		return asset, nil, nil
 	}
 

--- a/autocodesign/localcodesignasset/localcodesignasset_test.go
+++ b/autocodesign/localcodesignasset/localcodesignasset_test.go
@@ -21,7 +21,7 @@ const (
 	teamName = "Testing team"
 )
 
-func Test_GiveniOSAppLayoutWithUITestTargets_WhenExistingProfile_ThenFindsIt(t *testing.T) {
+func Test_GiveniOSAppLayoutWithTestTargets_WhenExistingProfile_ThenFindsIt(t *testing.T) {
 	// Given
 	certsByType := certsByType(t)
 	manager, profiles := createTestObjects(t)
@@ -31,14 +31,14 @@ func Test_GiveniOSAppLayoutWithUITestTargets_WhenExistingProfile_ThenFindsIt(t *
 		EntitlementsByArchivableTargetBundleID: map[string]autocodesign.Entitlements{
 			"io.ios.valid": entitlements(),
 		},
-		UITestTargetBundleIDs: []string{"io.ios.valid", "io.ios.valid"},
+		TestTargetBundleIDs: []string{"io.ios.valid", "io.ios.valid"},
 	}
 
 	expectedAssets := autocodesign.AppCodesignAssets{
 		ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
 			"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
 		},
-		UITestTargetProfilesByBundleID: map[string]autocodesign.Profile{
+		TestTargetProfilesByBundleID: map[string]autocodesign.Profile{
 			"io.ios.valid": findProvProfile(t, profiles, "uuid-4"),
 		},
 		Certificate: findCert(t, certsByType, "1"),
@@ -69,8 +69,8 @@ func Test_GiveniOSAppLayoutWithEntitlements_WhenExistingProfile_ThenFindsIt(t *t
 		ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
 			"io.ios.valid": findProvProfile(t, profiles, "uuid-1"),
 		},
-		UITestTargetProfilesByBundleID: nil,
-		Certificate:                    findCert(t, certsByType, "1"),
+		TestTargetProfilesByBundleID: nil,
+		Certificate:                  findCert(t, certsByType, "1"),
 	}
 
 	// When
@@ -98,8 +98,8 @@ func Test_GiventvOSAppLayout_WhenExistingProfile_ThenFindsIt(t *testing.T) {
 		ArchivableTargetProfilesByBundleID: map[string]autocodesign.Profile{
 			"io.tvos.valid": findProvProfile(t, profiles, "uuid-2"),
 		},
-		UITestTargetProfilesByBundleID: nil,
-		Certificate:                    findCert(t, certsByType, "2"),
+		TestTargetProfilesByBundleID: nil,
+		Certificate:                  findCert(t, certsByType, "2"),
 	}
 
 	// When

--- a/autocodesign/profiles.go
+++ b/autocodesign/profiles.go
@@ -48,7 +48,7 @@ func ensureProfiles(profileClient DevPortalClient, distrType DistributionType,
 
 	codesignAssets := AppCodesignAssets{
 		ArchivableTargetProfilesByBundleID: map[string]Profile{},
-		UITestTargetProfilesByBundleID:     map[string]Profile{},
+		TestTargetProfilesByBundleID:       map[string]Profile{},
 		Certificate:                        certificate.CertificateInfo,
 	}
 
@@ -80,21 +80,21 @@ func ensureProfiles(profileClient DevPortalClient, distrType DistributionType,
 		codesignAssets.ArchivableTargetProfilesByBundleID[bundleIDIdentifier] = *profile
 	}
 
-	if len(app.UITestTargetBundleIDs) > 0 && distrType == Development {
-		// Capabilities are not supported for UITest targets.
-		// Xcode managed signing uses Wildcard Provisioning Profiles for UITest target signing.
-		for _, bundleIDIdentifier := range app.UITestTargetBundleIDs {
+	if len(app.TestTargetBundleIDs) > 0 && distrType == Development {
+		// Capabilities are not supported for Test targets.
+		// Xcode managed signing uses Wildcard Provisioning Profiles for Test target signing.
+		for _, bundleIDIdentifier := range app.TestTargetBundleIDs {
 			wildcardBundleID, err := CreateWildcardBundleID(bundleIDIdentifier)
 			if err != nil {
 				return nil, fmt.Errorf("could not create wildcard bundle id: %s", err)
 			}
 
-			// Capabilities are not supported for UITest targets.
+			// Capabilities are not supported for Test targets.
 			profile, err := profileManager.ensureProfileWithRetry(profileType, wildcardBundleID, nil, certIDs, devPortalDeviceIDs, minProfileDaysValid)
 			if err != nil {
 				return nil, err
 			}
-			codesignAssets.UITestTargetProfilesByBundleID[bundleIDIdentifier] = *profile
+			codesignAssets.TestTargetProfilesByBundleID[bundleIDIdentifier] = *profile
 		}
 	}
 

--- a/autocodesign/profiles_test.go
+++ b/autocodesign/profiles_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 	"time"
 
-	devportaltime "github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
-
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
+	devportaltime "github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
 	"github.com/stretchr/testify/require"
 )
 

--- a/autocodesign/projectmanager/projectmanager.go
+++ b/autocodesign/projectmanager/projectmanager.go
@@ -27,6 +27,7 @@ type InitParams struct {
 	ProjectOrWorkspacePath string
 	SchemeName             string
 	ConfigurationName      string
+	XcodeMajorVersion      int
 }
 
 // NewFactory ...
@@ -41,7 +42,7 @@ func (f *Factory) Create() (Project, error) {
 
 // NewProject ...
 func NewProject(params InitParams) (Project, error) {
-	projectHelper, err := NewProjectHelper(params.ProjectOrWorkspacePath, params.SchemeName, params.ConfigurationName)
+	projectHelper, err := NewProjectHelper(params.ProjectOrWorkspacePath, params.SchemeName, params.ConfigurationName, params.XcodeMajorVersion)
 	if err != nil {
 		return Project{}, err
 	}
@@ -108,11 +109,11 @@ func (p Project) GetAppLayout(uiTestTargets bool) (autocodesign.AppLayout, error
 	var uiTestTargetBundleIDs []string
 	if uiTestTargets {
 		log.Printf("UITest targets:")
-		for _, target := range p.projHelper.UITestTargets {
+		for _, target := range p.projHelper.TestTargets {
 			log.Printf("- %s", target.Name)
 		}
 
-		uiTestTargetBundleIDs, err = p.projHelper.UITestTargetBundleIDs()
+		uiTestTargetBundleIDs, err = p.projHelper.TestTargetBundleIDs()
 		if err != nil {
 			return autocodesign.AppLayout{}, fmt.Errorf("failed to read UITest targets' entitlements: %s", err)
 		}
@@ -173,9 +174,9 @@ func (p Project) ForceCodesignAssets(distribution autocodesign.DistributionType,
 	devCodesignAssets, isDevelopmentAvailable := codesignAssetsByDistributionType[autocodesign.Development]
 	if isDevelopmentAvailable && len(devCodesignAssets.UITestTargetProfilesByBundleID) != 0 {
 		fmt.Println()
-		log.TInfof("Apply Bitrise managed codesigning on the UITest targets (%d)", len(p.projHelper.UITestTargets))
+		log.TInfof("Apply Bitrise managed codesigning on the UITest targets (%d)", len(p.projHelper.TestTargets))
 
-		for _, uiTestTarget := range p.projHelper.UITestTargets {
+		for _, uiTestTarget := range p.projHelper.TestTargets {
 			fmt.Println()
 			log.Infof("  Target: %s", uiTestTarget.Name)
 

--- a/autocodesign/projectmanager/projectmanager.go
+++ b/autocodesign/projectmanager/projectmanager.go
@@ -169,7 +169,7 @@ func (p Project) ForceCodesignAssets(distribution autocodesign.DistributionType,
 		archivableTargetsCounter++
 	}
 
-	log.TInfof("Applied Bitrise managed codesigning on up to %s targets", archivableTargetsCounter)
+	log.TInfof("Applied Bitrise managed codesigning on up to %d targets", archivableTargetsCounter)
 
 	devCodesignAssets, isDevelopmentAvailable := codesignAssetsByDistributionType[autocodesign.Development]
 	if isDevelopmentAvailable && len(devCodesignAssets.TestTargetProfilesByBundleID) != 0 {

--- a/autocodesign/utils.go
+++ b/autocodesign/utils.go
@@ -24,11 +24,11 @@ func mergeCodeSignAssets(base, additional *AppCodesignAssets) *AppCodesignAssets
 		}
 	}
 
-	if additional.UITestTargetProfilesByBundleID == nil {
-		additional.UITestTargetProfilesByBundleID = base.UITestTargetProfilesByBundleID
+	if additional.TestTargetProfilesByBundleID == nil {
+		additional.TestTargetProfilesByBundleID = base.TestTargetProfilesByBundleID
 	} else {
-		for bundleID, profile := range base.UITestTargetProfilesByBundleID {
-			additional.UITestTargetProfilesByBundleID[bundleID] = profile
+		for bundleID, profile := range base.TestTargetProfilesByBundleID {
+			additional.TestTargetProfilesByBundleID[bundleID] = profile
 		}
 	}
 
@@ -44,8 +44,8 @@ func printMissingCodeSignAssets(missingCodesignAssets *AppLayout) {
 	for bundleID := range missingCodesignAssets.EntitlementsByArchivableTargetBundleID {
 		log.Printf("- %s", bundleID)
 	}
-	log.Printf("UITest targets (%d)", len(missingCodesignAssets.UITestTargetBundleIDs))
-	for _, bundleID := range missingCodesignAssets.UITestTargetBundleIDs {
+	log.Printf("Test targets (%d)", len(missingCodesignAssets.TestTargetBundleIDs))
+	for _, bundleID := range missingCodesignAssets.TestTargetBundleIDs {
 		log.Printf("- %s", bundleID)
 	}
 }
@@ -63,8 +63,8 @@ func printExistingCodesignAssets(assets *AppCodesignAssets, distrType Distributi
 		log.Printf("- %s: %s (ID: %s UUID: %s Expiry: %s)", bundleID, profile.Attributes().Name, profile.ID(), profile.Attributes().UUID, time.Time(profile.Attributes().ExpirationDate))
 	}
 
-	log.Printf("UITest targets (%d)", len(assets.UITestTargetProfilesByBundleID))
-	for bundleID, profile := range assets.UITestTargetProfilesByBundleID {
+	log.Printf("Test targets (%d)", len(assets.TestTargetProfilesByBundleID))
+	for bundleID, profile := range assets.TestTargetProfilesByBundleID {
 		log.Printf("- %s: %s (ID: %s UUID: %s Expiry: %s)", bundleID, profile.Attributes().Name, profile.ID(), profile.Attributes().UUID, time.Time(profile.Attributes().ExpirationDate))
 	}
 }

--- a/autocodesign/utils_test.go
+++ b/autocodesign/utils_test.go
@@ -30,7 +30,7 @@ func Test_GivenCodeSignAssets_WhenMergingTwo_ThenValuesAreCorrect(t *testing.T) 
 				ArchivableTargetProfilesByBundleID: map[string]Profile{
 					"dev-1": dev1Profile,
 				},
-				UITestTargetProfilesByBundleID: map[string]Profile{
+				TestTargetProfilesByBundleID: map[string]Profile{
 					"dev-uitest-1": devUITest1Profile,
 				},
 				Certificate: certificate,
@@ -39,7 +39,7 @@ func Test_GivenCodeSignAssets_WhenMergingTwo_ThenValuesAreCorrect(t *testing.T) 
 				ArchivableTargetProfilesByBundleID: map[string]Profile{
 					"dev-2": dev2Profile,
 				},
-				UITestTargetProfilesByBundleID: map[string]Profile{
+				TestTargetProfilesByBundleID: map[string]Profile{
 					"dev-uitest-2": devUITest2Profile,
 				},
 				Certificate: certificate,
@@ -49,7 +49,7 @@ func Test_GivenCodeSignAssets_WhenMergingTwo_ThenValuesAreCorrect(t *testing.T) 
 					"dev-1": dev1Profile,
 					"dev-2": dev2Profile,
 				},
-				UITestTargetProfilesByBundleID: map[string]Profile{
+				TestTargetProfilesByBundleID: map[string]Profile{
 					"dev-uitest-1": devUITest1Profile,
 					"dev-uitest-2": devUITest2Profile,
 				},
@@ -63,15 +63,15 @@ func Test_GivenCodeSignAssets_WhenMergingTwo_ThenValuesAreCorrect(t *testing.T) 
 				ArchivableTargetProfilesByBundleID: map[string]Profile{
 					"enterprise-1": enterprise1Profile,
 				},
-				UITestTargetProfilesByBundleID: nil,
-				Certificate:                    certificate,
+				TestTargetProfilesByBundleID: nil,
+				Certificate:                  certificate,
 			},
 			expected: &AppCodesignAssets{
 				ArchivableTargetProfilesByBundleID: map[string]Profile{
 					"enterprise-1": enterprise1Profile,
 				},
-				UITestTargetProfilesByBundleID: nil,
-				Certificate:                    certificate,
+				TestTargetProfilesByBundleID: nil,
+				Certificate:                  certificate,
 			},
 		},
 		{
@@ -80,16 +80,16 @@ func Test_GivenCodeSignAssets_WhenMergingTwo_ThenValuesAreCorrect(t *testing.T) 
 				ArchivableTargetProfilesByBundleID: map[string]Profile{
 					"ad-hoc-1": adHoc1Profile,
 				},
-				UITestTargetProfilesByBundleID: nil,
-				Certificate:                    certificate,
+				TestTargetProfilesByBundleID: nil,
+				Certificate:                  certificate,
 			},
 			addition: nil,
 			expected: &AppCodesignAssets{
 				ArchivableTargetProfilesByBundleID: map[string]Profile{
 					"ad-hoc-1": adHoc1Profile,
 				},
-				UITestTargetProfilesByBundleID: nil,
-				Certificate:                    certificate,
+				TestTargetProfilesByBundleID: nil,
+				Certificate:                  certificate,
 			},
 		},
 		{

--- a/codesign/archive.go
+++ b/codesign/archive.go
@@ -28,7 +28,7 @@ func (a Archive) Platform() (autocodesign.Platform, error) {
 }
 
 // GetAppLayout ...
-func (a Archive) GetAppLayout(uiTestTargets bool) (autocodesign.AppLayout, error) {
+func (a Archive) GetAppLayout(_ bool) (autocodesign.AppLayout, error) {
 	params, err := a.archive.ReadCodesignParameters()
 	if err != nil {
 		return autocodesign.AppLayout{}, err

--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -42,7 +42,7 @@ type Opts struct {
 	XcodeMajorVersion int
 
 	RegisterTestDevices    bool
-	SignUITests            bool
+	SignTestTargets        bool
 	MinDaysProfileValidity int
 	IsVerboseLog           bool
 }
@@ -124,7 +124,7 @@ func NewManagerWithProject(
 type DetailsProvider interface {
 	IsSigningManagedAutomatically() (bool, error)
 	Platform() (autocodesign.Platform, error)
-	GetAppLayout(uiTestTargets bool) (autocodesign.AppLayout, error)
+	GetAppLayout(considerTestTargets bool) (autocodesign.AppLayout, error)
 }
 
 // AssetWriter ...
@@ -343,7 +343,7 @@ func (m *Manager) prepareCodeSigningWithBitrise(credentials appleauth.Credential
 	// Analyze project
 	fmt.Println()
 	m.logger.TDebugf("Analyzing project")
-	appLayout, err := m.detailsProvider.GetAppLayout(m.opts.SignUITests)
+	appLayout, err := m.detailsProvider.GetAppLayout(m.opts.SignTestTargets)
 	if err != nil {
 		return err
 	}

--- a/xcarchive/ios.go
+++ b/xcarchive/ios.go
@@ -53,6 +53,6 @@ func (archive IosArchive) ReadCodesignParameters() (*autocodesign.AppLayout, err
 	return &autocodesign.AppLayout{
 		Platform:                               platform,
 		EntitlementsByArchivableTargetBundleID: entitlementsMap,
-		UITestTargetBundleIDs:                  nil,
+		TestTargetBundleIDs:                    nil,
 	}, nil
 }


### PR DESCRIPTION
### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

The[ xcode-build-for-test Step CI is failing on the Xcode 14](https://app.bitrise.io/build/ded7ff6c-9501-4d33-b8e9-8a4ff47f5a75) stack with the following error:

```

Running xcodebuild
 $ set -o pipefail && xcodebuild "build-for-testing" "-project" "/Users/[REDACTED]/go/src/github.com/bitrise-steplib/steps-xcode-build-for-test/_tmp/ios-simple-objc/ios-simple-objc.xcodeproj" "-scheme" "ios-simple-objc" "-configuration" "Debug" "-destination" "generic/platform=iOS" "-xcconfig" "/var/folders/4x/p4lcqjn532v7c7n456nsp00h0000gn/T/2667471495/temp.xcconfig" | xcpretty
❌  error: Signing for "ios-simple-objcTests" requires a development team. Select a development team in the Signing & Capabilities editor. (in target 'ios-simple-objcTests' from project 'ios-simple-objc')
```

The source of the issues is that Project helper only considers UITest targets for automatic codesigning, but based on the above issue, it seems unit test targets need to be signed as well from Xcode 14.

This PR makes the project helper consider UnitTest targets if Xcode major version is >= 14.

### Changes

- Pass Xcode major version to ProjectHelper and consider different test targets based on it
- Rename uitest* to test*

**Non-functional changes:**
- Added `TestMain` function to project helper tests, so that sample projects are downloaded just once.

### Investigation details

### Decisions
