### PR TITLE
Use standard linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+run:
+  skip-dirs:
+  - .*/mocks
+
+issues:
+  # https://github.com/golangci/golangci-lint/issues/2439
+  exclude-use-default: false
+
+linters:
+  enable:
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - typecheck
+  - unused
+  - revive
+
+linters-settings:
+  revive:
+    severity: error
+    rules:
+    - name: exported
+      arguments:
+      - checkPrivateReceivers

--- a/autocodesign/autocodesign_test.go
+++ b/autocodesign/autocodesign_test.go
@@ -184,7 +184,7 @@ func Test_codesignAssetManager_EnsureCodesignAssets(t *testing.T) {
 		appLayout AppLayout
 		opts      CodesignAssetsOpts
 		want      map[DistributionType]AppCodesignAssets
-		wantErr   error
+		wantErr   *DetailedError
 	}{
 		{
 			name: "no valid certs found",

--- a/autocodesign/certdownloader/certdownloader.go
+++ b/autocodesign/certdownloader/certdownloader.go
@@ -32,6 +32,7 @@ func NewDownloader(certs []CertificateAndPassphrase, client *http.Client) autoco
 	}
 }
 
+// GetCertificates ...
 func (d downloader) GetCertificates() ([]certificateutil.CertificateInfoModel, error) {
 	var certInfos []certificateutil.CertificateInfoModel
 

--- a/autocodesign/devportalclient/appstoreconnectclient/devices_test.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices_test.go
@@ -15,7 +15,7 @@ type MockDeviceClient struct {
 	mock.Mock
 }
 
-func (c MockDeviceClient) Do(req *http.Request) (*http.Response, error) {
+func (c *MockDeviceClient) Do(req *http.Request) (*http.Response, error) {
 	fmt.Printf("do called: %#v - %#v\n", req.Method, req.URL.Path)
 
 	switch {
@@ -39,7 +39,7 @@ func TestDeviceClient_RegisterDevice_WhenInvaludUUID(t *testing.T) {
 		},
 	})
 
-	client := appstoreconnect.NewClient(mockClient, "keyID", "issueID", []byte("privateKey"))
+	client := appstoreconnect.NewClient(&mockClient, "keyID", "issueID", []byte("privateKey"))
 	deviceClient := NewDeviceClient(client)
 
 	got, err := deviceClient.RegisterDevice(devportalservice.TestDevice{

--- a/autocodesign/errors.go
+++ b/autocodesign/errors.go
@@ -14,7 +14,7 @@ type DetailedError struct {
 	Recommendation string
 }
 
-func (e *DetailedError) Error() string {
+func (e DetailedError) Error() string {
 	message := ""
 	if e.ErrorMessage != "" {
 		message += e.ErrorMessage + "\n"

--- a/autocodesign/profiledownloader/profiledownloader.go
+++ b/autocodesign/profiledownloader/profiledownloader.go
@@ -26,10 +26,12 @@ func New(profileURLs []string, client *http.Client) autocodesign.ProfileProvider
 	}
 }
 
+// IsAvailable returns true if there are available remote profiles to download
 func (d downloader) IsAvailable() bool {
 	return len(d.urls) != 0
 }
 
+// GetProfiles downloads remote profiles and returns their contents
 func (d downloader) GetProfiles() ([]autocodesign.LocalProfile, error) {
 	var profiles []autocodesign.LocalProfile
 

--- a/autocodesign/projectmanager/projecthelper_test.go
+++ b/autocodesign/projectmanager/projecthelper_test.go
@@ -97,11 +97,10 @@ func TestNew(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			projHelp, err := NewProjectHelper(tt.projOrWSPath, tt.schemeName, tt.configurationName)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("New() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if projHelp == nil {
-				t.Errorf("New() error = No projectHelper was generated")
+				t.Fatalf("New() error = No projectHelper was generated")
 			}
 			if projHelp.Configuration != tt.wantConfiguration {
 				t.Errorf("New() got1 = %v, want %v", projHelp.Configuration, tt.wantConfiguration)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,10 +8,13 @@ workflows:
 
   test:
     steps:
+    - git::https://github.com/bitrise-steplib/steps-check.git:
+        title: Lint
+        inputs:
+        - workflow: lint
+        - skip_step_yml_validation: "yes"
     - go-list:
         inputs:
         - exclude: |-
             */mocks
-    - golint:
-    - errcheck:
-    - go-test:
+    - go-test: { }

--- a/destination/device_finder.go
+++ b/destination/device_finder.go
@@ -36,7 +36,7 @@ func NewDeviceFinder(log log.Logger, commandFactory command.Factory) DeviceFinde
 	}
 }
 
-// GetSimulator returns a Simulator matching the destination
+// FindDevice returns a Simulator matching the destination
 func (d deviceFinder) FindDevice(destination Simulator) (Device, error) {
 	var (
 		device Device

--- a/xcarchive/ios_test.go
+++ b/xcarchive/ios_test.go
@@ -66,7 +66,7 @@ func TestIosArchive_ReadCodesignParameters(t *testing.T) {
 							},
 							Extensions: []v1xcarchive.IosExtension{
 								{
-									v1xcarchive.IosBaseApplication{
+									IosBaseApplication: v1xcarchive.IosBaseApplication{
 										InfoPlist: map[string]interface{}{
 											"CFBundleIdentifier": "io.bitrise.watch-widget",
 											"DTPlatformName":     "watchos",
@@ -91,7 +91,7 @@ func TestIosArchive_ReadCodesignParameters(t *testing.T) {
 						},
 						Extensions: []v1xcarchive.IosExtension{
 							{
-								v1xcarchive.IosBaseApplication{
+								IosBaseApplication: v1xcarchive.IosBaseApplication{
 									InfoPlist: map[string]interface{}{
 										"CFBundleIdentifier": "io.bitrise.ios-widget1",
 										"DTPlatformName":     "iphoneos",
@@ -102,7 +102,7 @@ func TestIosArchive_ReadCodesignParameters(t *testing.T) {
 								},
 							},
 							{
-								v1xcarchive.IosBaseApplication{
+								IosBaseApplication: v1xcarchive.IosBaseApplication{
 									InfoPlist: map[string]interface{}{
 										"CFBundleIdentifier": "io.bitrise.ios-widget2",
 										"DTPlatformName":     "iphoneos",

--- a/xcpretty/xcpretty.go
+++ b/xcpretty/xcpretty.go
@@ -119,6 +119,7 @@ func NewXcpretty(logger log.Logger) Xcpretty {
 	}
 }
 
+// IsInstalled ...
 func (x xcpretty) IsInstalled() (bool, error) {
 	locator := env.NewCommandLocator()
 	factory, err := ruby.NewCommandFactory(command.NewFactory(env.NewRepository()), locator)


### PR DESCRIPTION
Use the standard linters and config we use in other step repos.

This PR drops errcheck and golint in favor of golangci-lint through the check internal step.

There were a few lint violations with the new rules, this PR fixes those.

```
xcarchive/ios_test.go:68:9: composites: github.com/bitrise-io/go-xcode/xcarchive.IosExtension struct literal uses unkeyed fields (govet)
								{
								^
xcarchive/ios_test.go:93:8: composites: github.com/bitrise-io/go-xcode/xcarchive.IosExtension struct literal uses unkeyed fields (govet)
							{
							^
xcarchive/ios_test.go:104:8: composites: github.com/bitrise-io/go-xcode/xcarchive.IosExtension struct literal uses unkeyed fields (govet)
							{
							^
autocodesign/devportalclient/appstoreconnectclient/devices_test.go:18:9: copylocks: Do passes lock by value: github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnectclient.MockDeviceClient contains github.com/stretchr/testify/mock.Mock contains sync.Mutex (govet)
func (c MockDeviceClient) Do(req *http.Request) (*http.Response, error) {
        ^
autocodesign/devportalclient/appstoreconnectclient/devices_test.go:42:38: copylocks: call of appstoreconnect.NewClient copies lock value: github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnectclient.MockDeviceClient contains github.com/stretchr/testify/mock.Mock contains sync.Mutex (govet)
	client := appstoreconnect.NewClient(mockClient, "keyID", "issueID", []byte("privateKey"))
	                                    ^
autocodesign/autocodesign_test.go:278:28: errorsas: second argument to errors.As should not be *error (govet)
				(tt.wantErr != nil && !errors.As(err, &tt.wantErr)) {
				                       ^
autocodesign/projectmanager/projecthelper_test.go:106:16: SA5011: possible nil pointer dereference (staticcheck)
			if projHelp.Configuration != tt.wantConfiguration {
			            ^
autocodesign/projectmanager/projecthelper_test.go:103:7: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
			if projHelp == nil {
			   ^
```