### PR TITLE
[CI-615] File based device parsing

### DIFF
--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -166,18 +166,6 @@ type APIKeyConnection struct {
 	PrivateKey string `json:"private_key"`
 }
 
-// TestDevice ...
-type TestDevice struct {
-	ID     int `json:"id"`
-	UserID int `json:"user_id"`
-	// DeviceID is the Apple device UDID
-	DeviceID   string    `json:"device_identifier"`
-	Title      string    `json:"title"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	DeviceType string    `json:"device_type"`
-}
-
 // IsEqualUDID compares two UDIDs (stored in the DeviceID field of TestDevice)
 func IsEqualUDID(UDID string, otherUDID string) bool {
 	return normalizeDeviceUDID(UDID) == normalizeDeviceUDID(otherUDID)

--- a/devportalservice/testdevice.go
+++ b/devportalservice/testdevice.go
@@ -1,0 +1,51 @@
+package devportalservice
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+// TestDevice ...
+type TestDevice struct {
+	ID     int `json:"id"`
+	UserID int `json:"user_id"`
+	// DeviceID is the Apple device UDID
+	DeviceID   string    `json:"device_identifier"`
+	Title      string    `json:"title"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	DeviceType string    `json:"device_type"`
+}
+
+// ParseTestDevicesFromFile ...
+func ParseTestDevicesFromFile(path string, currentTime time.Time) []TestDevice {
+	absPath, err := pathutil.AbsPath(path)
+	if err != nil {
+		return []TestDevice{}
+	}
+
+	bytes, err := os.ReadFile(absPath)
+	if err != nil {
+		return []TestDevice{}
+	}
+
+	fileContent := strings.TrimSpace(string(bytes))
+	identifiers := strings.Split(fileContent, ",")
+
+	var testDevices []TestDevice
+	for i, identifier := range identifiers {
+		testDevices = append(testDevices, TestDevice{
+			DeviceID:   identifier,
+			Title:      fmt.Sprintf("Device %d", i+1),
+			CreatedAt:  currentTime,
+			UpdatedAt:  currentTime,
+			DeviceType: "unknown",
+		})
+	}
+
+	return testDevices
+}

--- a/devportalservice/testdevice.go
+++ b/devportalservice/testdevice.go
@@ -22,15 +22,15 @@ type TestDevice struct {
 }
 
 // ParseTestDevicesFromFile ...
-func ParseTestDevicesFromFile(path string, currentTime time.Time) []TestDevice {
+func ParseTestDevicesFromFile(path string, currentTime time.Time) ([]TestDevice, error) {
 	absPath, err := pathutil.AbsPath(path)
 	if err != nil {
-		return []TestDevice{}
+		return []TestDevice{}, err
 	}
 
 	bytes, err := os.ReadFile(absPath)
 	if err != nil {
-		return []TestDevice{}
+		return []TestDevice{}, err
 	}
 
 	fileContent := strings.TrimSpace(string(bytes))
@@ -47,5 +47,5 @@ func ParseTestDevicesFromFile(path string, currentTime time.Time) []TestDevice {
 		})
 	}
 
-	return testDevices
+	return testDevices, nil
 }

--- a/devportalservice/testdevice_test.go
+++ b/devportalservice/testdevice_test.go
@@ -1,0 +1,45 @@
+package devportalservice
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceParsing(t *testing.T) {
+	content := "00000000–0000000000000001,00000000–0000000000000002,00000000–0000000000000003"
+	pth := path.Join(t.TempDir(), "devices.txt")
+	err := fileutil.WriteStringToFile(pth, content)
+	require.NoError(t, err)
+
+	currentTime := time.Now()
+	got := ParseTestDevicesFromFile(pth, currentTime)
+	expected := []TestDevice{
+		{
+			DeviceID:   "00000000–0000000000000001",
+			Title:      "Device 1",
+			CreatedAt:  currentTime,
+			UpdatedAt:  currentTime,
+			DeviceType: "unknown",
+		},
+		{
+			DeviceID:   "00000000–0000000000000002",
+			Title:      "Device 2",
+			CreatedAt:  currentTime,
+			UpdatedAt:  currentTime,
+			DeviceType: "unknown",
+		},
+		{
+			DeviceID:   "00000000–0000000000000003",
+			Title:      "Device 3",
+			CreatedAt:  currentTime,
+			UpdatedAt:  currentTime,
+			DeviceType: "unknown",
+		},
+	}
+	assert.Equal(t, expected, got)
+}

--- a/devportalservice/testdevice_test.go
+++ b/devportalservice/testdevice_test.go
@@ -17,7 +17,9 @@ func TestDeviceParsing(t *testing.T) {
 	require.NoError(t, err)
 
 	currentTime := time.Now()
-	got := ParseTestDevicesFromFile(pth, currentTime)
+	got, err := ParseTestDevicesFromFile(pth, currentTime)
+	require.NoError(t, err)
+
 	expected := []TestDevice{
 		{
 			DeviceID:   "00000000–0000000000000001",


### PR DESCRIPTION
Bitrise does not provide a proper device management for the users. This PR does not aim to solve that but rather adding an extra easy way managing the test devices. 

The users will be able to provide a path to a file which contains a comma separated list of device identifiers. If this input is set then it will have priority over the Bitrise service connection. 

This parsing logic will be used by three steps:
- steps-xcode-archive
- steps-export-xcarchive
- steps-xcode-build-for-test

And here are some links to see how these changes would look in the steps:
- https://github.com/bitrise-steplib/steps-xcode-archive/compare/CI-615-file-based-device-list?expand=1
- https://github.com/bitrise-steplib/steps-export-xcarchive/compare/CI-615-file-based-device-list?expand=1
- https://github.com/bitrise-steplib/steps-xcode-build-for-test/compare/CI-615-file-based-device-list?expand=1