### PR TITLE
Do not log sensitive command params

### DIFF
--- a/autocodesign/devportalclient/spaceship/spaceship.go
+++ b/autocodesign/devportalclient/spaceship/spaceship.go
@@ -103,6 +103,7 @@ func runSpaceshipCommand(cmd spaceshipCommand) (string, error) {
 	log.Debugf("$ %s", cmd.printableCommandArgs)
 	output, err := cmd.command.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
+		// Omitting err from log, to avoid logging plaintext password present in command params
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
 			return "", fmt.Errorf("spaceship command exited with status %d, output: %s", exitError.ProcessState.ExitCode(), output)

--- a/autocodesign/devportalclient/spaceship/spaceship.go
+++ b/autocodesign/devportalclient/spaceship/spaceship.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -102,7 +103,12 @@ func runSpaceshipCommand(cmd spaceshipCommand) (string, error) {
 	log.Debugf("$ %s", cmd.printableCommandArgs)
 	output, err := cmd.command.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("spaceship command failed, output: %s, error: %v", output, err)
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return "", fmt.Errorf("spaceship command exited with status %d, output: %s", exitError.ProcessState.ExitCode(), output)
+		}
+
+		return "", fmt.Errorf("spaceship command failed with output: %s", output)
 	}
 
 	jsonRegexp := regexp.MustCompile(`(?m)^\{.*\}$`)


### PR DESCRIPTION
We logged potential secrets due to using the v2/command package: https://github.com/bitrise-io/go-utils/blob/921272de13f5811b3a22dcd883459ea472c7f461/command/command.go#L172.

```Apple ID authentication failed: The input stream is exhausted., error: command failed with exit status 1 (bundle "exec" "ruby" "main.rb" "--subcommand" "list_dev_certs" "--username" "myemail@gmail.com" "--password" "my-readable-password" "--session" ```

Fixed this by omitting the error returned by v2/command.