### PR TITLE
added testFlightInternalTestingOnly appStore option

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,19 +1,12 @@
-format_version: 1.0.0
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-app:
-  envs:
-  - ORIG_BITRISE_SOURCE_DIR: $BITRISE_SOURCE_DIR
-
 workflows:
-  ci:
+  check:
     before_run:
     - test
-    - swiftpm_cache
 
   test:
-    after_run:
-    - integration-test
     steps:
     - git::https://github.com/bitrise-steplib/steps-check.git:
         title: Lint
@@ -24,93 +17,3 @@ workflows:
         inputs:
         - exclude: "*/mocks"
     - go-test: { }
-
-  integration-test:
-    steps:
-    - script:
-        title: Run integration tests
-        inputs:
-        - content: |-
-            #!/bin/bash
-            echo "Running integration tests ..."
-            set -ex
-
-            go test -v ./_tests/integration/...
-
-  _swiftpm_step:
-    envs:
-    - CURRENT_PROJECT_PATH: $CURRENT_PROJECT_PATH
-    - BITRISE_ACCESS_TOKEN: $BITRISE_ACCESS_TOKEN
-    steps:
-    - build-router-start:
-        inputs:
-        - workflows: swiftpm_run_xcodebuild
-        - wait_for_builds: "true"
-        - access_token: $BITRISE_ACCESS_TOKEN
-        - environment_key_list: CURRENT_PROJECT_PATH
-        - verbose: "yes"
-
-  swiftpm_run_xcodebuild:
-    envs:
-    - CURRENT_PROJECT_PATH: $CURRENT_PROJECT_PATH
-    - SAMPLES_DIR: $ORIG_BITRISE_SOURCE_DIR/_checkout
-    steps:
-    - script:
-        title: Cleanup $TMP_DIR
-        inputs:
-        - content: |
-            #!/bin/bash
-            set -ex
-
-            rm -rf $SAMPLES_DIR
-            mkdir $SAMPLES_DIR
-            git clone https://github.com/bitrise-io/sample-apps-ios-swiftpm.git -b master $SAMPLES_DIR
-
-            rm -rf /Users/lpusok/Library/Developer/Xcode/DerivedData/*
-    - cache-pull:
-        run_if: true
-        inputs:
-        - is_debug_mode: true
-    - xcode-test:
-        title: Run xcodebuild
-        inputs:
-        - project_path: $SAMPLES_DIR/$CURRENT_PROJECT_PATH/sample-swiftpm2.xcodeproj
-        - scheme: sample-swiftpm2
-        - cache_level: swift_packages
-    - cache-push:
-        title: Push cache
-        run_if: true
-        is_skippable: false
-        inputs:
-        - is_debug_mode: true
-
-  _swiftpm_step2:
-    envs:
-    - CURRENT_PROJECT_PATH: sample-swiftpm2
-    after_run:
-    - _swiftpm_step
-
-  _swiftpm_step3:
-    envs:
-    - CURRENT_PROJECT_PATH: sample-swiftpm3
-    after_run:
-    - _swiftpm_step
-
-  _swiftpm_step5:
-    envs:
-    - CURRENT_PROJECT_PATH: sample-swiftpm5
-    after_run:
-    - _swiftpm_step
-
-  _swiftpm_step7:
-    envs:
-    - CURRENT_PROJECT_PATH: sample-swiftpm7
-    after_run:
-    - _swiftpm_step
-
-  swiftpm_cache:
-    after_run:
-    - _swiftpm_step2
-    - _swiftpm_step3
-    - _swiftpm_step5
-    - _swiftpm_step7

--- a/exportoptions/appstore_options.go
+++ b/exportoptions/appstore_options.go
@@ -22,16 +22,17 @@ type AppStoreOptionsModel struct {
 	UploadSymbols bool
 	// Should Xcode manage the app's build number when uploading to App Store Connect? Defaults to YES.
 	ManageAppVersion bool
-	// TestFlightInternalTestingOnly
+
 	TestFlightInternalTestingOnly bool
 }
 
 // NewAppStoreOptions ...
 func NewAppStoreOptions() AppStoreOptionsModel {
 	return AppStoreOptionsModel{
-		UploadBitcode:    UploadBitcodeDefault,
-		UploadSymbols:    UploadSymbolsDefault,
-		ManageAppVersion: manageAppVersionDefault,
+		UploadBitcode:                 UploadBitcodeDefault,
+		UploadSymbols:                 UploadSymbolsDefault,
+		ManageAppVersion:              manageAppVersionDefault,
+		TestFlightInternalTestingOnly: TestFlightInternalTestingOnlyDefault,
 	}
 }
 
@@ -75,7 +76,7 @@ func (options AppStoreOptionsModel) Hash() map[string]interface{} {
 	if options.Destination != "" {
 		hash[DestinationKey] = options.Destination
 	}
-	if options.TestFlightInternalTestingOnly {
+	if options.TestFlightInternalTestingOnly != TestFlightInternalTestingOnlyDefault {
 		hash[TestFlightInternalTestingOnlyKey] = options.TestFlightInternalTestingOnly
 	}
 	return hash

--- a/exportoptions/appstore_options.go
+++ b/exportoptions/appstore_options.go
@@ -76,7 +76,8 @@ func (options AppStoreOptionsModel) Hash() map[string]interface{} {
 	if options.Destination != "" {
 		hash[DestinationKey] = options.Destination
 	}
-	if options.TestFlightInternalTestingOnly != TestFlightInternalTestingOnlyDefault {
+	//if options.TestFlightInternalTestingOnly != TestFlightInternalTestingOnlyDefault {
+	if options.TestFlightInternalTestingOnly {
 		hash[TestFlightInternalTestingOnlyKey] = options.TestFlightInternalTestingOnly
 	}
 	return hash

--- a/exportoptions/appstore_options.go
+++ b/exportoptions/appstore_options.go
@@ -22,6 +22,8 @@ type AppStoreOptionsModel struct {
 	UploadSymbols bool
 	// Should Xcode manage the app's build number when uploading to App Store Connect? Defaults to YES.
 	ManageAppVersion bool
+	// TestFlightInternalTestingOnly
+	TestFlightInternalTestingOnly bool
 }
 
 // NewAppStoreOptions ...
@@ -72,6 +74,9 @@ func (options AppStoreOptionsModel) Hash() map[string]interface{} {
 	}
 	if options.Destination != "" {
 		hash[DestinationKey] = options.Destination
+	}
+	if options.TestFlightInternalTestingOnly {
+		hash[TestFlightInternalTestingOnlyKey] = options.TestFlightInternalTestingOnly
 	}
 	return hash
 }

--- a/exportoptions/appstore_options.go
+++ b/exportoptions/appstore_options.go
@@ -76,8 +76,8 @@ func (options AppStoreOptionsModel) Hash() map[string]interface{} {
 	if options.Destination != "" {
 		hash[DestinationKey] = options.Destination
 	}
-	//if options.TestFlightInternalTestingOnly != TestFlightInternalTestingOnlyDefault {
-	if options.TestFlightInternalTestingOnly {
+	//nolint:gosimple
+	if options.TestFlightInternalTestingOnly != TestFlightInternalTestingOnlyDefault {
 		hash[TestFlightInternalTestingOnlyKey] = options.TestFlightInternalTestingOnly
 	}
 	return hash

--- a/exportoptions/exportoptions_test.go
+++ b/exportoptions/exportoptions_test.go
@@ -111,6 +111,7 @@ func TestNewAppStoreOptions(t *testing.T) {
 		options := NewAppStoreOptions()
 		require.Equal(t, UploadBitcodeDefault, options.UploadBitcode)
 		require.Equal(t, UploadSymbolsDefault, options.UploadSymbols)
+		require.Equal(t, TestFlightInternalTestingOnlyDefault, options.TestFlightInternalTestingOnly)
 	}
 }
 
@@ -136,9 +137,10 @@ func TestAppStoreOptionsToHash(t *testing.T) {
 		options.UploadBitcode = false
 		options.UploadSymbols = false
 		options.ManageAppVersion = false
+		options.TestFlightInternalTestingOnly = true
 
 		hash := options.Hash()
-		require.Equal(t, 5, len(hash))
+		require.Equal(t, 6, len(hash))
 
 		{
 			value, ok := hash[MethodKey]
@@ -164,6 +166,11 @@ func TestAppStoreOptionsToHash(t *testing.T) {
 			value, ok := hash[manageAppVersionKey]
 			require.True(t, ok)
 			require.Equal(t, false, value)
+		}
+		{
+			value, ok := hash[TestFlightInternalTestingOnlyKey]
+			require.True(t, ok)
+			require.Equal(t, true, value)
 		}
 	}
 }

--- a/exportoptions/properties.go
+++ b/exportoptions/properties.go
@@ -177,6 +177,8 @@ const (
 
 const DestinationKey = "destination"
 
+const TestFlightInternalTestingOnlyKey = "testFlightInternalTestingOnly"
+
 type Destination string
 
 // Destination ...

--- a/exportoptions/properties.go
+++ b/exportoptions/properties.go
@@ -177,6 +177,7 @@ const (
 
 const DestinationKey = "destination"
 
+const TestFlightInternalTestingOnlyDefault = false
 const TestFlightInternalTestingOnlyKey = "testFlightInternalTestingOnly"
 
 type Destination string


### PR DESCRIPTION
Export Options now supports a `testFlightInternalTestingOnly` boolean option for app-store distribution method. 

This pull request adds that option to v1