### PR TITLE
Destination specifier

### DIFF
--- a/destination/destination.go
+++ b/destination/destination.go
@@ -15,13 +15,13 @@ const (
 type Platform string
 
 const (
-	macOS            Platform = "macOS"
-	iOS              Platform = "iOS"
-	iOSSimulator     Platform = "iOS Simulator"
-	watchOS          Platform = "watchOS"
-	watchOSSimulator Platform = "watchOS Simulator"
-	tvOS             Platform = "tvOS"
-	tvOSSimulator    Platform = "tvOS Simulator"
+	MacOS            Platform = "macOS"
+	IOS              Platform = "iOS"
+	IOSSimulator     Platform = "iOS Simulator"
+	WatchOS          Platform = "watchOS"
+	WatchOSSimulator Platform = "watchOS Simulator"
+	TvOS             Platform = "tvOS"
+	TvOSSimulator    Platform = "tvOS Simulator"
 	DriverKit        Platform = "DriverKit"
 )
 

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -6,57 +6,60 @@ import (
 )
 
 const (
-	platform = "platform"
-	name     = "name"
-	os       = "OS"
+	genericPlatformKey = "generic/platform"
+	platformKey        = "platform"
+	nameKey            = "name"
+	osKey              = "OS"
 )
 
-// Simulator ...
-type Simulator struct {
-	Platform string
-	Name     string
-	OS       string
-}
+type Platform string
 
-// NewSimulator ...
-func NewSimulator(destination string) (*Simulator, error) {
-	simulator := Simulator{}
-	destinationParts := strings.Split(destination, ",")
+const (
+	macOS            Platform = "macOS"
+	iOS              Platform = "iOS"
+	iOSSimulator     Platform = "iOS Simulator"
+	watchOS          Platform = "watchOS"
+	watchOSSimulator Platform = "watchOS Simulator"
+	tvOS             Platform = "tvOS"
+	tvOSSimulator    Platform = "tvOS Simulator"
+	DriverKit        Platform = "DriverKit"
+)
 
-	for _, part := range destinationParts {
+type Specifier map[string]string
+
+func NewSpecifier(destination string) (Specifier, error) {
+	specifier := Specifier{}
+
+	parts := strings.Split(destination, ",")
+	for _, part := range parts {
 		keyAndValue := strings.Split(part, "=")
 
 		if len(keyAndValue) != 2 {
-			return nil, fmt.Errorf(`could not parse "%s" because it is not a valid key=value pair in destination: %s`, keyAndValue, destination)
+			return nil, fmt.Errorf(`could not parse "%s" because it is not a valid key=value pair in destination: %s`, part, destination)
 		}
 
 		key := keyAndValue[0]
 		value := keyAndValue[1]
 
-		switch key {
-		case platform:
-			simulator.Platform = value
-		case name:
-			simulator.Name = value
-		case os:
-			simulator.OS = value
-		default:
-			return nil, fmt.Errorf(`could not parse key "%s" with value "%s" in destination: %s`, key, value, destination)
-		}
+		specifier[key] = value
 	}
 
-	if simulator.Platform == "" {
-		return nil, fmt.Errorf(`missing key "platform" in destination: %s`, destination)
+	return specifier, nil
+}
+
+func (s Specifier) Platform() (Platform, bool) {
+	p, ok := s[genericPlatformKey]
+	if ok {
+		return Platform(p), true
 	}
 
-	if simulator.Name == "" {
-		return nil, fmt.Errorf(`missing key "name" in destination: %s`, destination)
-	}
+	return Platform(s[platformKey]), false
+}
 
-	if simulator.OS == "" {
-		// OS=latest can be omitted in the destination specifier, because it's the default value.
-		simulator.OS = "latest"
-	}
+func (s Specifier) Name() string {
+	return s[nameKey]
+}
 
-	return &simulator, nil
+func (s Specifier) OS() string {
+	return s[osKey]
 }

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -12,8 +12,10 @@ const (
 	osKey              = "OS"
 )
 
+// Platform ...
 type Platform string
 
+// Platforms ...
 const (
 	MacOS            Platform = "macOS"
 	IOS              Platform = "iOS"
@@ -25,8 +27,10 @@ const (
 	DriverKit        Platform = "DriverKit"
 )
 
+// Specifier ...
 type Specifier map[string]string
 
+// NewSpecifier ...
 func NewSpecifier(destination string) (Specifier, error) {
 	specifier := Specifier{}
 
@@ -47,6 +51,7 @@ func NewSpecifier(destination string) (Specifier, error) {
 	return specifier, nil
 }
 
+// Platform ...
 func (s Specifier) Platform() (Platform, bool) {
 	p, ok := s[genericPlatformKey]
 	if ok {
@@ -56,10 +61,12 @@ func (s Specifier) Platform() (Platform, bool) {
 	return Platform(s[platformKey]), false
 }
 
+// Name ...
 func (s Specifier) Name() string {
 	return s[nameKey]
 }
 
+// OS ...
 func (s Specifier) OS() string {
 	return s[osKey]
 }

--- a/destination/simulator.go
+++ b/destination/simulator.go
@@ -1,0 +1,44 @@
+package destination
+
+import "fmt"
+
+// Simulator ...
+type Simulator struct {
+	Platform string
+	Name     string
+	OS       string
+}
+
+// NewSimulator ...
+func NewSimulator(destination string) (*Simulator, error) {
+	specifier, err := NewSpecifier(destination)
+	if err != nil {
+		return nil, err
+	}
+
+	platform, isGeneric := specifier.Platform()
+	if isGeneric {
+		return nil, fmt.Errorf("can't create a simulator from generic destination: %s", destination)
+	}
+
+	simulator := Simulator{
+		Platform: string(platform),
+		Name:     specifier.Name(),
+		OS:       specifier.OS(),
+	}
+
+	if simulator.Platform == "" {
+		return nil, fmt.Errorf(`missing key "platform" in destination: %s`, destination)
+	}
+
+	if simulator.Name == "" {
+		return nil, fmt.Errorf(`missing key "name" in destination: %s`, destination)
+	}
+
+	if simulator.OS == "" {
+		// OS=latest can be omitted in the destination specifier, because it's the default value.
+		simulator.OS = "latest"
+	}
+
+	return &simulator, nil
+}

--- a/destination/simulator_test.go
+++ b/destination/simulator_test.go
@@ -1,8 +1,9 @@
 package destination
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_GivenDestinationIsCorrect_WhenSimulatorIsCreated_ThenItReturnsCorrectSimulator(t *testing.T) {


### PR DESCRIPTION
### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

`xcodebuild build-for-testing` places the built targets and tests into the built test dir. The name of this dir depends on the build destination:
- For iOS Device (and Debug configuration) it looks like: `Debug-iphoneos`
- For iOS Simulator (and Debug configuration) it looks like: `Debug-iphonesimulator`

This PR introduces `destination.Specifier` struct to support the [improvement of how xcode-build-for-test step determines the built test dir name](https://github.com/bitrise-steplib/steps-xcode-build-for-test/pull/39#discussion_r896922993).

### Changes

- introduce `destination.Specifier`

### Investigation details

### Decisions

The available platforms (Xcode 14) are listed in the destination package, but not used by this package directly. 
The purpose is to support the consumer side in [branching the logic, based on the actual platform](https://github.com/bitrise-steplib/steps-xcode-build-for-test/pull/39/commits/e8d088fe9fdfbc57ee7ba3eff10776c179015c8a#diff-f9b80317077cdd80a92e3996a30b0f49975f2bdb00b194cf4bab3538a0850654R192-R200).
