### PR TITLE
Plang 2392 error messages

### DIFF
--- a/codesign/codesign.go
+++ b/codesign/codesign.go
@@ -210,7 +210,7 @@ func SelectConnectionCredentials(
 	if authType == APIKeyAuth {
 		if bitriseConnection == nil || bitriseConnection.APIKeyConnection == nil {
 			logger.Errorf(devportalclient.NotConnectedWarning)
-			return appleauth.Credentials{}, fmt.Errorf("API key authentication is selected in Step inputs, but Bitrise Apple Service connection is unset")
+			return appleauth.Credentials{}, fmt.Errorf("Apple Service connection via App Store Connect API key is not estabilished")
 		}
 
 		logger.Donef("Using Apple Service connection with API key.")
@@ -223,12 +223,12 @@ func SelectConnectionCredentials(
 	if authType == AppleIDAuth {
 		if bitriseConnection == nil || bitriseConnection.AppleIDConnection == nil {
 			logger.Errorf(devportalclient.NotConnectedWarning)
-			return appleauth.Credentials{}, fmt.Errorf("Apple ID authentication is selected in Step inputs, but Bitrise Apple Service connection is unset")
+			return appleauth.Credentials{}, fmt.Errorf("Apple Service connection through Apple ID is not estabilished")
 		}
 
 		session, err := bitriseConnection.AppleIDConnection.FastlaneLoginSession()
 		if err != nil {
-			return appleauth.Credentials{}, err
+			return appleauth.Credentials{}, fmt.Errorf("failed to restore Apple ID login session: %w", err)
 		}
 
 		logger.Donef("Using Apple Service connection with Apple ID.")

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -52,19 +52,26 @@ type Config struct {
 
 // ParseConfig validates and parses step inputs related to code signing and returns with a Config
 func ParseConfig(input Input, cmdFactory command.Factory) (Config, error) {
-	certificatesAndPassphrases, err := parseCertificates(input)
+	certificatesAndPassphrases, err := parseCertificatesAndPassphrases(input.CertificateURLList, string(input.CertificatePassphraseList))
 	if err != nil {
-		return Config{}, fmt.Errorf("failed to parse certificate URL and passphrase inputs: %s", err)
+		return Config{}, err
+	}
+
+	if strings.TrimSpace(input.KeychainPath) == "" {
+		return Config{}, fmt.Errorf("keychain path is not specified")
+	}
+	if strings.TrimSpace(string(input.KeychainPassword)) == "" {
+		return Config{}, fmt.Errorf("keychain password is not specified")
 	}
 
 	keychainWriter, err := keychain.New(input.KeychainPath, input.KeychainPassword, cmdFactory)
 	if err != nil {
-		return Config{}, fmt.Errorf("failed to open keychain: %s", err)
+		return Config{}, fmt.Errorf("failed to open keychain: %w", err)
 	}
 
-	fallbackProfiles, err := validateAndExpandProfilePaths(input.FallbackProvisioningProfiles)
+	fallbackProfiles, err := parseFallbackProvisioningProfiles(input.FallbackProvisioningProfiles)
 	if err != nil {
-		return Config{}, fmt.Errorf("failed to parse provisioning profiles: %w", err)
+		return Config{}, err
 	}
 
 	return Config{
@@ -119,19 +126,13 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 	}, nil
 }
 
-// parseCertificates returns an array of p12 file URLs and passphrases
-func parseCertificates(input Input) ([]certdownloader.CertificateAndPassphrase, error) {
-	if strings.TrimSpace(input.CertificateURLList) == "" {
+// parseCertificatesAndPassphrases returns an array of p12 file URLs and passphrases
+func parseCertificatesAndPassphrases(certificateURLList, certificatePassphraseList string) ([]certdownloader.CertificateAndPassphrase, error) {
+	if strings.TrimSpace(certificateURLList) == "" {
 		return nil, fmt.Errorf("code signing certificate URL is not specified")
 	}
-	if strings.TrimSpace(input.KeychainPath) == "" {
-		return nil, fmt.Errorf("keychain path is not specified")
-	}
-	if strings.TrimSpace(string(input.KeychainPassword)) == "" {
-		return nil, fmt.Errorf("keychain password is not specified")
-	}
 
-	pfxURLs, passphrases, err := validateCertificates(input.CertificateURLList, string(input.CertificatePassphraseList))
+	pfxURLs, passphrases, err := splitCertificatesAndPassphrases(certificateURLList, string(certificatePassphraseList))
 	if err != nil {
 		return nil, err
 	}
@@ -147,8 +148,8 @@ func parseCertificates(input Input) ([]certdownloader.CertificateAndPassphrase, 
 	return files, nil
 }
 
-// validateCertificates validates if the number of certificate URLs matches those of passphrases
-func validateCertificates(certURLList string, certPassphraseList string) ([]string, []string, error) {
+// splitCertificatesAndPassphrases validates if the number of certificate URLs matches those of passphrases
+func splitCertificatesAndPassphrases(certURLList string, certPassphraseList string) ([]string, []string, error) {
 	pfxURLs := splitAndClean(certURLList, "|", true)
 	passphrases := splitAndClean(certPassphraseList, "|", false) // allow empty items because passphrase can be empty
 
@@ -164,12 +165,12 @@ func splitAndClean(list string, sep string, omitEmpty bool) (items []string) {
 	return sliceutil.CleanWhitespace(strings.Split(list, sep), omitEmpty)
 }
 
-// validateAndExpandProfilePaths validates and expands profilesList.
+// parseFallbackProvisioningProfiles validates and expands profilesList.
 // profilesList must be a list of paths separated either by `|` or `\n`.
 // List items must be a remote (https://) or local (file://) file paths,
 // or a local directory (with no scheme).
 // For directory list items, the contained profiles' path will be returned.
-func validateAndExpandProfilePaths(profilesList string) ([]string, error) {
+func parseFallbackProvisioningProfiles(profilesList string) ([]string, error) {
 	profiles := splitAndClean(profilesList, "\n", true)
 	if len(profiles) == 1 {
 		profiles = splitAndClean(profiles[0], "|", true)
@@ -179,7 +180,7 @@ func validateAndExpandProfilePaths(profilesList string) ([]string, error) {
 	for _, profile := range profiles {
 		profileURL, err := url.Parse(profile)
 		if err != nil {
-			return []string{}, fmt.Errorf("invalid provisioning profile URL (%s): %w", profile, err)
+			return []string{}, fmt.Errorf("invalid provisioning profile URL specified (%s): %w", profile, err)
 		}
 
 		// When file or https scheme provided, will fetch as a file
@@ -203,14 +204,14 @@ func validateAndExpandProfilePaths(profilesList string) ([]string, error) {
 func listProfilesInDirectory(dir string) ([]string, error) {
 	exists, err := pathutil.IsDirExists(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if provisioning profile path (%s) exists: %w", dir, err)
+		return nil, fmt.Errorf("failed to check if provisioning profile path exists (%s): %w", dir, err)
 	} else if !exists {
-		return nil, fmt.Errorf("please provide remote (https://) or local (file://) provisioning profile file paths with a scheme, or a local directory without a scheme: profile directory (%s) does not exist", dir)
+		return nil, fmt.Errorf("directory of provisioning profiles does not exist (%s)", dir)
 	}
 
 	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list profile directory: %w", err)
+		return nil, fmt.Errorf("failed to list entries of the provisioning profiles directory (%s): %w", dir, err)
 	}
 
 	var profiles []string

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -88,7 +88,7 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 	if strings.HasPrefix(string(keyPathOrURL), "https://") {
 		resp, err := retryhttp.NewClient(logger).Get(string(keyPathOrURL))
 		if err != nil {
-			return nil, fmt.Errorf("API key download error: %s", err)
+			return nil, fmt.Errorf("failed to download App Store Connect API key: %w", err)
 		}
 
 		defer func(Body io.ReadCloser) {
@@ -98,12 +98,12 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 			}
 		}(resp.Body)
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("API key HTTP response %d: %s", resp.StatusCode, resp.Body)
+			return nil, fmt.Errorf("downloading App Store Connect API key failed with exit status %d: %s", resp.StatusCode, resp.Body)
 		}
 
 		key, err = io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to read App Store Connect API key download response: %w", err)
 		}
 	} else {
 		trimmedPath := string(keyPathOrURL)
@@ -113,9 +113,9 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 		var err error
 		key, err = os.ReadFile(trimmedPath)
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("private key does not exist at %s", trimmedPath)
+			return nil, fmt.Errorf("App Store Connect API does not exist at %s", trimmedPath)
 		} else if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to read App Store Connect API at %s: %w", trimmedPath, err)
 		}
 	}
 

--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -122,13 +122,13 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 // parseCertificates returns an array of p12 file URLs and passphrases
 func parseCertificates(input Input) ([]certdownloader.CertificateAndPassphrase, error) {
 	if strings.TrimSpace(input.CertificateURLList) == "" {
-		return nil, fmt.Errorf("code signing certificate URL: required input is not present")
+		return nil, fmt.Errorf("code signing certificate URL is not specified")
 	}
 	if strings.TrimSpace(input.KeychainPath) == "" {
-		return nil, fmt.Errorf("keychain path: required input is not present")
+		return nil, fmt.Errorf("keychain path is not specified")
 	}
 	if strings.TrimSpace(string(input.KeychainPassword)) == "" {
-		return nil, fmt.Errorf("keychain password: required input is not present")
+		return nil, fmt.Errorf("keychain password is not specified")
 	}
 
 	pfxURLs, passphrases, err := validateCertificates(input.CertificateURLList, string(input.CertificatePassphraseList))
@@ -153,7 +153,7 @@ func validateCertificates(certURLList string, certPassphraseList string) ([]stri
 	passphrases := splitAndClean(certPassphraseList, "|", false) // allow empty items because passphrase can be empty
 
 	if len(pfxURLs) != len(passphrases) {
-		return nil, nil, fmt.Errorf("certificate count (%d) and passphrase count (%d) should match", len(pfxURLs), len(passphrases))
+		return nil, nil, fmt.Errorf("code signing certificate count (%d) and passphrase count (%d) should match", len(pfxURLs), len(passphrases))
 	}
 
 	return pfxURLs, passphrases, nil

--- a/codesign/inputparse_test.go
+++ b/codesign/inputparse_test.go
@@ -123,7 +123,7 @@ func TestParseCertificates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseCertificatesAndPassphrases(tt.input)
+			got, err := parseCertificatesAndPassphrases(tt.input.CertificateURLList, string(tt.input.CertificatePassphraseList))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/codesign/inputparse_test.go
+++ b/codesign/inputparse_test.go
@@ -123,7 +123,7 @@ func TestParseCertificates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseCertificates(tt.input)
+			got, err := parseCertificatesAndPassphrases(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -186,7 +186,7 @@ func Test_validateAndExpandProfilePaths(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := validateAndExpandProfilePaths(tt.profilesList)
+			got, err := parseFallbackProvisioningProfiles(tt.profilesList)
 
 			if !tt.wantErr {
 				require.NoError(t, err)


### PR DESCRIPTION
### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

Update `codesign.ParseConfig` and `codesign.SelectConnectionCredentials` error messages.

### Changes

- Wrap errors with `%w`
- Improve function names called by `codesign.ParseConfig`
- Improve error messages

`codesign.ParseConfig` new errors:

```
code signing certificate URL is not specified
code signing certificate count (%d) and passphrase count (%d) should match
keychain path is not specified
keychain password is not specified
failed to open keychain: %w
invalid provisioning profile URL specified (%s): %w
failed to check if provisioning profile path exists (%s): %w
directory of provisioning profiles does not exist (%s)
failed to list entries of the provisioning profiles directory (%s): %w
```

`codesign.SelectConnectionCredentials` new errors:

```
failed to download App Store Connect API key: %w
downloading App Store Connect API key failed with exit status %d: %w
failed to read App Store Connect API key download response: %w
App Store Connect API does not exist at %s
failed to read App Store Connect API at %s: %w
Apple Service connection via App Store Connect API key is not estabilished
Apple Service connection through Apple ID is not estabilished
failed to restore Apple ID login session: %w
```


### Investigation details

### Decisions
