### PR TITLE
[CI-267] Add generic xcodebuild error finder

### DIFF
--- a/errorfinder/errorfinder.go
+++ b/errorfinder/errorfinder.go
@@ -1,0 +1,80 @@
+package errorfinder
+
+import (
+	"bufio"
+	"strings"
+)
+
+// FindXcodebuildErrors ...
+func FindXcodebuildErrors(out string) []string {
+	var errorLines []string       // single line errors with "error: " prefix
+	var xcodebuildErrors []string // multiline errors starting with "xcodebuild: error: " prefix
+	var nserrors []nsError        // single line NSErrors with schema: Error Domain=<domain> Code=<code> "<reason>" UserInfo=<user_info>
+
+	isXcodebuildError := false
+	var xcodebuildError string
+
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if isXcodebuildError {
+			line = strings.TrimLeft(line, " ")
+			if strings.HasPrefix(line, "Reason: ") || strings.HasPrefix(line, "Recovery suggestion: ") {
+				xcodebuildError += "\n" + line
+				continue
+			} else {
+				xcodebuildErrors = append(xcodebuildErrors, xcodebuildError)
+				xcodebuildError = ""
+				isXcodebuildError = false
+			}
+		}
+
+		switch {
+		case strings.HasPrefix(line, "xcodebuild: error: "):
+			xcodebuildError = line
+			isXcodebuildError = true
+		case strings.HasPrefix(line, "error: ") || strings.Contains(line, " error: "):
+			errorLines = append(errorLines, line)
+		case strings.HasPrefix(line, "Error "):
+			if e := newNSError(line); e != nil {
+				nserrors = append(nserrors, *e)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil
+	}
+
+	if xcodebuildError != "" {
+		xcodebuildErrors = append(xcodebuildErrors, xcodebuildError)
+	}
+
+	// Regular error lines (line with 'error: ' prefix) seems to have
+	// NSError line pairs (same description) in some cases.
+	errorLines = intersection(errorLines, nserrors)
+
+	return append(errorLines, xcodebuildErrors...)
+}
+
+func intersection(errorLines []string, nserrors []nsError) []string {
+	union := make([]string, len(errorLines))
+	copy(union, errorLines)
+
+	for _, nserror := range nserrors {
+		found := false
+		for i, errorLine := range errorLines {
+			// Checking suffix, as regular error lines have additional prefixes, like "error: exportArchive: "
+			if strings.HasSuffix(errorLine, nserror.Description) {
+				union[i] = nserror.Error()
+				found = true
+				break
+			}
+		}
+		if !found {
+			union = append(union, nserror.Error())
+		}
+	}
+	return union
+}

--- a/errorfinder/errorfinder_test.go
+++ b/errorfinder/errorfinder_test.go
@@ -1,0 +1,181 @@
+package errorfinder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want *nsError
+	}{
+		{
+			name: "Real NSError",
+			str:  `Error Domain=IDEProvisioningErrorDomain Code=9 ""ios-simple-objc.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="ios-simple-objc.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}`,
+			want: &nsError{
+				Description: `"ios-simple-objc.app" requires a provisioning profile.`,
+				Suggestion:  `Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`,
+			},
+		},
+		{
+			name: "UserInfo properties order changed",
+			str:  `Error Domain=IDEProvisioningErrorDomain Code=9 UserInfo={NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list., IDEDistributionIssueSeverity=3, NSLocalizedDescription="ios-simple-objc.app" requires a provisioning profile.}`,
+			want: &nsError{
+				Description: `"ios-simple-objc.app" requires a provisioning profile.`,
+				Suggestion:  `Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newNSError(tt.str); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewNSError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_findXcodebuildErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{
+			name: "Regular error",
+			out:  `error: exportArchive: "code-sign-test.app" requires a provisioning profile.`,
+			want: []string{`error: exportArchive: "code-sign-test.app" requires a provisioning profile.`},
+		},
+		{
+			name: "Regular error with project path prefix",
+			out:  `./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')`,
+			want: []string{`./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')`},
+		},
+		{
+			name: "xcodebuild error",
+			out: `xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`,
+			want: []string{`xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`},
+		},
+		{
+			name: "xcodebuild error and regular error with project path prefix",
+			out: `./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')
+
+xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`,
+			want: []string{
+				`./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')`,
+				`xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`},
+		},
+		{
+			name: "NSError",
+			out:  `Error Domain=IDEProvisioningErrorDomain Code=9 ""code-sign-test.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="code-sign-test.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}`,
+			want: []string{`"code-sign-test.app" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`},
+		},
+		{
+			name: "Regular error and NSError pair",
+			out: `error: exportArchive: "share-extension.appex" requires a provisioning profile.
+
+Error Domain=IDEProvisioningErrorDomain Code=9 ""share-extension.appex" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="share-extension.appex" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}`,
+			want: []string{`"share-extension.appex" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`},
+		},
+		{
+			name: "Extra regular error",
+			out: `error: exportArchive: "watchkit-app.app" requires a provisioning profile.
+
+Error Domain=IDEProvisioningErrorDomain Code=9 ""watchkit-app.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="watchkit-app.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
+
+error: exportArchive: "share-extension.appex" requires a provisioning profile.
+`,
+			want: []string{
+				`"watchkit-app.app" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`,
+				`error: exportArchive: "share-extension.appex" requires a provisioning profile.`,
+			},
+		},
+		{
+			name: "Regular error with NSError pair and xcodebuild error",
+			out: `error: exportArchive: "watchkit-app.app" requires a provisioning profile.
+
+Error Domain=IDEProvisioningErrorDomain Code=9 ""watchkit-app.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="watchkit-app.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
+
+xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform.
+`,
+			want: []string{
+				`"watchkit-app.app" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`,
+				`xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform.`,
+			},
+		},
+		{
+			name: "All of the various errors appear in the output",
+			out: `Error Domain=IDEProvisioningErrorDomain Code=9 ""ios-simple-objc.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="ios-simple-objc.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
+More build stuff
+xcodebuild: error: testing failed
+Recovery suggestion: test again
+A bunch of nonsense
+error: archiving failed
+More nonsense
+ error: store upload failed`,
+			want: []string{
+				"error: archiving failed",
+				" error: store upload failed",
+				"\"ios-simple-objc.app\" requires a provisioning profile. Add a profile to the \"provisioningProfiles\" dictionary in your Export Options property list.",
+				"xcodebuild: error: testing failed\nRecovery suggestion: test again",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FindXcodebuildErrors(tt.out); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findXcodebuildErrors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindXcodebuildErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		output         string
+		wantErrorLines []string
+	}{
+		{
+			name: "Single error",
+			output: `Error Domain=IDEProvisioningErrorDomain Code=9 ""ios-simple-objc.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="ios-simple-objc.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
+More build stuff
+xcodebuild: error: testing failed
+Recovery suggestion: test again
+A bunch of nonsense
+error: archiving failed
+More nonsense
+ error: store upload failed`,
+			wantErrorLines: []string{
+				"error: archiving failed",
+				" error: store upload failed",
+				"\"ios-simple-objc.app\" requires a provisioning profile. Add a profile to the \"provisioningProfiles\" dictionary in your Export Options property list.",
+				"xcodebuild: error: testing failed\nRecovery suggestion: test again",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errorLines := FindXcodebuildErrors(tt.output)
+
+			if !reflect.DeepEqual(errorLines, tt.wantErrorLines) {
+				t.Errorf("got error lines = %s, want %s", errorLines, tt.wantErrorLines)
+			}
+		})
+	}
+}

--- a/errorfinder/nserror.go
+++ b/errorfinder/nserror.go
@@ -1,0 +1,62 @@
+package errorfinder
+
+import (
+	"regexp"
+	"strings"
+)
+
+type nsError struct {
+	Description string
+	Suggestion  string
+}
+
+func newNSError(str string) *nsError {
+	if !isNSError(str) {
+		return nil
+	}
+
+	descriptionPattern := `NSLocalizedDescription=(.+?),|NSLocalizedDescription=(.+?)}`
+	description := findFirstSubMatch(str, descriptionPattern)
+	if description == "" {
+		return nil
+	}
+
+	suggestionPattern := `NSLocalizedRecoverySuggestion=(.+?),|NSLocalizedRecoverySuggestion=(.+?)}`
+	suggestion := findFirstSubMatch(str, suggestionPattern)
+
+	return &nsError{
+		Description: description,
+		Suggestion:  suggestion,
+	}
+}
+
+func (e nsError) Error() string {
+	msg := e.Description
+	if e.Suggestion != "" {
+		msg += " " + e.Suggestion
+	}
+	return msg
+}
+
+func findFirstSubMatch(str, pattern string) string {
+	exp := regexp.MustCompile(pattern)
+	matches := exp.FindStringSubmatch(str)
+	if len(matches) > 1 {
+		for _, match := range matches[1:] {
+			if match != "" {
+				return match
+			}
+		}
+	}
+	return ""
+}
+
+func isNSError(str string) bool {
+	// example: Error Domain=IDEProvisioningErrorDomain Code=9 ""ios-simple-objc.app" requires a provisioning profile."
+	//   UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="ios-simple-objc.app" requires a provisioning profile.,
+	//   NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
+	return strings.Contains(str, "Error ") &&
+		strings.Contains(str, "Domain=") &&
+		strings.Contains(str, "Code=") &&
+		strings.Contains(str, "UserInfo=")
+}


### PR DESCRIPTION
It seems like the xcodebuild error formats are generic and shared between all of the xcodebuild subcommands. The xcode-test step was producing similar errors as the xcode-archive one. 

This PR extracts and adds test to the already existing custom xcodebuild error finder logic which at the moment only lives in the xcode-archive step: https://github.com/bitrise-steplib/steps-xcode-archive/blob/9f4ef188d017b110374ea71ba9445bae1acfa6ef/step/errors.go