### PR TITLE
Add support for simulator arch flag

### DIFF
--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/errorutil"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/v2/destination"
 )
 
 const (
@@ -22,7 +23,7 @@ const (
 type Manager interface {
 	LaunchWithGUI(simulatorID string) error
 	ResetLaunchServices() error
-	Boot(id string) error
+	Boot(device destination.Device) error
 	WaitForBootFinished(id string, timeout time.Duration) error
 	EnableVerboseLog(id string) error
 	CollectDiagnostics() (string, error)
@@ -105,8 +106,13 @@ func (m manager) ResetLaunchServices() error {
 }
 
 // Boot boots Simulator in headless mode
-func (m manager) Boot(id string) error {
-	cmd := m.commandFactory.Create("xcrun", []string{"simctl", "boot", id}, &command.Opts{
+func (m manager) Boot(device destination.Device) error {
+	args := []string{"simctl", "boot", device.ID}
+	if device.Arch != "" {
+		args = append(args, fmt.Sprintf("--arch=%s", device.Arch))
+	}
+
+	cmd := m.commandFactory.Create("xcrun", args, &command.Opts{
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	})

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -53,6 +53,23 @@ func Test_GivenSimulator_WhenBoot_ThenBootsTheRequestedSimulator(t *testing.T) {
 	mocks.commandFactory.AssertCalled(t, "Create", "xcrun", parameters, mock.Anything)
 }
 
+func Test_GivenSimulator_WhenBootRosetta_ThenBootsTheRequestedSimulator(t *testing.T) {
+	// Given
+	manager, mocks := createSimulatorAndMocks()
+
+	const identifier = "test-identifier"
+	parameters := []string{"simctl", "boot", identifier, "--arch=x86_64"}
+	mocks.commandFactory.On("Create", "xcrun", parameters, mock.Anything).Return(createCommand(""))
+
+	// When
+	err := manager.Boot(destination.Device{ID: identifier, Arch: "x86_64"})
+
+	// Then
+	assert.NoError(t, err)
+
+	mocks.commandFactory.AssertCalled(t, "Create", "xcrun", parameters, mock.Anything)
+}
+
 func Test_GivenSimulator_WhenWaitForBootFinishedTimesOut_ThenFails(t *testing.T) {
 	// Given
 	manager, mocks := createSimulatorAndMocks()

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/v2/destination"
 	mockcommand "github.com/bitrise-io/go-xcode/v2/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -44,7 +45,7 @@ func Test_GivenSimulator_WhenBoot_ThenBootsTheRequestedSimulator(t *testing.T) {
 	mocks.commandFactory.On("Create", "xcrun", parameters, mock.Anything).Return(createCommand(""))
 
 	// When
-	err := manager.Boot(identifier)
+	err := manager.Boot(destination.Device{ID: identifier})
 
 	// Then
 	assert.NoError(t, err)


### PR DESCRIPTION
### Context

Add arch flag to Simulator when booting, this allows booting Simulator in Rosetta mode.