### PR TITLE
Adding support for default Bitrise device.

### DIFF
--- a/destination/device_finder.go
+++ b/destination/device_finder.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
+const defaultDeviceName = "Bitrise iOS default"
+
 // Device is an available device
 type Device struct {
 	Name   string

--- a/destination/device_finder.go
+++ b/destination/device_finder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
+// Keep it in sync with https://github.com/bitrise-io/image-build-utils/blob/master/roles/simulators/defaults/main.yml#L14
 const defaultDeviceName = "Bitrise iOS default"
 
 // Device is an available device

--- a/destination/device_finder_test.go
+++ b/destination/device_finder_test.go
@@ -100,7 +100,7 @@ func Test_deviceFinder_FindDevice(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "default device",
+			name: "default device, already created",
 			wantedDevice: Simulator{
 				Platform: "iOS Simulator",
 				OS:       "13.7",
@@ -111,6 +111,20 @@ func Test_deviceFinder_FindDevice(t *testing.T) {
 				ID:     "20FDD0DF-0369-43FF-98E6-DBB8C820341E",
 				Status: "Shutdown",
 				OS:     "13.7",
+			},
+		},
+		{
+			name: "default device, but not yet created",
+			wantedDevice: Simulator{
+				Platform: "iOS Simulator",
+				OS:       "latest",
+				Name:     "Bitrise iOS default",
+			},
+			want: Device{
+				Name:   "iPhone 8",
+				ID:     "D64FA78C-5A25-4BF3-9EE8-855761042DEE",
+				Status: "Shutdown",
+				OS:     "16.0",
 			},
 		},
 		{

--- a/destination/device_finder_test.go
+++ b/destination/device_finder_test.go
@@ -100,6 +100,29 @@ func Test_deviceFinder_FindDevice(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "default device",
+			wantedDevice: Simulator{
+				Platform: "iOS Simulator",
+				OS:       "13.7",
+				Name:     "Bitrise iOS default",
+			},
+			want: Device{
+				Name:   "Bitrise iOS default",
+				ID:     "20FDD0DF-0369-43FF-98E6-DBB8C820341E",
+				Status: "Shutdown",
+				OS:     "13.7",
+			},
+		},
+		{
+			name: "device type not available",
+			wantedDevice: Simulator{
+				Platform: "iOS Simulator",
+				OS:       "latest",
+				Name:     "iPhone NotExists",
+			},
+			wantErr: true,
+		},
+		{
 			name: "runtime not available",
 			wantedDevice: Simulator{
 				Platform: "iOS Simulator",

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -15,17 +15,17 @@ import (
 )
 
 /*
-  "devicetypes" : [{
-  "productFamily" : "iPhone",
-  "bundlePath" : "\/Applications\/Xcode-beta.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform\/Library\/Developer\/CoreSimulator\/Profiles\/DeviceTypes\/iPhone 11.simdevicetype",
-  "maxRuntimeVersion" : 4294967295,
-  "maxRuntimeVersionString" : "65535.255.255",
-  "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-11",
-  "modelIdentifier" : "iPhone12,1",
-  "minRuntimeVersionString" : "13.0.0",
-  "minRuntimeVersion" : 851968,
-  "name" : "iPhone 11"
-}, ... ]
+	  "devicetypes" : [{
+	  "productFamily" : "iPhone",
+	  "bundlePath" : "\/Applications\/Xcode-beta.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform\/Library\/Developer\/CoreSimulator\/Profiles\/DeviceTypes\/iPhone 11.simdevicetype",
+	  "maxRuntimeVersion" : 4294967295,
+	  "maxRuntimeVersionString" : "65535.255.255",
+	  "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-11",
+	  "modelIdentifier" : "iPhone12,1",
+	  "minRuntimeVersionString" : "13.0.0",
+	  "minRuntimeVersion" : 851968,
+	  "name" : "iPhone 11"
+	}, ... ]
 */
 type deviceType struct {
 	Name          string `json:"name"`
@@ -34,25 +34,25 @@ type deviceType struct {
 }
 
 /*
-  "runtimes" : [
-    {
-      "bundlePath" : "\/Library\/Developer\/CoreSimulator\/Profiles\/Runtimes\/iOS 12.4.simruntime",
-      "buildversion" : "16G73",
-      "platform" : "iOS",
-      "runtimeRoot" : "\/Library\/Developer\/CoreSimulator\/Profiles\/Runtimes\/iOS 12.4.simruntime\/Contents\/Resources\/RuntimeRoot",
-      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-12-4",
-      "version" : "12.4",
-      "isInternal" : false,
-      "isAvailable" : true,
-      "name" : "iOS 12.4",
-      "supportedDeviceTypes" : [
-        {
-          "bundlePath" : "\/Applications\/Xcode-beta.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform\/Library\/Developer\/CoreSimulator\/Profiles\/DeviceTypes\/iPhone 5s.simdevicetype",
-          "name" : "iPhone 5s",
-          "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
-          "productFamily" : "iPhone"
-        }, ... ],
-	}, ... ]
+	  "runtimes" : [
+	    {
+	      "bundlePath" : "\/Library\/Developer\/CoreSimulator\/Profiles\/Runtimes\/iOS 12.4.simruntime",
+	      "buildversion" : "16G73",
+	      "platform" : "iOS",
+	      "runtimeRoot" : "\/Library\/Developer\/CoreSimulator\/Profiles\/Runtimes\/iOS 12.4.simruntime\/Contents\/Resources\/RuntimeRoot",
+	      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-12-4",
+	      "version" : "12.4",
+	      "isInternal" : false,
+	      "isAvailable" : true,
+	      "name" : "iOS 12.4",
+	      "supportedDeviceTypes" : [
+	        {
+	          "bundlePath" : "\/Applications\/Xcode-beta.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform\/Library\/Developer\/CoreSimulator\/Profiles\/DeviceTypes\/iPhone 5s.simdevicetype",
+	          "name" : "iPhone 5s",
+	          "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
+	          "productFamily" : "iPhone"
+	        }, ... ],
+		}, ... ]
 */
 type deviceRuntime struct {
 	Identifier           string       `json:"identifier"`
@@ -64,33 +64,33 @@ type deviceRuntime struct {
 }
 
 /*
-  "devices" : {
-    "com.apple.CoreSimulator.SimRuntime.watchOS-7-4" : [
-      {
-        "availabilityError" : "runtime profile not found",
-        "dataPath" : "\/Users\/lpusok\/Library\/Developer\/CoreSimulator\/Devices\/6503EC5B-2393-46F1-A947-B32677A3360F\/data",
-        "dataPathSize" : 0,
-        "logPath" : "\/Users\/lpusok\/Library\/Logs\/CoreSimulator\/6503EC5B-2393-46F1-A947-B32677A3360F",
-        "udid" : "6503EC5B-2393-46F1-A947-B32677A3360F",
-        "isAvailable" : false,
-        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-5-40mm",
-        "state" : "Shutdown",
-        "name" : "Apple Watch Series 5 - 40mm"
-      }, ... ],
-	"com.apple.CoreSimulator.SimRuntime.iOS-16-0" : [
-      {
-        "lastBootedAt" : "2022-06-07T11:34:18Z",
-        "dataPath" : "\/Users\/lpusok\/Library\/Developer\/CoreSimulator\/Devices\/D64FA78C-5A25-4BF3-9EE8-855761042DEE\/data",
-        "dataPathSize" : 311848960,
-        "logPath" : "\/Users\/lpusok\/Library\/Logs\/CoreSimulator\/D64FA78C-5A25-4BF3-9EE8-855761042DEE",
-        "udid" : "D64FA78C-5A25-4BF3-9EE8-855761042DEE",
-        "isAvailable" : true,
-        "logPathSize" : 57344,
-        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-8",
-        "state" : "Shutdown",
-        "name" : "iPhone 8"
-      }, ... ]
-  }
+	  "devices" : {
+	    "com.apple.CoreSimulator.SimRuntime.watchOS-7-4" : [
+	      {
+	        "availabilityError" : "runtime profile not found",
+	        "dataPath" : "\/Users\/lpusok\/Library\/Developer\/CoreSimulator\/Devices\/6503EC5B-2393-46F1-A947-B32677A3360F\/data",
+	        "dataPathSize" : 0,
+	        "logPath" : "\/Users\/lpusok\/Library\/Logs\/CoreSimulator\/6503EC5B-2393-46F1-A947-B32677A3360F",
+	        "udid" : "6503EC5B-2393-46F1-A947-B32677A3360F",
+	        "isAvailable" : false,
+	        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-5-40mm",
+	        "state" : "Shutdown",
+	        "name" : "Apple Watch Series 5 - 40mm"
+	      }, ... ],
+		"com.apple.CoreSimulator.SimRuntime.iOS-16-0" : [
+	      {
+	        "lastBootedAt" : "2022-06-07T11:34:18Z",
+	        "dataPath" : "\/Users\/lpusok\/Library\/Developer\/CoreSimulator\/Devices\/D64FA78C-5A25-4BF3-9EE8-855761042DEE\/data",
+	        "dataPathSize" : 311848960,
+	        "logPath" : "\/Users\/lpusok\/Library\/Logs\/CoreSimulator\/D64FA78C-5A25-4BF3-9EE8-855761042DEE",
+	        "udid" : "D64FA78C-5A25-4BF3-9EE8-855761042DEE",
+	        "isAvailable" : true,
+	        "logPathSize" : 57344,
+	        "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-8",
+	        "state" : "Shutdown",
+	        "name" : "iPhone 8"
+	      }, ... ]
+	  }
 */
 type device struct {
 	Name              string `json:"name"`
@@ -197,15 +197,12 @@ func (d deviceFinder) filterDeviceList(wantedDevice Simulator) (Device, error) {
 		return Device{}, fmt.Errorf("runtime (%s) not found", runtimeID)
 	}
 
-	deviceTypeIdentifier, err := d.lookupDeviceTypeID(wantedDevice.Name)
-	if err != nil {
-		return Device{}, err
-	}
-
+	// As the name of the device matches the device type ('iPhone 11') for factory created devices, look up device by name.
+	// If the default name is required and already created will use that.
 	for _, device := range devices {
-		if device.TypeIdentifier == deviceTypeIdentifier {
+		if device.Name == wantedDevice.Name {
 			if !device.IsAvailable {
-				return Device{}, fmt.Errorf("device type (%s) with runtime OS (%s) is unavailable: %s", wantedDevice.Name, runtime.Version, device.AvailabilityError)
+				return Device{}, fmt.Errorf("device (%s) with runtime OS (%s) is unavailable: %s", wantedDevice.Name, runtime.Version, device.AvailabilityError)
 			}
 
 			return Device{
@@ -217,8 +214,30 @@ func (d deviceFinder) filterDeviceList(wantedDevice Simulator) (Device, error) {
 		}
 	}
 
+	// Returns the first available device in case the default device name is specified, but not yet created.
+	if wantedDevice.Name == defaultDeviceName {
+		for _, device := range devices {
+			if !device.IsAvailable {
+				continue
+			}
+
+			return Device{
+				Name:   device.Name,
+				ID:     device.UDID,
+				Status: device.State,
+				OS:     runtime.Version,
+			}, nil
+		}
+	}
+
+	// If there is no matching device, look up device type so we can create device in a later step
+	deviceTypeIdentifier, err := d.lookupDeviceTypeID(wantedDevice.Name)
+	if err != nil {
+		return Device{}, err
+	}
+
 	if !runtime.isDeviceSupported(deviceTypeIdentifier) {
-		return Device{}, fmt.Errorf("runtime (%s) is incompatible with device (%s)", runtimeID, deviceTypeIdentifier)
+		return Device{}, fmt.Errorf("runtime (%s) is incompatible with device type (%s)", runtimeID, deviceTypeIdentifier)
 	}
 
 	return Device{}, newMissingDeviceErr(wantedDevice.Name, deviceTypeIdentifier, runtimeID)

--- a/destination/testdata/testout.go
+++ b/destination/testdata/testout.go
@@ -1604,7 +1604,7 @@ const DeviceList = `
 		  "isAvailable" : true,
 		  "deviceTypeIdentifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-6s",
 		  "state" : "Shutdown",
-		  "name" : "test"
+		  "name" : "Bitrise iOS default"
 		},
 		{
 		  "dataPath" : "\/Users\/lpusok\/Library\/Developer\/CoreSimulator\/Devices\/3F9A1206-31E2-417B-BBC7-6330B52B8358\/data",


### PR DESCRIPTION
### Context
We want to remove hardcoded device names (`iPhone 8 Plus`) from Step inputs.
On most Stacks there is a default device created, the Steps will use that by default. If the default device is not available, will use the first available device.