### PR TITLE
[BE-1124] Limit iOS simulator runtime to runtimes released for a given Xcode

### DIFF
--- a/destination/device_finder.go
+++ b/destination/device_finder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/v2/xcodeversion"
 )
 
 // Keep it in sync with https://github.com/bitrise-io/image-build-utils/blob/master/roles/simulators/defaults/main.yml#L14
@@ -31,15 +32,17 @@ type DeviceFinder interface {
 type deviceFinder struct {
 	logger         log.Logger
 	commandFactory command.Factory
+	xcodeVersion   xcodeversion.Version
 
 	list *deviceList
 }
 
 // NewDeviceFinder retruns the default implementation of DeviceFinder
-func NewDeviceFinder(log log.Logger, commandFactory command.Factory) DeviceFinder {
+func NewDeviceFinder(log log.Logger, commandFactory command.Factory, xcodeVersion xcodeversion.Version) DeviceFinder {
 	return &deviceFinder{
 		logger:         log,
 		commandFactory: commandFactory,
+		xcodeVersion:   xcodeVersion,
 	}
 }
 

--- a/destination/device_finder_test.go
+++ b/destination/device_finder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-xcode/v2/destination/testdata"
 	"github.com/bitrise-io/go-xcode/v2/mocks"
+	"github.com/bitrise-io/go-xcode/v2/xcodeversion"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -72,6 +73,7 @@ func Test_deviceFinder_FindDevice(t *testing.T) {
 
 	tests := []struct {
 		name         string
+		xcodeVersion xcodeversion.Version
 		wantedDevice Simulator
 		want         Device
 		wantErr      bool
@@ -89,6 +91,22 @@ func Test_deviceFinder_FindDevice(t *testing.T) {
 				Platform: "iOS Simulator",
 				Name:     "iPhone 8",
 				OS:       "16.0",
+			},
+		},
+		{
+			name:         "latest for an earler Xcode version",
+			xcodeVersion: xcodeversion.Version{MajorVersion: 13},
+			wantedDevice: Simulator{
+				Platform: "iOS Simulator",
+				OS:       "latest",
+				Name:     "iPhone 8",
+			},
+			want: Device{
+				ID:       "3F9A1206-31E2-417B-BBC7-6330B52B8358",
+				Status:   "Shutdown",
+				Platform: "iOS Simulator",
+				Name:     "iPhone 8",
+				OS:       "13.7",
 			},
 		},
 		{
@@ -231,6 +249,7 @@ func Test_deviceFinder_FindDevice(t *testing.T) {
 			d := deviceFinder{
 				logger:         logger,
 				commandFactory: commandFactory,
+				xcodeVersion:   tt.xcodeVersion,
 			}
 
 			got, err := d.FindDevice(tt.wantedDevice)

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -274,7 +274,6 @@ func (d deviceFinder) filterRuntime(wanted Simulator) (deviceRuntime, error) {
 	var allVersions []deviceRuntime
 
 	for _, runtime := range d.list.Runtimes {
-
 		if !runtime.IsAvailable {
 			continue
 		}
@@ -317,8 +316,11 @@ func (d deviceFinder) filterRuntime(wanted Simulator) (deviceRuntime, error) {
 				return deviceRuntime{}, fmt.Errorf("failed to parse Simulator version (%s): %w", runtimeVersion, err)
 			}
 
-			if (latestVersion == nil || runtimeVersion.GreaterThan(latestVersion)) &&
-				isIOSRuntimeSupportedByXcode(runtimeVersion, d.xcodeVersion) {
+			if wanted.Platform == string(IOS) && !isIOSRuntimeSupportedByXcode(runtimeVersion, d.xcodeVersion) {
+				continue
+			}
+
+			if latestVersion == nil || runtimeVersion.GreaterThan(latestVersion) {
 				latestVersion = runtimeVersion
 				latestRuntime = runtime
 			}

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -316,7 +316,7 @@ func (d deviceFinder) filterRuntime(wanted Simulator) (deviceRuntime, error) {
 				return deviceRuntime{}, fmt.Errorf("failed to parse Simulator version (%s): %w", runtimeVersion, err)
 			}
 
-			if wanted.Platform == string(IOS) && !isIOSRuntimeSupportedByXcode(runtimeVersion, d.xcodeVersion) {
+			if wanted.Platform == string(IOS) && !isRuntimeSupportedByXcode(wanted.Platform, runtimeVersion, d.xcodeVersion) {
 				continue
 			}
 

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -313,13 +313,14 @@ func (d deviceFinder) filterRuntime(wanted Simulator) (deviceRuntime, error) {
 		)
 
 		for _, runtime := range allVersions {
-			version, err := version.NewVersion(runtime.Version)
+			runtimeVersion, err := version.NewVersion(runtime.Version)
 			if err != nil {
-				return deviceRuntime{}, fmt.Errorf("failed to parse Simulator version (%s): %w", version, err)
+				return deviceRuntime{}, fmt.Errorf("failed to parse Simulator version (%s): %w", runtimeVersion, err)
 			}
 
-			if latestVersion == nil || version.GreaterThan(latestVersion) {
-				latestVersion = version
+			if isIOSRuntimeSupportedByXcode(runtimeVersion, deviceFinder.X) &&
+				(latestVersion == nil || runtimeVersion.GreaterThan(latestVersion)) {
+				latestVersion = runtimeVersion
 				latestRuntime = runtime
 			}
 		}

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-utils/errorutil"
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/hashicorp/go-version"
@@ -341,7 +340,7 @@ func (d deviceFinder) filterRuntime(wanted Simulator) (deviceRuntime, error) {
 
 		runtimeSegments := runtimeVersion.Segments()
 		if len(runtimeSegments) < 2 {
-			log.Warnf("no minor version found in Simulator version (%s)", runtime.Version)
+			d.logger.Warnf("no minor version found in Simulator version (%s)", runtime.Version)
 			continue
 		}
 

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -318,8 +318,8 @@ func (d deviceFinder) filterRuntime(wanted Simulator) (deviceRuntime, error) {
 				return deviceRuntime{}, fmt.Errorf("failed to parse Simulator version (%s): %w", runtimeVersion, err)
 			}
 
-			if isIOSRuntimeSupportedByXcode(runtimeVersion, deviceFinder.X) &&
-				(latestVersion == nil || runtimeVersion.GreaterThan(latestVersion)) {
+			if (latestVersion == nil || runtimeVersion.GreaterThan(latestVersion)) &&
+				isIOSRuntimeSupportedByXcode(runtimeVersion, d.xcodeVersion) {
 				latestVersion = runtimeVersion
 				latestRuntime = runtime
 			}

--- a/destination/xcode_runtime_support.go
+++ b/destination/xcode_runtime_support.go
@@ -1,0 +1,18 @@
+package destination
+
+func isIOSRuntimeSupportedByXcode(runtimeMajorVersion, xcodeMajorVersion int64) bool {
+	// Very simplified version of https://developer.apple.com/support/xcode/
+	// Only considering major versions for simplicity
+	var latestSupportedIOSRuntime = map[int64]int64{
+		15: 17,
+		14: 16,
+		13: 15,
+	}
+
+	latestSupportedMajorVersion, ok := latestSupportedIOSRuntime[runtimeMajorVersion]
+	if !ok {
+		return true
+	}
+
+	return latestSupportedMajorVersion >= runtimeMajorVersion
+}

--- a/destination/xcode_runtime_support.go
+++ b/destination/xcode_runtime_support.go
@@ -5,13 +5,25 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-func isIOSRuntimeSupportedByXcode(runtimeVersion *version.Version, xcodeVersion xcodeversion.Version) bool {
+func isRuntimeSupportedByXcode(runtimePlatform string, runtimeVersion *version.Version, xcodeVersion xcodeversion.Version) bool {
 	// Very simplified version of https://developer.apple.com/support/xcode/
 	// Only considering major versions for simplicity
-	var latestSupportedIOSRuntime = map[int64]int64{
-		15: 17,
-		14: 16,
-		13: 15,
+	var xcodeVersionToSupportedRuntimes = map[int64]map[string]int64{
+		15: {
+			string(IOS):     17,
+			string(TvOS):    17,
+			string(WatchOS): 10,
+		},
+		14: {
+			string(IOS):     16,
+			string(TvOS):    16,
+			string(WatchOS): 9,
+		},
+		13: {
+			string(IOS):     15,
+			string(TvOS):    15,
+			string(WatchOS): 8,
+		},
 	}
 
 	if len(runtimeVersion.Segments64()) == 0 || xcodeVersion.MajorVersion == 0 {
@@ -19,7 +31,12 @@ func isIOSRuntimeSupportedByXcode(runtimeVersion *version.Version, xcodeVersion 
 	}
 	runtimeMajorVersion := runtimeVersion.Segments64()[0]
 
-	latestSupportedMajorVersion, ok := latestSupportedIOSRuntime[xcodeVersion.MajorVersion]
+	platformToLatestSupportedVersion, ok := xcodeVersionToSupportedRuntimes[xcodeVersion.MajorVersion]
+	if !ok {
+		return true
+	}
+
+	latestSupportedMajorVersion, ok := platformToLatestSupportedVersion[runtimePlatform]
 	if !ok {
 		return true
 	}

--- a/destination/xcode_runtime_support.go
+++ b/destination/xcode_runtime_support.go
@@ -1,6 +1,11 @@
 package destination
 
-func isIOSRuntimeSupportedByXcode(runtimeMajorVersion, xcodeMajorVersion int64) bool {
+import (
+	"github.com/bitrise-io/go-xcode/v2/xcodeversion"
+	"github.com/hashicorp/go-version"
+)
+
+func isIOSRuntimeSupportedByXcode(runtimeVersion *version.Version, xcodeVersion xcodeversion.Version) bool {
 	// Very simplified version of https://developer.apple.com/support/xcode/
 	// Only considering major versions for simplicity
 	var latestSupportedIOSRuntime = map[int64]int64{
@@ -9,7 +14,12 @@ func isIOSRuntimeSupportedByXcode(runtimeMajorVersion, xcodeMajorVersion int64) 
 		13: 15,
 	}
 
-	latestSupportedMajorVersion, ok := latestSupportedIOSRuntime[runtimeMajorVersion]
+	if len(runtimeVersion.Segments64()) == 0 || xcodeVersion.MajorVersion == 0 {
+		return true
+	}
+	runtimeMajorVersion := runtimeVersion.Segments64()[0]
+
+	latestSupportedMajorVersion, ok := latestSupportedIOSRuntime[xcodeVersion.MajorVersion]
 	if !ok {
 		return true
 	}

--- a/destination/xcode_runtime_support_test.go
+++ b/destination/xcode_runtime_support_test.go
@@ -1,0 +1,54 @@
+package destination
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-xcode/v2/xcodeversion"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isRuntimeSupportedByXcode(t *testing.T) {
+	tests := []struct {
+		name            string
+		runtimePlatform string
+		runtimeVersion  *version.Version
+		xcodeVersion    xcodeversion.Version
+		want            bool
+	}{
+		{
+			name:            "iOS 16 on Xcode 15",
+			runtimePlatform: "iOS",
+			runtimeVersion:  version.Must(version.NewVersion("16.4")),
+			xcodeVersion:    xcodeversion.Version{MajorVersion: 15},
+			want:            true,
+		},
+		{
+			name:            "iOS 16 on unknown Xcode version",
+			runtimePlatform: "iOS",
+			runtimeVersion:  version.Must(version.NewVersion("16.4")),
+			xcodeVersion:    xcodeversion.Version{MajorVersion: 3}, // unknown version
+			want:            true,
+		},
+		{
+			name:            "tvOS 17 on Xcode 14",
+			runtimePlatform: "tvOS",
+			runtimeVersion:  version.Must(version.NewVersion("17")),
+			xcodeVersion:    xcodeversion.Version{MajorVersion: 14},
+			want:            false,
+		},
+		{
+			name:            "unknown platform",
+			runtimePlatform: "walletOS",
+			runtimeVersion:  version.Must(version.NewVersion("1")),
+			xcodeVersion:    xcodeversion.Version{MajorVersion: 15},
+			want:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRuntimeSupportedByXcode(tt.runtimePlatform, tt.runtimeVersion, tt.xcodeVersion)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Context

When Xcode 14.3 and Xcode 15 (beta)  is present on the same machine, requiring the `latest` (this is the default) version of the Simulator runtime, will find iOS 17 (beta). This is undesirable as the beta Simulator can be unstable or at least not officially supported by earlier Xcodes.

In practice Xcode still works with newer runtimes, at least across the same major version (despite this table: https://developer.apple.com/support/xcode/). When there are different major versions, there is some risk of not working right.

```
Input:
- xctestrun: /var/folders/69/qgnyrbkx23dbp0p6p_b6bc9m0000gn/T/test_bundle928674358/BullsEye_FullTests_iphonesimulator16.4-arm64-x86_64.xctestrun
- destination: platform=iOS Simulator,name=iPhone 12 Pro Max
- xcodebuild_options: -parallel-testing-enabled YES
- test_repetition_mode: none
- maximum_test_repetitions: 3
- relaunch_tests_for_each_repetition: false
- BITRISE_DEPLOY_DIR: /Users/vagrant/deploy
- BITRISE_TEST_RESULT_DIR: /var/folders/69/qgnyrbkx23dbp0p6p_b6bc9m0000gn/T/test_results3063414584/test_result52921623
Creating missing device...
[11:39:06] $ xcrun "simctl" "create" "iPhone 12 Pro Max" "com.apple.CoreSimulator.SimDeviceType.iPhone-12-Pro-Max" "com.apple.CoreSimulator.SimRuntime.iOS-17-0"
Simulator device:
- name: iPhone 12 Pro Max, version: 17.0, UDID: 26EC21F3-BD7E-4734-A91C-CEBD84021316, status: Shutdown
```

Integrated in a Step:
https://github.com/bitrise-steplib/bitrise-step-xcode-test-without-building/pull/9