### PR TITLE
Add NSunbufferedIO env to xcbeautify too

### DIFF
--- a/xcodecommand/xcbeautify.go
+++ b/xcodecommand/xcbeautify.go
@@ -52,6 +52,7 @@ func (c *XcbeautifyRunner) Run(workDir string, xcodebuildArgs []string, xcbeauti
 		Stdin:  pipeReader,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
+		Env:    xcodeCommandEnvs,
 	})
 
 	defer func() {

--- a/xcodecommand/xcbeautify.go
+++ b/xcodecommand/xcbeautify.go
@@ -43,7 +43,7 @@ func (c *XcbeautifyRunner) Run(workDir string, xcodebuildArgs []string, xcbeauti
 	buildCmd := c.commandFactory.Create("xcodebuild", xcodebuildArgs, &command.Opts{
 		Stdout:      buildOutWriter,
 		Stderr:      buildOutWriter,
-		Env:         xcodeCommandEnvs,
+		Env:         unbufferedIOEnv,
 		Dir:         workDir,
 		ErrorFinder: errorfinder.FindXcodebuildErrors,
 	})
@@ -52,7 +52,7 @@ func (c *XcbeautifyRunner) Run(workDir string, xcodebuildArgs []string, xcbeauti
 		Stdin:  pipeReader,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-		Env:    xcodeCommandEnvs,
+		Env:    unbufferedIOEnv,
 	})
 
 	defer func() {

--- a/xcodecommand/xcodebuild_only.go
+++ b/xcodecommand/xcodebuild_only.go
@@ -11,7 +11,7 @@ import (
 	version "github.com/hashicorp/go-version"
 )
 
-var xcodeCommandEnvs = []string{"NSUnbufferedIO=YES"}
+var unbufferedIOEnv = []string{"NSUnbufferedIO=YES"}
 
 // RawXcodeCommandRunner is an xcodebuild runner that uses no additional log formatter
 type RawXcodeCommandRunner struct {
@@ -38,7 +38,7 @@ func (c *RawXcodeCommandRunner) Run(workDir string, args []string, _ []string) (
 	command := c.commandFactory.Create("xcodebuild", args, &command.Opts{
 		Stdout:      &outBuffer,
 		Stderr:      &outBuffer,
-		Env:         xcodeCommandEnvs,
+		Env:         unbufferedIOEnv,
 		Dir:         workDir,
 		ErrorFinder: errorfinder.FindXcodebuildErrors,
 	})

--- a/xcodecommand/xcpretty.go
+++ b/xcodecommand/xcpretty.go
@@ -53,7 +53,7 @@ func (c *XcprettyCommandRunner) Run(workDir string, xcodebuildArgs []string, xcp
 	buildCmd := c.commandFactory.Create("xcodebuild", xcodebuildArgs, &command.Opts{
 		Stdout:      buildOutWriter,
 		Stderr:      buildOutWriter,
-		Env:         xcodeCommandEnvs,
+		Env:         unbufferedIOEnv,
 		Dir:         workDir,
 		ErrorFinder: errorfinder.FindXcodebuildErrors,
 	})


### PR DESCRIPTION
The xcodebuild command had this env set, but not xcbeautify; as we use go pipes not the bash command ` NSUnbufferedIO=YES xcodebuild [args] 2>&1 | xcbeautify` (reccomended by xcbeatify).

This may affect xcbeautify behaviour, and may solve some "hangs".


See: https://developer.apple.com/library/archive/technotes/tn2124/_index.html
```
NSUnbufferedIO
If set to YES, Foundation will use unbuffered I/O for stdout (stderr is unbuffered by default) 
```