### PR TITLE
Add visionOS Simulator as platform

### DIFF
--- a/destination/destination.go
+++ b/destination/destination.go
@@ -16,6 +16,7 @@ const (
 // Platform ...
 type Platform string
 
+// Platforms ...
 const (
 	MacOS             Platform = "macOS"
 	IOS               Platform = "iOS"

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -13,7 +13,7 @@ const (
 	archKey            = "arch"
 )
 
-//revive:disable:exported
+//revive:disable-next-line:exported
 type Platform string
 
 const (
@@ -32,7 +32,7 @@ const (
 // Specifier is the parsed destination specifier
 type Specifier map[string]string
 
-//revive:disable:exported
+//revive:disable-next-line:exported
 func NewSpecifier(destination string) (Specifier, error) {
 	specifier := Specifier{}
 
@@ -63,17 +63,17 @@ func (s Specifier) Platform() (Platform, bool) {
 	return Platform(s[platformKey]), false
 }
 
-//revive:disable:exported
+//revive:disable-next-line:exported
 func (s Specifier) Name() string {
 	return s[nameKey]
 }
 
-//revive:disable:exported
+//revive:disable-next-line:exported
 func (s Specifier) OS() string {
 	return s[osKey]
 }
 
-//revive:disable:exported
+//revive:disable-next-line:exported
 func (s Specifier) Arch() string {
 	return s[archKey]
 }

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -13,7 +13,7 @@ const (
 	archKey            = "arch"
 )
 
-//revive:disable-next-line:exported
+// Platform ...
 type Platform string
 
 const (
@@ -29,10 +29,10 @@ const (
 	VisionOSSimulator Platform = "visionOS Simulator"
 )
 
-// Specifier is the parsed destination specifier
+// Specifier ...
 type Specifier map[string]string
 
-//revive:disable-next-line:exported
+// NewSpecifier ...
 func NewSpecifier(destination string) (Specifier, error) {
 	specifier := Specifier{}
 
@@ -63,17 +63,17 @@ func (s Specifier) Platform() (Platform, bool) {
 	return Platform(s[platformKey]), false
 }
 
-//revive:disable-next-line:exported
+// Name ...
 func (s Specifier) Name() string {
 	return s[nameKey]
 }
 
-//revive:disable-next-line:exported
+// OS ...
 func (s Specifier) OS() string {
 	return s[osKey]
 }
 
-//revive:disable-next-line:exported
+// Arch ...
 func (s Specifier) Arch() string {
 	return s[archKey]
 }

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -13,6 +13,7 @@ const (
 	archKey            = "arch"
 )
 
+//revive:disable:exported
 type Platform string
 
 const (
@@ -24,13 +25,14 @@ const (
 	TvOS              Platform = "tvOS"
 	TvOSSimulator     Platform = "tvOS Simulator"
 	DriverKit         Platform = "DriverKit"
+	VisionOS          Platform = "visionOS"
 	VisionOSSimulator Platform = "visionOS Simulator"
 )
 
-// Specifier ...
+// Specifier is the parsed destination specifier
 type Specifier map[string]string
 
-// NewSpecifier ...
+//revive:disable:exported
 func NewSpecifier(destination string) (Specifier, error) {
 	specifier := Specifier{}
 
@@ -51,7 +53,7 @@ func NewSpecifier(destination string) (Specifier, error) {
 	return specifier, nil
 }
 
-// Platform ...
+// Platform returns the platform part of the specifier and true if it's the generic platform
 func (s Specifier) Platform() (Platform, bool) {
 	p, ok := s[genericPlatformKey]
 	if ok {
@@ -61,17 +63,17 @@ func (s Specifier) Platform() (Platform, bool) {
 	return Platform(s[platformKey]), false
 }
 
-// Name ...
+//revive:disable:exported
 func (s Specifier) Name() string {
 	return s[nameKey]
 }
 
-// OS ...
+//revive:disable:exported
 func (s Specifier) OS() string {
 	return s[osKey]
 }
 
-// Arch ...
+//revive:disable:exported
 func (s Specifier) Arch() string {
 	return s[archKey]
 }

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -13,19 +13,18 @@ const (
 	archKey            = "arch"
 )
 
-// Platform ...
 type Platform string
 
-// Platforms ...
 const (
-	MacOS            Platform = "macOS"
-	IOS              Platform = "iOS"
-	IOSSimulator     Platform = "iOS Simulator"
-	WatchOS          Platform = "watchOS"
-	WatchOSSimulator Platform = "watchOS Simulator"
-	TvOS             Platform = "tvOS"
-	TvOSSimulator    Platform = "tvOS Simulator"
-	DriverKit        Platform = "DriverKit"
+	MacOS             Platform = "macOS"
+	IOS               Platform = "iOS"
+	IOSSimulator      Platform = "iOS Simulator"
+	WatchOS           Platform = "watchOS"
+	WatchOSSimulator  Platform = "watchOS Simulator"
+	TvOS              Platform = "tvOS"
+	TvOSSimulator     Platform = "tvOS Simulator"
+	DriverKit         Platform = "DriverKit"
+	VisionOSSimulator Platform = "visionOS Simulator"
 )
 
 // Specifier ...

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -306,8 +306,8 @@ func (d deviceFinder) runtimeForPlatformVersion(wantedPlatform, wantedVersion st
 			continue
 		}
 
-		// simctl reports visionOS as xrOS
-		if runtime.Platform == "xrOS" && wantedPlatform == string(VisionOS) {
+		// simctl reports visionOS as xrOS (as of Xcode 15.1 Beta 3)
+		if (runtime.Platform == "xrOS" || runtime.Platform == "visionOS") && wantedPlatform == string(VisionOS) {
 			runtimesOfPlatform = append(runtimesOfPlatform, runtime)
 			continue
 		}

--- a/destination/parse.go
+++ b/destination/parse.go
@@ -303,7 +303,12 @@ func (d deviceFinder) runtimeForPlatformVersion(wantedPlatform, wantedVersion st
 
 		if runtime.Platform != "" && runtime.Platform == string(wantedPlatform) {
 			runtimesOfPlatform = append(runtimesOfPlatform, runtime)
+			continue
+		}
 
+		// simctl reports visionOS as xrOS
+		if runtime.Platform == "xrOS" && wantedPlatform == string(VisionOS) {
+			runtimesOfPlatform = append(runtimesOfPlatform, runtime)
 			continue
 		}
 
@@ -331,6 +336,9 @@ func (d deviceFinder) runtimeForPlatformVersion(wantedPlatform, wantedVersion st
 		}
 		if wantedPlatform == string(TvOS) {
 			return deviceRuntime{}, fmt.Errorf("the platform %s is unavailable. Did you mean %s?", wantedPlatform, TvOSSimulator)
+		}
+		if wantedPlatform == string(VisionOS) {
+			return deviceRuntime{}, fmt.Errorf("the platform %s is unavailable. Did you mean %s?", wantedPlatform, VisionOSSimulator)
 		}
 		return deviceRuntime{}, fmt.Errorf("no runtime installed for platform %s", wantedPlatform)
 	}

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -143,7 +143,6 @@ func (m manager) WaitForBootFinished(id string, timeout time.Duration) error {
 
 	launchDoneCh := make(chan error, 1)
 	doWait := func() {
-		time.Sleep(5 * time.Second)
 		waitCmd := m.commandFactory.Create("xcrun", []string{"simctl", "launch", id, "com.apple.Preferences"}, &command.Opts{
 			Stdout: os.Stderr,
 			Stderr: os.Stderr,

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -143,6 +143,7 @@ func (m manager) WaitForBootFinished(id string, timeout time.Duration) error {
 
 	launchDoneCh := make(chan error, 1)
 	doWait := func() {
+		time.Sleep(5 * time.Second)
 		waitCmd := m.commandFactory.Create("xcrun", []string{"simctl", "launch", id, "com.apple.Preferences"}, &command.Opts{
 			Stdout: os.Stderr,
 			Stderr: os.Stderr,


### PR DESCRIPTION
Add support for handling `visionOS` destinations, devices, platform lookups, etc.

Tested in https://github.com/bitrise-steplib/bitrise-step-xcode-start-simulator/pull/10