### PR TITLE
Set current team id after spaceship login on the spaceship client

### DIFF
--- a/autocodesign/devportalclient/spaceship/spaceship.go
+++ b/autocodesign/devportalclient/spaceship/spaceship.go
@@ -55,7 +55,7 @@ func NewClient(authConfig appleauth.AppleID, teamID string, cmdFactory ruby.Comm
 		return nil, fmt.Errorf("spaceship command failed: %s", err)
 	}
 
-	fmt.Println("current team id:", currentTeamID)
+	log.Debugf("current team id: %s", currentTeamID)
 
 	c.teamID = currentTeamID
 

--- a/autocodesign/devportalclient/spaceship/spaceship.go
+++ b/autocodesign/devportalclient/spaceship/spaceship.go
@@ -50,10 +50,14 @@ func NewClient(authConfig appleauth.AppleID, teamID string, cmdFactory ruby.Comm
 		cmdFactory: cmdFactory,
 	}
 
-	_, err = c.runSpaceshipCommand("login")
+	teamID, err = c.runSpaceshipCommand("login")
 	if err != nil {
 		return nil, fmt.Errorf("running command failed with error: %s", err)
 	}
+
+	fmt.Println("current team id:", teamID)
+
+	c.teamID = teamID
 
 	return c, nil
 }

--- a/autocodesign/devportalclient/spaceship/spaceship/main.rb
+++ b/autocodesign/devportalclient/spaceship/spaceship/main.rb
@@ -27,9 +27,12 @@ begin
 
   FastlaneCore::Globals.verbose = true
 
+  result = '{}'
+
   if options[:subcommand] == 'login'
     begin
-      Portal::AuthClient.login(options[:username], options[:password], options[:session], options[:team_id])
+      team_id = Portal::AuthClient.login(options[:username], options[:password], options[:session], options[:team_id])
+      result = team_id
     rescue => e
       puts "\nApple ID authentication failed: #{e}"
       exit(1)
@@ -37,7 +40,6 @@ begin
   else
     Portal::AuthClient.restore_from_session(options[:username], options[:team_id])
 
-    result = '{}'
     case options[:subcommand]
     when 'list_dev_certs'
       client = CertificateHelper.new

--- a/autocodesign/devportalclient/spaceship/spaceship/portal/auth_client.rb
+++ b/autocodesign/devportalclient/spaceship/spaceship/portal/auth_client.rb
@@ -17,6 +17,8 @@ module Portal
       end
 
       client.store_cookie
+
+      client.team_id
     end
 
     def self.restore_from_session(username, team_id)


### PR DESCRIPTION
This PR fixes a regression introduced in this recent PR: https://github.com/bitrise-io/go-xcode/pull/226.

Spaceship login automatically sets the Apple developer team on the spaceship client when it is not specified explicitly. The logic selects the single Apple developer team to which the given Apple developer account belongs, or to the first team when it belongs to multiple teams.

After the first spaceship login, we don't do further logins, just restore a client. On this restored client the automatic team selection is not happening, so we need to do it manually, to avoid this issue:

```
Apple provided the following error info: Please select a team.
```