### PR TITLE
Add support for automatic signing style

### DIFF
--- a/exportoptionsgenerator/certificates.go
+++ b/exportoptionsgenerator/certificates.go
@@ -1,0 +1,21 @@
+package exportoptionsgenerator
+
+import "github.com/bitrise-io/go-xcode/certificateutil"
+
+// CodesignIdentityProvider can list certificate infos.
+type CodesignIdentityProvider interface {
+	ListCodesignIdentities() ([]certificateutil.CertificateInfoModel, error)
+}
+
+// LocalCodesignIdentityProvider ...
+type LocalCodesignIdentityProvider struct{}
+
+// ListCodesignIdentities ...
+func (p LocalCodesignIdentityProvider) ListCodesignIdentities() ([]certificateutil.CertificateInfoModel, error) {
+	certs, err := certificateutil.InstalledCodesigningCertificateInfos()
+	if err != nil {
+		return nil, err
+	}
+	certInfo := certificateutil.FilterValidCertificateInfos(certs)
+	return append(certInfo.ValidCertificates, certInfo.DuplicatedCertificates...), nil
+}

--- a/exportoptionsgenerator/exportoptionsgenerator.go
+++ b/exportoptionsgenerator/exportoptionsgenerator.go
@@ -77,11 +77,6 @@ func (g ExportOptionsGenerator) GenerateApplicationExportOptions(
 		exportOpts = disableManagedBuildNumberFromXcode13(exportOpts)
 	}
 
-	if xcodeMajorVersion >= 15 {
-		exportOpts = addSigningStyle(exportOpts, codeSigningStyle)
-		exportOpts = addDestinationExport(exportOpts)
-	}
-
 	if codeSigningStyle == exportoptions.SigningStyleAutomatic {
 		exportOpts = addTeamID(exportOpts, teamID)
 	} else {
@@ -381,18 +376,6 @@ func addSigningStyle(exportOpts exportoptions.ExportOptions, signingStyle export
 		return options
 	case exportoptions.NonAppStoreOptionsModel:
 		options.SigningStyle = signingStyle
-		return options
-	}
-	return exportOpts
-}
-
-func addDestinationExport(exportOpts exportoptions.ExportOptions) exportoptions.ExportOptions {
-	switch options := exportOpts.(type) {
-	case exportoptions.AppStoreOptionsModel:
-		options.Destination = exportoptions.DestinationExport
-		return options
-	case exportoptions.NonAppStoreOptionsModel:
-		options.Destination = exportoptions.DestinationExport
 		return options
 	}
 	return exportOpts

--- a/exportoptionsgenerator/exportoptionsgenerator.go
+++ b/exportoptionsgenerator/exportoptionsgenerator.go
@@ -2,15 +2,8 @@ package exportoptionsgenerator
 
 import (
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-
-	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/sliceutil"
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/bitrise-io/go-xcode/certificateutil"
 	"github.com/bitrise-io/go-xcode/export"
 	"github.com/bitrise-io/go-xcode/exportoptions"
 	"github.com/bitrise-io/go-xcode/plistutil"
@@ -18,12 +11,18 @@ import (
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 	"github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj"
 	"github.com/bitrise-io/go-xcode/xcodeproject/xcscheme"
+	"os"
 )
 
-// const for AppClipProductType and manualSigningStyle
 const (
 	AppClipProductType = "com.apple.product-type.application.on-demand-install-capable"
-	manualSigningStyle = "manual"
+)
+
+type SigningStyle string
+
+const (
+	ManualSigningStyle    = "manual"
+	AutomaticSigningStyle = "automatic"
 )
 
 // ExportOptionsGenerator generates an exportOptions.plist file.
@@ -53,14 +52,60 @@ func New(xcodeProj *xcodeproj.XcodeProj, scheme *xcscheme.Scheme, configuration 
 }
 
 // GenerateApplicationExportOptions generates exportOptions for an application export.
-func (g ExportOptionsGenerator) GenerateApplicationExportOptions(exportMethod exportoptions.Method, containerEnvironment string, teamID string, uploadBitcode bool, compileBitcode bool, xcodeManaged bool,
-	xcodeMajorVersion int64) (exportoptions.ExportOptions, error) {
-
-	g.logger.TDebugf("Generating application export options for: %s", exportMethod)
-
-	mainTarget, err := ArchivableApplicationTarget(g.xcodeProj, g.scheme)
+func (g ExportOptionsGenerator) GenerateApplicationExportOptions(
+	exportMethod exportoptions.Method,
+	containerEnvironment string,
+	teamID string,
+	uploadBitcode bool,
+	compileBitcode bool,
+	archivedWithXcodeManagedProfiles bool,
+	codeSigningStyle SigningStyle,
+	xcodeMajorVersion int64,
+) (exportoptions.ExportOptions, error) {
+	mainTargetBundleID, entitlementsByBundleID, err := g.applicationTargetsAndEntitlements(exportMethod)
 	if err != nil {
 		return nil, err
+	}
+
+	iCloudContainerEnvironment, err := determineIcloudContainerEnvironment(containerEnvironment, entitlementsByBundleID, exportMethod, xcodeMajorVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	exportOpts := generateBaseExportOptions(exportMethod, uploadBitcode, compileBitcode, iCloudContainerEnvironment)
+	if xcodeMajorVersion >= 12 {
+		exportOpts = addDistributionBundleIdentifierFromXcode12(exportOpts, mainTargetBundleID)
+	}
+	if xcodeMajorVersion >= 13 {
+		exportOpts = disableManagedBuildNumberFromXcode13(exportOpts)
+	}
+
+	if xcodeMajorVersion >= 15 {
+		exportOpts = addSigningStyle(exportOpts, codeSigningStyle)
+		exportOpts = addDestinationExport(exportOpts)
+	}
+
+	if codeSigningStyle == AutomaticSigningStyle {
+		exportOpts = addTeamID(exportOpts, teamID)
+	} else {
+		codeSignGroup, err := g.determineCodesignGroup(entitlementsByBundleID, exportMethod, teamID, archivedWithXcodeManagedProfiles)
+		if err != nil {
+			return nil, err
+		}
+		if codeSignGroup == nil {
+			return exportOpts, nil
+		}
+
+		exportOpts = addManualSigningFields(exportOpts, codeSignGroup, archivedWithXcodeManagedProfiles, g.logger)
+	}
+
+	return exportOpts, nil
+}
+
+func (g ExportOptionsGenerator) applicationTargetsAndEntitlements(exportMethod exportoptions.Method) (string, map[string]plistutil.PlistData, error) {
+	mainTarget, err := ArchivableApplicationTarget(g.xcodeProj, g.scheme)
+	if err != nil {
+		return "", nil, err
 	}
 
 	dependentTargets := filterApplicationBundleTargets(
@@ -74,12 +119,12 @@ func (g ExportOptionsGenerator) GenerateApplicationExportOptions(exportMethod ex
 	for i, target := range targets {
 		bundleID, err := g.targetInfoProvider.TargetBundleID(target.Name, g.configuration)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get target (%s) bundle id: %s", target.Name, err)
+			return "", nil, fmt.Errorf("failed to get target (%s) bundle id: %s", target.Name, err)
 		}
 
 		entitlements, err := g.targetInfoProvider.TargetCodeSignEntitlements(target.Name, g.configuration)
 		if err != nil && !serialized.IsKeyNotFoundError(err) {
-			return nil, fmt.Errorf("failed to get target (%s) bundle id: %s", target.Name, err)
+			return "", nil, fmt.Errorf("failed to get target (%s) bundle id: %s", target.Name, err)
 		}
 
 		entitlementsByBundleID[bundleID] = plistutil.PlistData(entitlements)
@@ -89,177 +134,7 @@ func (g ExportOptionsGenerator) GenerateApplicationExportOptions(exportMethod ex
 		}
 	}
 
-	g.logger.TDebugf("Generated application export options plist for: %s", exportMethod)
-
-	return g.generateExportOptions(exportMethod, containerEnvironment, teamID, uploadBitcode, compileBitcode,
-		xcodeManaged, entitlementsByBundleID, xcodeMajorVersion, mainTargetBundleID)
-}
-
-// TargetInfoProvider can determine a target's bundle id and codesign entitlements.
-type TargetInfoProvider interface {
-	TargetBundleID(target, configuration string) (string, error)
-	TargetCodeSignEntitlements(target, configuration string) (serialized.Object, error)
-}
-
-// XcodebuildTargetInfoProvider implements TargetInfoProvider.
-type XcodebuildTargetInfoProvider struct {
-	xcodeProj *xcodeproj.XcodeProj
-}
-
-// TargetBundleID ...
-func (b XcodebuildTargetInfoProvider) TargetBundleID(target, configuration string) (string, error) {
-	return b.xcodeProj.TargetBundleID(target, configuration)
-}
-
-// TargetCodeSignEntitlements ...
-func (b XcodebuildTargetInfoProvider) TargetCodeSignEntitlements(target, configuration string) (serialized.Object, error) {
-	return b.xcodeProj.TargetCodeSignEntitlements(target, configuration)
-}
-
-// ArchivableApplicationTarget locate archivable app target from a given project and scheme
-func ArchivableApplicationTarget(xcodeProj *xcodeproj.XcodeProj, scheme *xcscheme.Scheme) (*xcodeproj.Target, error) {
-	archiveEntry, ok := scheme.AppBuildActionEntry()
-	if !ok {
-		return nil, fmt.Errorf("archivable entry not found in project: %s for scheme: %s", xcodeProj.Path, scheme.Name)
-	}
-
-	mainTarget, ok := xcodeProj.Proj.Target(archiveEntry.BuildableReference.BlueprintIdentifier)
-	if !ok {
-		return nil, fmt.Errorf("target not found: %s", archiveEntry.BuildableReference.BlueprintIdentifier)
-	}
-
-	return &mainTarget, nil
-}
-
-func filterApplicationBundleTargets(targets []xcodeproj.Target, exportMethod exportoptions.Method) (filteredTargets []xcodeproj.Target) {
-	fmt.Printf("Filtering %v application bundle targets", len(targets))
-
-	for _, target := range targets {
-		if !target.IsExecutableProduct() {
-			continue
-		}
-
-		// App store exports contain App Clip too. App Clip provisioning profile has to be included in export options:
-		// ..
-		// <key>provisioningProfiles</key>
-		// <dict>
-		// 	<key>io.bundle.id</key>
-		// 	<string>Development Application Profile</string>
-		// 	<key>io.bundle.id.AppClipID</key>
-		// 	<string>Development App Clip Profile</string>
-		// </dict>
-		// ..,
-		if exportMethod != exportoptions.MethodAppStore && target.IsAppClipProduct() {
-			continue
-		}
-
-		filteredTargets = append(filteredTargets, target)
-	}
-
-	fmt.Printf("Found %v application bundle targets", len(filteredTargets))
-
-	return
-}
-
-// projectUsesCloudKit determines whether the project uses any CloudKit capability or not.
-func projectUsesCloudKit(bundleIDEntitlementsMap map[string]plistutil.PlistData) bool {
-	fmt.Printf("Checking if project uses CloudKit")
-
-	for _, entitlements := range bundleIDEntitlementsMap {
-		if entitlements == nil {
-			continue
-		}
-
-		services, ok := entitlements.GetStringArray("com.apple.developer.icloud-services")
-		if !ok {
-			continue
-		}
-
-		if sliceutil.IsStringInSlice("CloudKit", services) || sliceutil.IsStringInSlice("CloudDocuments", services) {
-			fmt.Printf("Project uses CloudKit")
-
-			return true
-		}
-	}
-	return false
-}
-
-// determineIcloudContainerEnvironment calculates the value of iCloudContainerEnvironment.
-func determineIcloudContainerEnvironment(desiredIcloudContainerEnvironment string, bundleIDEntitlementsMap map[string]plistutil.PlistData, exportMethod exportoptions.Method, xcodeMajorVersion int64) (string, error) {
-	// iCloudContainerEnvironment: If the app is using CloudKit, this configures the "com.apple.developer.icloud-container-environment" entitlement.
-	// Available options vary depending on the type of provisioning profile used, but may include: Development and Production.
-	usesCloudKit := projectUsesCloudKit(bundleIDEntitlementsMap)
-	if !usesCloudKit {
-		return "", nil
-	}
-
-	// From Xcode 9 iCloudContainerEnvironment is required for every export method, before that version only for non app-store exports.
-	if xcodeMajorVersion < 9 && exportMethod == exportoptions.MethodAppStore {
-		return "", nil
-	}
-
-	if exportMethod == exportoptions.MethodAppStore {
-		return "Production", nil
-	}
-
-	if desiredIcloudContainerEnvironment == "" {
-		return "", fmt.Errorf("Your project uses CloudKit but \"iCloud container environment\" input not specified.\n"+
-			"Export method is: %s (For app-store export method Production container environment is implied.)", exportMethod)
-	}
-
-	return desiredIcloudContainerEnvironment, nil
-}
-
-// generateBaseExportOptions creates a default exportOptions introudced in Xcode 7.
-func generateBaseExportOptions(exportMethod exportoptions.Method, cfgUploadBitcode, cfgCompileBitcode bool, iCloudContainerEnvironment string) exportoptions.ExportOptions {
-	if exportMethod == exportoptions.MethodAppStore {
-		appStoreOptions := exportoptions.NewAppStoreOptions()
-		appStoreOptions.UploadBitcode = cfgUploadBitcode
-		if iCloudContainerEnvironment != "" {
-			appStoreOptions.ICloudContainerEnvironment = exportoptions.ICloudContainerEnvironment(iCloudContainerEnvironment)
-		}
-		return appStoreOptions
-	}
-
-	nonAppStoreOptions := exportoptions.NewNonAppStoreOptions(exportMethod)
-	nonAppStoreOptions.CompileBitcode = cfgCompileBitcode
-
-	if iCloudContainerEnvironment != "" {
-		nonAppStoreOptions.ICloudContainerEnvironment = exportoptions.ICloudContainerEnvironment(iCloudContainerEnvironment)
-	}
-
-	return nonAppStoreOptions
-}
-
-// CodesignIdentityProvider can list certificate infos.
-type CodesignIdentityProvider interface {
-	ListCodesignIdentities() ([]certificateutil.CertificateInfoModel, error)
-}
-
-// LocalCodesignIdentityProvider ...
-type LocalCodesignIdentityProvider struct{}
-
-// ListCodesignIdentities ...
-func (p LocalCodesignIdentityProvider) ListCodesignIdentities() ([]certificateutil.CertificateInfoModel, error) {
-	certs, err := certificateutil.InstalledCodesigningCertificateInfos()
-	if err != nil {
-		return nil, err
-	}
-	certInfo := certificateutil.FilterValidCertificateInfos(certs)
-	return append(certInfo.ValidCertificates, certInfo.DuplicatedCertificates...), nil
-}
-
-// ProvisioningProfileProvider can list profile infos.
-type ProvisioningProfileProvider interface {
-	ListProvisioningProfiles() ([]profileutil.ProvisioningProfileInfoModel, error)
-}
-
-// LocalProvisioningProfileProvider ...
-type LocalProvisioningProfileProvider struct{}
-
-// ListProvisioningProfiles ...
-func (p LocalProvisioningProfileProvider) ListProvisioningProfiles() ([]profileutil.ProvisioningProfileInfoModel, error) {
-	return profileutil.InstalledProvisioningProfileInfos(profileutil.ProfileTypeIos)
+	return mainTargetBundleID, entitlementsByBundleID, nil
 }
 
 // determineCodesignGroup finds the best codesign group (certificate + profiles)
@@ -358,7 +233,7 @@ func (g ExportOptionsGenerator) determineCodesignGroup(bundleIDEntitlementsMap m
 
 	defaultProfileURL := os.Getenv("BITRISE_DEFAULT_PROVISION_URL")
 	if teamID == "" && defaultProfileURL != "" {
-		if defaultProfile, err := g.GetDefaultProvisioningProfile(); err == nil {
+		if defaultProfile, err := g.profileProvider.GetDefaultProvisioningProfile(); err == nil {
 			g.logger.Debugf("\ndefault profile: %v\n", defaultProfile)
 			filteredCodeSignGroups := export.FilterSelectableCodeSignGroups(codeSignGroups,
 				export.CreateExcludeProfileNameSelectableCodeSignGroupFilter(defaultProfile.Name))
@@ -408,6 +283,76 @@ func (g ExportOptionsGenerator) determineCodesignGroup(bundleIDEntitlementsMap m
 	return &iosCodeSignGroups[0], nil
 }
 
+// determineIcloudContainerEnvironment calculates the value of iCloudContainerEnvironment.
+func determineIcloudContainerEnvironment(desiredIcloudContainerEnvironment string, bundleIDEntitlementsMap map[string]plistutil.PlistData, exportMethod exportoptions.Method, xcodeMajorVersion int64) (string, error) {
+	// iCloudContainerEnvironment: If the app is using CloudKit, this configures the "com.apple.developer.icloud-container-environment" entitlement.
+	// Available options vary depending on the type of provisioning profile used, but may include: Development and Production.
+	usesCloudKit := projectUsesCloudKit(bundleIDEntitlementsMap)
+	if !usesCloudKit {
+		return "", nil
+	}
+
+	// From Xcode 9 iCloudContainerEnvironment is required for every export method, before that version only for non app-store exports.
+	if xcodeMajorVersion < 9 && exportMethod == exportoptions.MethodAppStore {
+		return "", nil
+	}
+
+	if exportMethod == exportoptions.MethodAppStore {
+		return "Production", nil
+	}
+
+	if desiredIcloudContainerEnvironment == "" {
+		return "", fmt.Errorf("Your project uses CloudKit but \"iCloud container environment\" input not specified.\n"+
+			"Export method is: %s (For app-store export method Production container environment is implied.)", exportMethod)
+	}
+
+	return desiredIcloudContainerEnvironment, nil
+}
+
+// projectUsesCloudKit determines whether the project uses any CloudKit capability or not.
+func projectUsesCloudKit(bundleIDEntitlementsMap map[string]plistutil.PlistData) bool {
+	fmt.Printf("Checking if project uses CloudKit")
+
+	for _, entitlements := range bundleIDEntitlementsMap {
+		if entitlements == nil {
+			continue
+		}
+
+		services, ok := entitlements.GetStringArray("com.apple.developer.icloud-services")
+		if !ok {
+			continue
+		}
+
+		if sliceutil.IsStringInSlice("CloudKit", services) || sliceutil.IsStringInSlice("CloudDocuments", services) {
+			fmt.Printf("Project uses CloudKit")
+
+			return true
+		}
+	}
+	return false
+}
+
+// generateBaseExportOptions creates a default exportOptions introudced in Xcode 7.
+func generateBaseExportOptions(exportMethod exportoptions.Method, cfgUploadBitcode, cfgCompileBitcode bool, iCloudContainerEnvironment string) exportoptions.ExportOptions {
+	if exportMethod == exportoptions.MethodAppStore {
+		appStoreOptions := exportoptions.NewAppStoreOptions()
+		appStoreOptions.UploadBitcode = cfgUploadBitcode
+		if iCloudContainerEnvironment != "" {
+			appStoreOptions.ICloudContainerEnvironment = exportoptions.ICloudContainerEnvironment(iCloudContainerEnvironment)
+		}
+		return appStoreOptions
+	}
+
+	nonAppStoreOptions := exportoptions.NewNonAppStoreOptions(exportMethod)
+	nonAppStoreOptions.CompileBitcode = cfgCompileBitcode
+
+	if iCloudContainerEnvironment != "" {
+		nonAppStoreOptions.ICloudContainerEnvironment = exportoptions.ICloudContainerEnvironment(iCloudContainerEnvironment)
+	}
+
+	return nonAppStoreOptions
+}
+
 func addDistributionBundleIdentifierFromXcode12(exportOpts exportoptions.ExportOptions, distributionBundleIdentifier string) exportoptions.ExportOptions {
 	switch options := exportOpts.(type) {
 	case exportoptions.AppStoreOptionsModel:
@@ -432,40 +377,45 @@ func disableManagedBuildNumberFromXcode13(exportOpts exportoptions.ExportOptions
 	return exportOpts
 }
 
-// generateExportOptions generates an exportOptions based on the provided conditions.
-func (g ExportOptionsGenerator) generateExportOptions(exportMethod exportoptions.Method, containerEnvironment string, teamID string, uploadBitcode bool, compileBitcode bool, xcodeManaged bool,
-	bundleIDEntitlementsMap map[string]plistutil.PlistData, xcodeMajorVersion int64, distributionBundleIdentifier string) (exportoptions.ExportOptions, error) {
-	g.logger.TDebugf("Generating export options")
-
-	iCloudContainerEnvironment, err := determineIcloudContainerEnvironment(containerEnvironment, bundleIDEntitlementsMap, exportMethod, xcodeMajorVersion)
-	if err != nil {
-		return nil, err
+func addSigningStyle(exportOpts exportoptions.ExportOptions, signingStyle SigningStyle) exportoptions.ExportOptions {
+	switch options := exportOpts.(type) {
+	case exportoptions.AppStoreOptionsModel:
+		options.SigningStyle = string(signingStyle)
+		return options
+	case exportoptions.NonAppStoreOptionsModel:
+		options.SigningStyle = string(signingStyle)
+		return options
 	}
+	return exportOpts
+}
 
-	g.logger.Printf("Adding bundle id")
-
-	exportOpts := generateBaseExportOptions(exportMethod, uploadBitcode, compileBitcode, iCloudContainerEnvironment)
-	if xcodeMajorVersion >= 12 {
-		exportOpts = addDistributionBundleIdentifierFromXcode12(exportOpts, distributionBundleIdentifier)
+func addDestinationExport(exportOpts exportoptions.ExportOptions) exportoptions.ExportOptions {
+	switch options := exportOpts.(type) {
+	case exportoptions.AppStoreOptionsModel:
+		options.Destination = exportoptions.DestinationExport
+		return options
+	case exportoptions.NonAppStoreOptionsModel:
+		options.Destination = exportoptions.DestinationExport
+		return options
 	}
-	if xcodeMajorVersion >= 13 {
-		exportOpts = disableManagedBuildNumberFromXcode13(exportOpts)
-	}
+	return exportOpts
+}
 
-	g.logger.TDebugf("Determining code signing group")
-
-	codeSignGroup, err := g.determineCodesignGroup(bundleIDEntitlementsMap, exportMethod, teamID, xcodeManaged)
-	if err != nil {
-		return nil, err
+func addTeamID(exportOpts exportoptions.ExportOptions, teamID string) exportoptions.ExportOptions {
+	switch options := exportOpts.(type) {
+	case exportoptions.AppStoreOptionsModel:
+		options.TeamID = teamID
+		return options
+	case exportoptions.NonAppStoreOptionsModel:
+		options.TeamID = teamID
+		return options
 	}
-	if codeSignGroup == nil {
-		return exportOpts, nil
-	}
+	return exportOpts
+}
 
+func addManualSigningFields(exportOpts exportoptions.ExportOptions, codeSignGroup *export.IosCodeSignGroup, archivedWithXcodeManagedProfiles bool, logger log.Logger) exportoptions.ExportOptions {
 	exportCodeSignStyle := ""
 	exportProfileMapping := map[string]string{}
-
-	g.logger.TDebugf("Determining code signing style")
 
 	for bundleID, profileInfo := range codeSignGroup.BundleIDProfileMap() {
 		exportProfileMapping[bundleID] = profileInfo.Name
@@ -473,25 +423,25 @@ func (g ExportOptionsGenerator) generateExportOptions(exportMethod exportoptions
 		isXcodeManaged := profileutil.IsXcodeManaged(profileInfo.Name)
 		if isXcodeManaged {
 			if exportCodeSignStyle != "" && exportCodeSignStyle != "automatic" {
-				g.logger.Errorf("Both Xcode managed and NON Xcode managed profiles in code signing group")
+				logger.Errorf("Both Xcode managed and NON Xcode managed profiles in code signing group")
 			}
 			exportCodeSignStyle = "automatic"
 		} else {
-			if exportCodeSignStyle != "" && exportCodeSignStyle != manualSigningStyle {
-				g.logger.Errorf("Both Xcode managed and NON Xcode managed profiles in code signing group")
+			if exportCodeSignStyle != "" && exportCodeSignStyle != ManualSigningStyle {
+				logger.Errorf("Both Xcode managed and NON Xcode managed profiles in code signing group")
 			}
-			exportCodeSignStyle = manualSigningStyle
+			exportCodeSignStyle = ManualSigningStyle
 		}
 	}
 
-	shouldSetManualSigning := xcodeManaged && exportCodeSignStyle == manualSigningStyle
+	shouldSetManualSigning := archivedWithXcodeManagedProfiles && exportCodeSignStyle == ManualSigningStyle
 	if shouldSetManualSigning {
-		g.logger.Warnf("App was signed with Xcode managed profile when archiving,")
-		g.logger.Warnf("ipa export uses manual code signing.")
-		g.logger.Warnf(`Setting "signingStyle" to "manual".`)
+		logger.Warnf("App was signed with Xcode managed profile when archiving,")
+		logger.Warnf("ipa export uses manual code signing.")
+		logger.Warnf(`Setting "signingStyle" to "manual".`)
 	}
 
-	g.logger.TDebugf("Determined code signing style")
+	logger.TDebugf("Determined code signing style")
 
 	switch options := exportOpts.(type) {
 	case exportoptions.AppStoreOptionsModel:
@@ -500,7 +450,7 @@ func (g ExportOptionsGenerator) generateExportOptions(exportMethod exportoptions
 		options.TeamID = codeSignGroup.Certificate().TeamID
 
 		if shouldSetManualSigning {
-			options.SigningStyle = manualSigningStyle
+			options.SigningStyle = ManualSigningStyle
 		}
 		exportOpts = options
 	case exportoptions.NonAppStoreOptionsModel:
@@ -509,55 +459,10 @@ func (g ExportOptionsGenerator) generateExportOptions(exportMethod exportoptions
 		options.TeamID = codeSignGroup.Certificate().TeamID
 
 		if shouldSetManualSigning {
-			options.SigningStyle = manualSigningStyle
+			options.SigningStyle = ManualSigningStyle
 		}
 		exportOpts = options
 	}
 
-	return exportOpts, nil
-}
-
-// GetDefaultProvisioningProfile ...
-func (g ExportOptionsGenerator) GetDefaultProvisioningProfile() (profileutil.ProvisioningProfileInfoModel, error) {
-	defaultProfileURL := os.Getenv("BITRISE_DEFAULT_PROVISION_URL")
-	if defaultProfileURL == "" {
-		return profileutil.ProvisioningProfileInfoModel{}, nil
-	}
-
-	tmpDir, err := pathutil.NormalizedOSTempDirPath("tmp_default_profile")
-	if err != nil {
-		return profileutil.ProvisioningProfileInfoModel{}, err
-	}
-
-	tmpDst := filepath.Join(tmpDir, "default.mobileprovision")
-	tmpDstFile, err := os.Create(tmpDst)
-	if err != nil {
-		return profileutil.ProvisioningProfileInfoModel{}, err
-	}
-	defer func() {
-		if err := tmpDstFile.Close(); err != nil {
-			g.logger.Errorf("Failed to close file (%s), error: %s", tmpDst, err)
-		}
-	}()
-
-	response, err := http.Get(defaultProfileURL)
-	if err != nil {
-		return profileutil.ProvisioningProfileInfoModel{}, err
-	}
-	defer func() {
-		if err := response.Body.Close(); err != nil {
-			g.logger.Errorf("Failed to close response body, error: %s", err)
-		}
-	}()
-
-	if _, err := io.Copy(tmpDstFile, response.Body); err != nil {
-		return profileutil.ProvisioningProfileInfoModel{}, err
-	}
-
-	defaultProfile, err := profileutil.NewProvisioningProfileInfoFromFile(tmpDst)
-	if err != nil {
-		return profileutil.ProvisioningProfileInfoModel{}, err
-	}
-
-	return defaultProfile, nil
+	return exportOpts
 }

--- a/exportoptionsgenerator/exportoptionsgenerator.go
+++ b/exportoptionsgenerator/exportoptionsgenerator.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	// AppClipProductType ...
 	AppClipProductType = "com.apple.product-type.application.on-demand-install-capable"
 )
 

--- a/exportoptionsgenerator/exportoptionsgenerator.go
+++ b/exportoptionsgenerator/exportoptionsgenerator.go
@@ -369,18 +369,6 @@ func disableManagedBuildNumberFromXcode13(exportOpts exportoptions.ExportOptions
 	return exportOpts
 }
 
-func addSigningStyle(exportOpts exportoptions.ExportOptions, signingStyle exportoptions.SigningStyle) exportoptions.ExportOptions {
-	switch options := exportOpts.(type) {
-	case exportoptions.AppStoreOptionsModel:
-		options.SigningStyle = signingStyle
-		return options
-	case exportoptions.NonAppStoreOptionsModel:
-		options.SigningStyle = signingStyle
-		return options
-	}
-	return exportOpts
-}
-
 func addTeamID(exportOpts exportoptions.ExportOptions, teamID string) exportoptions.ExportOptions {
 	switch options := exportOpts.(type) {
 	case exportoptions.AppStoreOptionsModel:

--- a/exportoptionsgenerator/exportoptionsgenerator_test.go
+++ b/exportoptionsgenerator/exportoptionsgenerator_test.go
@@ -195,14 +195,10 @@ func TestExportOptionsGenerator_GenerateApplicationExportOptions_ForAutomaticSig
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>destination</key>
-		<string>export</string>
 		<key>distributionBundleIdentifier</key>
 		<string>io.bundle.id</string>
 		<key>method</key>
 		<string>development</string>
-		<key>signingStyle</key>
-		<string>automatic</string>
 		<key>teamID</key>
 		<string>TEAM123</string>
 	</dict>
@@ -228,14 +224,10 @@ func TestExportOptionsGenerator_GenerateApplicationExportOptions_ForAutomaticSig
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>destination</key>
-		<string>export</string>
 		<key>manageAppVersionAndBuildNumber</key>
 		<false/>
 		<key>method</key>
 		<string>app-store</string>
-		<key>signingStyle</key>
-		<string>automatic</string>
 		<key>teamID</key>
 		<string>TEAM123</string>
 	</dict>
@@ -263,16 +255,12 @@ func TestExportOptionsGenerator_GenerateApplicationExportOptions_ForAutomaticSig
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>destination</key>
-		<string>export</string>
 		<key>distributionBundleIdentifier</key>
 		<string>io.bundle.id</string>
 		<key>iCloudContainerEnvironment</key>
 		<string>Production</string>
 		<key>method</key>
 		<string>development</string>
-		<key>signingStyle</key>
-		<string>automatic</string>
 		<key>teamID</key>
 		<string>TEAM123</string>
 	</dict>

--- a/exportoptionsgenerator/exportoptionsgenerator_test.go
+++ b/exportoptionsgenerator/exportoptionsgenerator_test.go
@@ -282,7 +282,7 @@ func TestExportOptionsGenerator_GenerateApplicationExportOptions_ForAutomaticSig
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Act
-			gotOpts, err := tt.generatorFactory().GenerateApplicationExportOptions(tt.exportMethod, tt.containerEnvironment, teamID, true, true, false, AutomaticSigningStyle, tt.xcodeVersion)
+			gotOpts, err := tt.generatorFactory().GenerateApplicationExportOptions(tt.exportMethod, tt.containerEnvironment, teamID, true, true, false, exportoptions.SigningStyleAutomatic, tt.xcodeVersion)
 
 			// Assert
 			require.NoError(t, err)
@@ -384,7 +384,7 @@ func TestExportOptionsGenerator_GenerateApplicationExportOptions(t *testing.T) {
 			}
 
 			// Act
-			gotOpts, err := g.GenerateApplicationExportOptions(tt.exportMethod, "Production", teamID, true, true, false, ManualSigningStyle, tt.xcodeVersion)
+			gotOpts, err := g.GenerateApplicationExportOptions(tt.exportMethod, "Production", teamID, true, true, false, exportoptions.SigningStyleManual, tt.xcodeVersion)
 
 			// Assert
 			require.NoError(t, err)
@@ -454,7 +454,7 @@ func TestExportOptionsGenerator_GenerateApplicationExportOptions_WhenNoProfileFo
 			}
 
 			// Act
-			gotOpts, err := g.GenerateApplicationExportOptions(tt.exportMethod, "Production", teamID, true, true, false, ManualSigningStyle, tt.xcodeVersion)
+			gotOpts, err := g.GenerateApplicationExportOptions(tt.exportMethod, "Production", teamID, true, true, false, exportoptions.SigningStyleManual, tt.xcodeVersion)
 
 			// Assert
 			require.NoError(t, err)

--- a/exportoptionsgenerator/profiles.go
+++ b/exportoptionsgenerator/profiles.go
@@ -1,0 +1,73 @@
+package exportoptionsgenerator
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/profileutil"
+)
+
+// ProvisioningProfileProvider can list profile infos.
+type ProvisioningProfileProvider interface {
+	ListProvisioningProfiles() ([]profileutil.ProvisioningProfileInfoModel, error)
+	GetDefaultProvisioningProfile() (profileutil.ProvisioningProfileInfoModel, error)
+}
+
+// LocalProvisioningProfileProvider ...
+type LocalProvisioningProfileProvider struct {
+	logger log.Logger
+}
+
+// ListProvisioningProfiles ...
+func (p LocalProvisioningProfileProvider) ListProvisioningProfiles() ([]profileutil.ProvisioningProfileInfoModel, error) {
+	return profileutil.InstalledProvisioningProfileInfos(profileutil.ProfileTypeIos)
+}
+
+// GetDefaultProvisioningProfile ...
+func (p LocalProvisioningProfileProvider) GetDefaultProvisioningProfile() (profileutil.ProvisioningProfileInfoModel, error) {
+	defaultProfileURL := os.Getenv("BITRISE_DEFAULT_PROVISION_URL")
+	if defaultProfileURL == "" {
+		return profileutil.ProvisioningProfileInfoModel{}, nil
+	}
+
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("tmp_default_profile")
+	if err != nil {
+		return profileutil.ProvisioningProfileInfoModel{}, err
+	}
+
+	tmpDst := filepath.Join(tmpDir, "default.mobileprovision")
+	tmpDstFile, err := os.Create(tmpDst)
+	if err != nil {
+		return profileutil.ProvisioningProfileInfoModel{}, err
+	}
+	defer func() {
+		if err := tmpDstFile.Close(); err != nil {
+			p.logger.Warnf("Failed to close file (%s), error: %s", tmpDst, err)
+		}
+	}()
+
+	response, err := http.Get(defaultProfileURL)
+	if err != nil {
+		return profileutil.ProvisioningProfileInfoModel{}, err
+	}
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			p.logger.Warnf("Failed to close response body, error: %s", err)
+		}
+	}()
+
+	if _, err := io.Copy(tmpDstFile, response.Body); err != nil {
+		return profileutil.ProvisioningProfileInfoModel{}, err
+	}
+
+	defaultProfile, err := profileutil.NewProvisioningProfileInfoFromFile(tmpDst)
+	if err != nil {
+		return profileutil.ProvisioningProfileInfoModel{}, err
+	}
+
+	return defaultProfile, nil
+}

--- a/exportoptionsgenerator/targets.go
+++ b/exportoptionsgenerator/targets.go
@@ -1,0 +1,75 @@
+package exportoptionsgenerator
+
+import (
+	"fmt"
+	"github.com/bitrise-io/go-xcode/exportoptions"
+	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
+	"github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj"
+	"github.com/bitrise-io/go-xcode/xcodeproject/xcscheme"
+)
+
+// TargetInfoProvider can determine a target's bundle id and codesign entitlements.
+type TargetInfoProvider interface {
+	TargetBundleID(target, configuration string) (string, error)
+	TargetCodeSignEntitlements(target, configuration string) (serialized.Object, error)
+}
+
+// XcodebuildTargetInfoProvider implements TargetInfoProvider.
+type XcodebuildTargetInfoProvider struct {
+	xcodeProj *xcodeproj.XcodeProj
+}
+
+// TargetBundleID ...
+func (b XcodebuildTargetInfoProvider) TargetBundleID(target, configuration string) (string, error) {
+	return b.xcodeProj.TargetBundleID(target, configuration)
+}
+
+// TargetCodeSignEntitlements ...
+func (b XcodebuildTargetInfoProvider) TargetCodeSignEntitlements(target, configuration string) (serialized.Object, error) {
+	return b.xcodeProj.TargetCodeSignEntitlements(target, configuration)
+}
+
+// ArchivableApplicationTarget locate archivable app target from a given project and scheme
+func ArchivableApplicationTarget(xcodeProj *xcodeproj.XcodeProj, scheme *xcscheme.Scheme) (*xcodeproj.Target, error) {
+	archiveEntry, ok := scheme.AppBuildActionEntry()
+	if !ok {
+		return nil, fmt.Errorf("archivable entry not found in project: %s for scheme: %s", xcodeProj.Path, scheme.Name)
+	}
+
+	mainTarget, ok := xcodeProj.Proj.Target(archiveEntry.BuildableReference.BlueprintIdentifier)
+	if !ok {
+		return nil, fmt.Errorf("target not found: %s", archiveEntry.BuildableReference.BlueprintIdentifier)
+	}
+
+	return &mainTarget, nil
+}
+
+func filterApplicationBundleTargets(targets []xcodeproj.Target, exportMethod exportoptions.Method) (filteredTargets []xcodeproj.Target) {
+	fmt.Printf("Filtering %v application bundle targets", len(targets))
+
+	for _, target := range targets {
+		if !target.IsExecutableProduct() {
+			continue
+		}
+
+		// App store exports contain App Clip too. App Clip provisioning profile has to be included in export options:
+		// ..
+		// <key>provisioningProfiles</key>
+		// <dict>
+		// 	<key>io.bundle.id</key>
+		// 	<string>Development Application Profile</string>
+		// 	<key>io.bundle.id.AppClipID</key>
+		// 	<string>Development App Clip Profile</string>
+		// </dict>
+		// ..,
+		if exportMethod != exportoptions.MethodAppStore && target.IsAppClipProduct() {
+			continue
+		}
+
+		filteredTargets = append(filteredTargets, target)
+	}
+
+	fmt.Printf("Found %v application bundle targets", len(filteredTargets))
+
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.18
 	github.com/bitrise-io/go-utils v1.0.12
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23
-	github.com/bitrise-io/go-xcode v1.0.18
+	github.com/bitrise-io/go-xcode v1.1.1-0.20241009090606-5f960ab7be91
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.18
 	github.com/bitrise-io/go-utils v1.0.12
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23
-	github.com/bitrise-io/go-xcode v1.1.1-0.20241009090606-5f960ab7be91
+	github.com/bitrise-io/go-xcode v1.1.1
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,10 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23 h1:Dfh4nyZPuEtilBisidejqxBrkx9
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23/go.mod h1:3XUplo0dOWc3DqT2XA2SeHToDSg7+j1y1HTHibT2H68=
 github.com/bitrise-io/go-xcode v1.0.18 h1:guFywV/AwcZuexqIQkL1ixc3QThpbJvA4voa9MqvPto=
 github.com/bitrise-io/go-xcode v1.0.18/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
+github.com/bitrise-io/go-xcode v1.1.0 h1:34JKUMnTuBYtgORcGTOoGkXNzw0fFrTVjQG7QnHQHeM=
+github.com/bitrise-io/go-xcode v1.1.0/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
+github.com/bitrise-io/go-xcode v1.1.1-0.20241009090606-5f960ab7be91 h1:v87soQjWZiV4DFEX04WbwcecsFlvpYm5tdimFuCpQvA=
+github.com/bitrise-io/go-xcode v1.1.1-0.20241009090606-5f960ab7be91/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -11,12 +11,8 @@ github.com/bitrise-io/go-utils v1.0.12 h1:iJV1ZpyvSA0NCte/N6x+aIQ9TrNr5sIBlcJBf0
 github.com/bitrise-io/go-utils v1.0.12/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23 h1:Dfh4nyZPuEtilBisidejqxBrkx9cWvbOUrpq8VEION0=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23/go.mod h1:3XUplo0dOWc3DqT2XA2SeHToDSg7+j1y1HTHibT2H68=
-github.com/bitrise-io/go-xcode v1.0.18 h1:guFywV/AwcZuexqIQkL1ixc3QThpbJvA4voa9MqvPto=
-github.com/bitrise-io/go-xcode v1.0.18/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
-github.com/bitrise-io/go-xcode v1.1.0 h1:34JKUMnTuBYtgORcGTOoGkXNzw0fFrTVjQG7QnHQHeM=
-github.com/bitrise-io/go-xcode v1.1.0/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
-github.com/bitrise-io/go-xcode v1.1.1-0.20241009090606-5f960ab7be91 h1:v87soQjWZiV4DFEX04WbwcecsFlvpYm5tdimFuCpQvA=
-github.com/bitrise-io/go-xcode v1.1.1-0.20241009090606-5f960ab7be91/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
+github.com/bitrise-io/go-xcode v1.1.1 h1:Krfa8iYZZWdLBuH7AXbufFZwL+Pys7etqvd8+Ehdwt8=
+github.com/bitrise-io/go-xcode v1.1.1/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR reorganizes the files in the `exportoptionsgenerator` package and adds support for the automatic signing style.

The `exportoptionsgenerator` package new organisation:
- `ExportOptionsGenerator` dependencies are moved to their own files, to shorten the code in `exportoptionsgenerator.go`
- Const, Types, and exported funcs are at the top of the files

Automatic signing style support:

- the `provisioningProfiles` entry shouldn't be in the exportOptions.plist when the IPA export is Xcode managed
