### PR TITLE
Add API connection override input parsing

### DIFF
--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -1,7 +1,6 @@
 package codesign
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -198,7 +197,7 @@ func SelectConnectionCredentials(
 	if authType == APIKeyAuth && inputs.APIKeyPath != "" && inputs.APIKeyIssuerID != "" && inputs.APIKeyID != "" {
 		logger.Infof("Overriding App Store Connect API connection with step-provided credentials (api_key_path, api_key_id, api_key_issuer_id)")
 
-		config, err := parseConnectionOverrideConfig(inputs.APIKeyPath, inputs.APIKeyID, inputs.APIKeyIssuerID)
+		config, err := parseConnectionOverrideConfig(inputs.APIKeyPath, inputs.APIKeyID, inputs.APIKeyIssuerID, logger)
 		if err != nil {
 			return appleauth.Credentials{}, err
 		}

--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -93,7 +93,6 @@ func NewManagerWithArchive(
 func NewManagerWithProject(
 	opts Opts,
 	appleAuth appleauth.Credentials,
-	connection *devportalservice.AppleDeveloperConnection,
 	clientFactory devportalclient.Factory,
 	certDownloader autocodesign.CertificateProvider,
 	fallbackProfileDownloader autocodesign.ProfileProvider,

--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -195,7 +195,7 @@ func SelectConnectionCredentials(
 	bitriseConnection *devportalservice.AppleDeveloperConnection,
 	inputs ConnectionOverrideInputs, logger log.Logger) (appleauth.Credentials, error) {
 	if authType == APIKeyAuth && inputs.APIKeyPath != "" && inputs.APIKeyIssuerID != "" && inputs.APIKeyID != "" {
-		logger.Infof("Overriding App Store Connect API connection with step-provided credentials (api_key_path, api_key_id, api_key_issuer_id)")
+		logger.Infof("Overriding Bitrise Apple Service connection with Step-provided credentials (api_key_path, api_key_id, api_key_issuer_id)")
 
 		config, err := parseConnectionOverrideConfig(inputs.APIKeyPath, inputs.APIKeyID, inputs.APIKeyIssuerID, logger)
 		if err != nil {

--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -244,7 +244,7 @@ func SelectConnectionCredentials(
 		}, nil
 	}
 
-	return appleauth.Credentials{}, errors.New(devportalclient.NotConnectedWarning)
+	panic("Unexpected AuthType")
 }
 
 func (m *Manager) selectCodeSigningStrategy(credentials appleauth.Credentials) (codeSigningStrategy, string, error) {

--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -209,7 +209,8 @@ func SelectConnectionCredentials(
 	}
 
 	if authType == APIKeyAuth {
-		if bitriseConnection.APIKeyConnection == nil {
+		if bitriseConnection == nil || bitriseConnection.APIKeyConnection == nil {
+			logger.Errorf(devportalclient.NotConnectedWarning)
 			return appleauth.Credentials{}, fmt.Errorf("API key authentication is selected in Step inputs, but Bitrise Apple Service connection is unset")
 		}
 
@@ -221,7 +222,8 @@ func SelectConnectionCredentials(
 	}
 
 	if authType == AppleIDAuth {
-		if bitriseConnection.AppleIDConnection == nil {
+		if bitriseConnection == nil || bitriseConnection.AppleIDConnection == nil {
+			logger.Errorf(devportalclient.NotConnectedWarning)
 			return appleauth.Credentials{}, fmt.Errorf("Apple ID authentication is selected in Step inputs, but Bitrise Apple Service connection is unset")
 		}
 

--- a/codesign/codesign_test.go
+++ b/codesign/codesign_test.go
@@ -190,7 +190,7 @@ func generateCert(t *testing.T, commonName string) certificateutil.CertificateIn
 }
 
 func TestSelectConnectionCredentials(t *testing.T) {
-	testApiKeyConnection := devportalservice.APIKeyConnection{
+	testAPIKeyConnection := devportalservice.APIKeyConnection{
 		KeyID:      "TestKeyID",
 		IssuerID:   "TestIssuerID",
 		PrivateKey: "test private key contents",
@@ -235,14 +235,14 @@ func TestSelectConnectionCredentials(t *testing.T) {
 			authType: APIKeyAuth,
 			bitriseConnection: &devportalservice.AppleDeveloperConnection{
 				AppleIDConnection:     nil,
-				APIKeyConnection:      &testApiKeyConnection,
+				APIKeyConnection:      &testAPIKeyConnection,
 				TestDevices:           []devportalservice.TestDevice{},
 				DuplicatedTestDevices: []devportalservice.TestDevice{},
 			},
 			inputs: testNoInputs,
 			want: appleauth.Credentials{
 				AppleID: nil,
-				APIKey:  &testApiKeyConnection,
+				APIKey:  &testAPIKeyConnection,
 			},
 		},
 		{
@@ -281,7 +281,7 @@ func TestSelectConnectionCredentials(t *testing.T) {
 			authType: APIKeyAuth,
 			bitriseConnection: &devportalservice.AppleDeveloperConnection{
 				AppleIDConnection:     nil,
-				APIKeyConnection:      &testApiKeyConnection,
+				APIKeyConnection:      &testAPIKeyConnection,
 				TestDevices:           []devportalservice.TestDevice{},
 				DuplicatedTestDevices: []devportalservice.TestDevice{},
 			},
@@ -339,7 +339,7 @@ func TestSelectConnectionCredentials(t *testing.T) {
 			authType: AppleIDAuth,
 			bitriseConnection: &devportalservice.AppleDeveloperConnection{
 				AppleIDConnection:     &testAppleIDConnection,
-				APIKeyConnection:      &testApiKeyConnection,
+				APIKeyConnection:      &testAPIKeyConnection,
 				TestDevices:           nil,
 				DuplicatedTestDevices: nil,
 			},

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -10,16 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/log"
-
-	"github.com/bitrise-io/go-xcode/devportalservice"
-
-	"github.com/bitrise-io/go-utils/retry"
-
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/sliceutil"
 	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/retryhttp"
+	"github.com/bitrise-io/go-xcode/devportalservice"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/codesignasset"
@@ -79,10 +76,10 @@ func ParseConfig(input Input, cmdFactory command.Factory) (Config, error) {
 }
 
 // parseConnectionOverrideConfig validates and parses the step input-level connection parameters
-func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssuerID string) (*devportalservice.APIKeyConnection, error) {
+func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssuerID string, logger log.Logger) (*devportalservice.APIKeyConnection, error) {
 	var key []byte
 	if strings.HasPrefix(string(keyPathOrURL), "https://") {
-		resp, err := retry.NewHTTPClient().Get(string(keyPathOrURL))
+		resp, err := retryhttp.NewClient(logger).Get(string(keyPathOrURL))
 		if err != nil {
 			return nil, fmt.Errorf("API key download error: %s", err)
 		}
@@ -90,7 +87,7 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 		defer func(Body io.ReadCloser) {
 			err := Body.Close()
 			if err != nil {
-				log.Errorf(err.Error())
+				logger.Errorf(err.Error())
 			}
 		}(resp.Body)
 		if resp.StatusCode != http.StatusOK {

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bitrise-io/go-utils/log"
+
 	"github.com/bitrise-io/go-xcode/devportalservice"
 
 	"github.com/bitrise-io/go-utils/retry"
@@ -77,7 +79,12 @@ func ParseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 			return nil, fmt.Errorf("API key download error: %s", err)
 		}
 
-		defer resp.Body.Close()
+		defer func(Body io.ReadCloser) {
+			err := Body.Close()
+			if err != nil {
+				log.Errorf(err.Error())
+			}
+		}(resp.Body)
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("API key HTTP response %d: %s", resp.StatusCode, resp.Body)
 		}

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -99,10 +99,14 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 			return nil, err
 		}
 	} else {
+		trimmedPath := string(keyPathOrURL)
+		if strings.HasPrefix(string(keyPathOrURL), "file://") {
+			trimmedPath = strings.TrimPrefix(string(keyPathOrURL), "file://")
+		}
 		var err error
-		key, err = os.ReadFile(string(keyPathOrURL))
+		key, err = os.ReadFile(trimmedPath)
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("private key does not exist at %s", keyPathOrURL)
+			return nil, fmt.Errorf("private key does not exist at %s", trimmedPath)
 		} else if err != nil {
 			return nil, err
 		}

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -37,6 +37,14 @@ type Input struct {
 	FallbackProvisioningProfiles string
 }
 
+// ConnectionOverrideInputs are used in steps to control the API key based auth credentials
+// This overrides the global API connection defined on Bitrise.io
+type ConnectionOverrideInputs struct {
+	APIKeyPath     stepconf.Secret
+	APIKeyID       string
+	APIKeyIssuerID string
+}
+
 // Config ...
 type Config struct {
 	CertificatesAndPassphrases   []certdownloader.CertificateAndPassphrase
@@ -70,8 +78,8 @@ func ParseConfig(input Input, cmdFactory command.Factory) (Config, error) {
 	}, nil
 }
 
-// ParseConnectionOverrideConfig validates and parses the step input-level connection parameters
-func ParseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssuerID string) (*devportalservice.APIKeyConnection, error) {
+// parseConnectionOverrideConfig validates and parses the step input-level connection parameters
+func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssuerID string) (*devportalservice.APIKeyConnection, error) {
 	var key []byte
 	if strings.HasPrefix(string(keyPathOrURL), "https://") {
 		resp, err := retry.NewHTTPClient().Get(string(keyPathOrURL))

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -68,6 +68,7 @@ func ParseConfig(input Input, cmdFactory command.Factory) (Config, error) {
 	}, nil
 }
 
+// ParseConnectionOverrideConfig validates and parses the step input-level connection parameters
 func ParseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssuerID string) (*devportalservice.APIKeyConnection, error) {
 	var key []byte
 	if strings.HasPrefix(string(keyPathOrURL), "https://") {

--- a/codesign/inputparse_test.go
+++ b/codesign/inputparse_test.go
@@ -211,7 +211,7 @@ func Test_ParseConnectionOverrideConfig(t *testing.T) {
 	keyIssuerID := "   ABC456 "
 
 	// When
-	connection, err := ParseConnectionOverrideConfig(stepconf.Secret(path), keyID, keyIssuerID)
+	connection, err := parseConnectionOverrideConfig(stepconf.Secret(path), keyID, keyIssuerID)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/codesign/inputparse_test.go
+++ b/codesign/inputparse_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-xcode/devportalservice"
-
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader"
 	"github.com/stretchr/testify/require"
 )
@@ -211,7 +211,7 @@ func Test_ParseConnectionOverrideConfig(t *testing.T) {
 	keyIssuerID := "   ABC456 "
 
 	// When
-	connection, err := parseConnectionOverrideConfig(stepconf.Secret(path), keyID, keyIssuerID)
+	connection, err := parseConnectionOverrideConfig(stepconf.Secret(path), keyID, keyIssuerID, log.NewLogger())
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/codesign/inputparse_test.go
+++ b/codesign/inputparse_test.go
@@ -2,10 +2,14 @@ package codesign
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/bitrise-io/go-steputils/v2/stepconf"
+	"github.com/bitrise-io/go-xcode/devportalservice"
 
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader"
 	"github.com/stretchr/testify/require"
@@ -192,4 +196,31 @@ func Test_validateAndExpandProfilePaths(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_ParseConnectionOverrideConfig(t *testing.T) {
+	// Given
+	path := filepath.Join(t.TempDir(), "private_key.p8")
+	fileContent := "this is a private key"
+	err := ioutil.WriteFile(path, []byte(fileContent), 0666)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	keyID := " ABC123   "
+	keyIssuerID := "   ABC456 "
+
+	// When
+	connection, err := ParseConnectionOverrideConfig(stepconf.Secret(path), keyID, keyIssuerID)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Then
+	expected := devportalservice.APIKeyConnection{
+		KeyID:      "ABC123",
+		IssuerID:   "ABC456",
+		PrivateKey: fileContent,
+	}
+	require.Equal(t, expected, *connection)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.2
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.2
 	github.com/bitrise-io/go-utils v1.0.2
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.7
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11
 	github.com/bitrise-io/go-xcode v1.0.9
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0
 github.com/bitrise-io/go-utils v1.0.2 h1:w4Mz2IvrgDzrFJECuHdvsK1LHO30cdtuy9bBa7Lw2c0=
 github.com/bitrise-io/go-utils v1.0.2/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.7 h1:d0XDESvQwOO+V9afZrI8QGR7bJGDkmE4Q9ezIBB4TLw=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.7/go.mod h1:6i0Gt0JRIbXpsrFDJT1YWghFfdN8qF26/fnpc/6d/88=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11 h1:IacLMHL7hhgVcqtx15Bysq738P8FRCp6ckGk1NvioWo=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11/go.mod h1:SJqGxzwjIAx2LVQxNGS4taN7X//eDPJLrFxJ1MpOuyA=
 github.com/bitrise-io/go-xcode v1.0.9 h1:+sbqOYidQ+aiFfCTDpf2LdGSQEM5RfbtDsiG27zJG+s=
 github.com/bitrise-io/go-xcode v1.0.9/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=
@@ -67,6 +67,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
### Context

Code signing steps should be able to override the App Store Connect connection details by step inputs.

This PR adds common code to all steps that will handle connection override inputs.

### Changes

- Add a method that validates and parses connection parameters
- Path to private key can be either a local file path or a remote URL, the code handles both and returns with the raw contents