### PR TITLE
Fix workspace settings key not found handling

### DIFF
--- a/xcodeproject/xcodeproj/schemes.go
+++ b/xcodeproject/xcodeproj/schemes.go
@@ -227,6 +227,10 @@ func (p XcodeProj) isAutocreateSchemesEnabled() (bool, error) {
 
 	autoCreate, err := settings.Bool("IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded")
 	if err != nil {
+		if serialized.IsKeyNotFoundError(err) {
+			// By default 'Autocreate Schemes' is enabled
+			return true, nil
+		}
 		return false, err
 	}
 

--- a/xcodeproject/xcodeproj/schemes_test.go
+++ b/xcodeproject/xcodeproj/schemes_test.go
@@ -24,6 +24,24 @@ func Test_GivenNewlyGeneratedXcodeProject_WhenListingSchemes_ThenReturnsTheDefau
 	require.Equal(t, true, schemes[0].IsShared)
 }
 
+func Test_GivenNewlyGeneratedXcodeProjectWithWorkspaceSettings_WhenListingSchemes_ThenReturnsTheDefaultScheme(t *testing.T) {
+	xcodeProjectPath := testhelper.NewlyGeneratedXcodeProjectPath(t)
+
+	worksaceSettingsPth := filepath.Join(xcodeProjectPath, "project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings")
+	require.NoError(t, fileutil.WriteStringToFile(worksaceSettingsPth, workspaceSettingsWithBuildSystemTypeOriginalContent))
+
+	proj, err := Open(xcodeProjectPath)
+	require.NoError(t, err)
+
+	schemes, err := proj.Schemes()
+	require.NoError(t, err)
+
+	expectedSchemeName := "ios-sample"
+	require.Equal(t, 1, len(schemes))
+	require.Equal(t, expectedSchemeName, schemes[0].Name)
+	require.Equal(t, true, schemes[0].IsShared)
+}
+
 func Test_GivenNewlyGeneratedXcodeProjectWithUserDataGitignored_WhenListingSchemes_ThenReturnsTheDefaultScheme(t *testing.T) {
 	xcodeProjectPath := testhelper.NewlyGeneratedXcodeProjectPath(t)
 
@@ -86,6 +104,16 @@ const workspaceSettingsWithAutocreateSchemesDisabledContent = `<?xml version="1.
 <dict>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
+</dict>
+</plist>
+`
+
+const workspaceSettingsWithBuildSystemTypeOriginalContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
 </dict>
 </plist>
 `

--- a/xcodeproject/xcworkspace/schemes.go
+++ b/xcodeproject/xcworkspace/schemes.go
@@ -184,6 +184,10 @@ func (w Workspace) isAutocreateSchemesEnabled() (bool, error) {
 
 	autoCreate, err := settings.Bool("IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded")
 	if err != nil {
+		if serialized.IsKeyNotFoundError(err) {
+			// By default 'Autocreate Schemes' is enabled
+			return true, nil
+		}
 		return false, err
 	}
 

--- a/xcodeproject/xcworkspace/schemes_test.go
+++ b/xcodeproject/xcworkspace/schemes_test.go
@@ -30,6 +30,28 @@ func Test_GivenNewlyGeneratedWorkspace_WhenListingSchemes_ThenReturnsTheDefaultS
 	require.Equal(t, true, actualSchemes[0].IsShared)
 }
 
+func Test_GivenNewlyGeneratedWorkspaceWithWorkspaceSettings_WhenListingSchemes_ThenReturnsTheDefaultScheme(t *testing.T) {
+	xcodeWorkspacePath := testhelper.NewlyGeneratedXcodeWorkspacePath(t)
+	workspace, err := Open(xcodeWorkspacePath)
+	require.NoError(t, err)
+
+	worksaceSettingsPth := filepath.Join(xcodeWorkspacePath, "xcshareddata/WorkspaceSettings.xcsettings")
+	require.NoError(t, fileutil.WriteStringToFile(worksaceSettingsPth, workspaceSettingsWithBuildSystemTypeOriginalContent))
+
+	schemesByContainer, err := workspace.Schemes()
+	require.NoError(t, err)
+
+	expectedSchemeName := "ios-sample"
+	var actualSchemes []xcscheme.Scheme
+	for _, schemes := range schemesByContainer {
+		actualSchemes = append(actualSchemes, schemes...)
+	}
+
+	require.Equal(t, 1, len(actualSchemes))
+	require.Equal(t, expectedSchemeName, actualSchemes[0].Name)
+	require.Equal(t, true, actualSchemes[0].IsShared)
+}
+
 func Test_GivenNewlyGeneratedWorkspaceWithAutocreateSchemesDisabled_WhenListingSchemes_ThenReturnsError(t *testing.T) {
 	xcodeWorkspacePath := testhelper.NewlyGeneratedXcodeWorkspacePath(t)
 
@@ -54,6 +76,16 @@ const workspaceSettingsWithAutocreateSchemesDisabledContent = `<?xml version="1.
 <dict>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
+</dict>
+</plist>
+`
+
+const workspaceSettingsWithBuildSystemTypeOriginalContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
 </dict>
 </plist>
 `


### PR DESCRIPTION
This PR fixes an issue with the new Xcode scheme listing.
When the logic founds a workspace setting file, but the `IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded` key doesn't present in it, the function failed with:

```
listing schemes in Xcode workspace at <workspace_path>.xcworkspace failed: key: string("IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded") not found in: serialized.Object(serialized.Object{"BuildSystemType":"Original"})
```

This shouldn't happen, since the Autocreate schemes option is enabled by default.