### PR TITLE
[SSW-2210] Paging workarounds and improvements

### DIFF
--- a/autocodesign/autocodesign.go
+++ b/autocodesign/autocodesign.go
@@ -67,9 +67,10 @@ type Certificate struct {
 	ID              string
 }
 
-// DeviceIDs is the opaque ID of a device, UDID is the unique identifier of a device
-// DeviceIDs are used in the Developer Portal API, UDIDs are used in the provisioning profiles
+// DeviceIDs is the opaque ID of a device (from used in the Developer Portal API)
 type DeviceIDs []string
+
+// DeviceUDIDs are used in the provisioning profiles, as unique device identifiers
 type DeviceUDIDs []string
 
 // DevPortalClient abstract away the Apple Developer Portal API

--- a/autocodesign/autocodesign.go
+++ b/autocodesign/autocodesign.go
@@ -22,7 +22,7 @@ type Profile interface {
 	ID() string
 	Attributes() appstoreconnect.ProfileAttributes
 	CertificateIDs() ([]string, error)
-	DeviceIDs() ([]string, error)
+	DeviceUDIDs() ([]string, error)
 	BundleID() (appstoreconnect.BundleID, error)
 	Entitlements() (Entitlements, error)
 }
@@ -66,6 +66,11 @@ type Certificate struct {
 	CertificateInfo certificateutil.CertificateInfoModel
 	ID              string
 }
+
+// DeviceIDs is the opaque ID of a device, UDID is the unique identifier of a device
+// DeviceIDs are used in the Developer Portal API, UDIDs are used in the provisioning profiles
+type DeviceIDs []string
+type DeviceUDIDs []string
 
 // DevPortalClient abstract away the Apple Developer Portal API
 type DevPortalClient interface {
@@ -170,8 +175,8 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 		return nil, err
 	}
 
-	var devPortalDeviceIDs []string
-	var devPortalDeviceUDIDs []string
+	var devPortalDeviceIDs DeviceIDs
+	var devPortalDeviceUDIDs DeviceUDIDs
 	if DistributionTypeRequiresDeviceList(distrTypes) {
 		devPortalDevices, err := EnsureTestDevices(m.devPortalClient, opts.BitriseTestDevices, appLayout.Platform)
 		if err != nil {
@@ -208,7 +213,7 @@ func (m codesignAssetManager) EnsureCodesignAssets(appLayout AppLayout, opts Cod
 			printMissingCodeSignAssets(missingAppLayout)
 
 			// Ensure Profiles
-			newCodesignAssets, err := ensureProfiles(m.devPortalClient, distrType, certsByType, *missingAppLayout, devPortalDeviceIDs, opts.MinProfileValidityDays)
+			newCodesignAssets, err := ensureProfiles(m.devPortalClient, distrType, certsByType, *missingAppLayout, devPortalDeviceIDs, devPortalDeviceUDIDs, opts.MinProfileValidityDays)
 			if err != nil {
 				switch {
 				case errors.As(err, &ErrAppClipAppID{}):

--- a/autocodesign/autocodesign_test.go
+++ b/autocodesign/autocodesign_test.go
@@ -49,7 +49,7 @@ func newMockProfile(m profileArgs) Profile {
 	profile.On("BundleID").Return(func() appstoreconnect.BundleID {
 		return m.appID
 	}, nil)
-	profile.On("DeviceIDs").Return(func() []string {
+	profile.On("DeviceUDIDs").Return(func() []string {
 		return m.devices
 	}, nil)
 	profile.On("CertificateIDs").Return(func() []string {

--- a/autocodesign/devportalclient/appstoreconnect/bundleids.go
+++ b/autocodesign/devportalclient/appstoreconnect/bundleids.go
@@ -16,9 +16,22 @@ type ListBundleIDsOptions struct {
 	Include          string           `url:"include,omitempty"`
 }
 
+// PagingInformationPaging ...
+type PagingInformationPaging struct {
+	Total int `json:"total,omitempty"`
+	Limit int `json:"limit,omitempty"`
+}
+
+// PagingInformation ...
+type PagingInformation struct {
+	Paging PagingInformationPaging `json:"paging,omitempty"`
+}
+
 // PagedDocumentLinks ...
 type PagedDocumentLinks struct {
-	Next string `json:"next,omitempty"`
+	First string `json:"first,omitempty"`
+	Next  string `json:"next,omitempty"`
+	Self  string `json:"self,omitempty"`
 }
 
 // BundleIDAttributes ...

--- a/autocodesign/devportalclient/appstoreconnect/bundleids.go
+++ b/autocodesign/devportalclient/appstoreconnect/bundleids.go
@@ -7,13 +7,31 @@ import (
 // BundleIDsEndpoint ...
 const BundleIDsEndpoint = "bundleIds"
 
+// ListBundleIDsSortOption ...
+type ListBundleIDsSortOption string
+
+// ListBundleIDsSortOptions ...
+const (
+	ListBundleIDsSortOptionName           ListBundleIDsSortOption = "name"
+	ListBundleIDsSortOptionNameDesc       ListBundleIDsSortOption = "-name"
+	ListBundleIDsSortOptionPlatform       ListBundleIDsSortOption = "platform"
+	ListBundleIDsSortOptionPlatformDesc   ListBundleIDsSortOption = "-platform"
+	ListBundleIDsSortOptionIdentifier     ListBundleIDsSortOption = "identifier"
+	ListBundleIDsSortOptionIdentifierDesc ListBundleIDsSortOption = "-identifier"
+	ListBundleIDsSortOptionSeedId         ListBundleIDsSortOption = "seedId"
+	ListBundleIDsSortOptionSeedIdDesc     ListBundleIDsSortOption = "-seedId"
+	ListBundleIDsSortOptionID             ListBundleIDsSortOption = "id"
+	ListBundleIDsSortOptionIDDesc         ListBundleIDsSortOption = "-id"
+)
+
 // ListBundleIDsOptions ...
 type ListBundleIDsOptions struct {
 	PagingOptions
-	FilterIdentifier string           `url:"filter[identifier],omitempty"`
-	FilterName       string           `url:"filter[name],omitempty"`
-	FilterPlatform   BundleIDPlatform `url:"filter[platform],omitempty"`
-	Include          string           `url:"include,omitempty"`
+	FilterIdentifier string                  `url:"filter[identifier],omitempty"`
+	FilterName       string                  `url:"filter[name],omitempty"`
+	FilterPlatform   BundleIDPlatform        `url:"filter[platform],omitempty"`
+	Include          string                  `url:"include,omitempty"`
+	Sort             ListBundleIDsSortOption `url:"sort,omitempty"`
 }
 
 // PagingInformationPaging ...
@@ -71,6 +89,7 @@ type BundleID struct {
 type BundleIdsResponse struct {
 	Data  []BundleID         `json:"data,omitempty"`
 	Links PagedDocumentLinks `json:"links,omitempty"`
+	Meta  PagingInformation  `json:"meta,omitempty"`
 }
 
 // ListBundleIDs ...

--- a/autocodesign/devportalclient/appstoreconnect/certificates.go
+++ b/autocodesign/devportalclient/appstoreconnect/certificates.go
@@ -8,11 +8,27 @@ import (
 // CertificatesEndpoint ...
 const CertificatesEndpoint = "certificates"
 
+// ListCertificatesSortOption ...
+type ListCertificatesSortOption string
+
+// ListCertificatesSortOptions ...
+const (
+	ListCertificatesSortOptionDisplayName         ListCertificatesSortOption = "displayName"
+	ListCertificatesSortOptionDisplayNameDesc     ListCertificatesSortOption = "-displayName"
+	ListCertificatesSortOptionCertificateType     ListCertificatesSortOption = "certificateType"
+	ListCertificatesSortOptionCertificateTypeDesc ListCertificatesSortOption = "-certificateType"
+	ListCertificatesSortOptionSerialNumber        ListCertificatesSortOption = "serialNumber"
+	ListCertificatesSortOptionSerialNumberDesc    ListCertificatesSortOption = "-serialNumber"
+	ListCertificatesSortOptionID                  ListCertificatesSortOption = "id"
+	ListCertificatesSortOptionIDDesc              ListCertificatesSortOption = "-id"
+)
+
 // ListCertificatesOptions ...
 type ListCertificatesOptions struct {
 	PagingOptions
-	FilterSerialNumber    string          `url:"filter[serialNumber],omitempty"`
-	FilterCertificateType CertificateType `url:"filter[certificateType],omitempty"`
+	FilterSerialNumber    string                     `url:"filter[serialNumber],omitempty"`
+	FilterCertificateType CertificateType            `url:"filter[certificateType],omitempty"`
+	Sort                  ListCertificatesSortOption `url:"sort,omitempty"`
 }
 
 // CertificateType ...
@@ -53,6 +69,7 @@ type Certificate struct {
 type CertificatesResponse struct {
 	Data  []Certificate      `json:"data"`
 	Links PagedDocumentLinks `json:"links,omitempty"`
+	Meta  PagingInformation  `json:"meta,omitempty"`
 }
 
 // ListCertificates ...

--- a/autocodesign/devportalclient/appstoreconnect/devices.go
+++ b/autocodesign/devportalclient/appstoreconnect/devices.go
@@ -7,12 +7,30 @@ import (
 // DevicesEndpoint ...
 const DevicesEndpoint = "devices"
 
+// ListDevicesSortOption ...
+type ListDevicesSortOption string
+
+// ListDevicesSortOptions ...
+const (
+	ListDevicesSortOptionName         ListDevicesSortOption = "name"
+	ListDevicesSortOptionNameDesc     ListDevicesSortOption = "-name"
+	ListDevicesSortOptionPlatform     ListDevicesSortOption = "platform"
+	ListDevicesSortOptionPlatformDesc ListDevicesSortOption = "-platform"
+	ListDevicesSortOptionUDID         ListDevicesSortOption = "udid"
+	ListDevicesSortOptionUDIDDesc     ListDevicesSortOption = "-udid"
+	ListDevicesSortOptionStatus       ListDevicesSortOption = "status"
+	ListDevicesSortOptionStatusDesc   ListDevicesSortOption = "-status"
+	ListDevicesSortOptionID           ListDevicesSortOption = "id"
+	ListDevicesSortOptionIDDesc       ListDevicesSortOption = "-id"
+)
+
 // ListDevicesOptions ...
 type ListDevicesOptions struct {
 	PagingOptions
-	FilterUDID     string         `url:"filter[udid],omitempty"`
-	FilterPlatform DevicePlatform `url:"filter[platform],omitempty"`
-	FilterStatus   Status         `url:"filter[status],omitempty"`
+	FilterUDID     string                `url:"filter[udid],omitempty"`
+	FilterPlatform DevicePlatform        `url:"filter[platform],omitempty"`
+	FilterStatus   Status                `url:"filter[status],omitempty"`
+	Sort           ListDevicesSortOption `url:"sort,omitempty"`
 }
 
 // DeviceClass ...
@@ -68,6 +86,7 @@ type Device struct {
 type DevicesResponse struct {
 	Data  []Device           `json:"data"`
 	Links PagedDocumentLinks `json:"links,omitempty"`
+	Meta  PagingInformation  `json:"meta,omitempty"`
 }
 
 // DeviceResponse ...

--- a/autocodesign/devportalclient/appstoreconnect/error.go
+++ b/autocodesign/devportalclient/appstoreconnect/error.go
@@ -3,6 +3,7 @@ package appstoreconnect
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // ErrorResponseError ...
@@ -35,6 +36,16 @@ func (r ErrorResponse) Error() string {
 	}
 
 	return m
+}
+
+// IsCursorInvalid ...
+func (r ErrorResponse) IsCursorInvalid() bool {
+	for _, err := range r.Errors {
+		if err.ID == "PARAMETER_ERROR.INVALID" && strings.Contains(err.Detail, "is not a valid cursor for this request") {
+			return true
+		}
+	}
+	return false
 }
 
 // DeviceRegistrationError ...

--- a/autocodesign/devportalclient/appstoreconnect/error.go
+++ b/autocodesign/devportalclient/appstoreconnect/error.go
@@ -40,8 +40,9 @@ func (r ErrorResponse) Error() string {
 
 // IsCursorInvalid ...
 func (r ErrorResponse) IsCursorInvalid() bool {
+	// {"errors"=>[{"id"=>"[ ... ]", "status"=>"400", "code"=>"PARAMETER_ERROR.INVALID", "title"=>"A parameter has an invalid value", "detail"=>"'eyJvZmZzZXQiOiIyMCJ9' is not a valid cursor for this request", "source"=>{"parameter"=>"cursor"}}]}
 	for _, err := range r.Errors {
-		if err.ID == "PARAMETER_ERROR.INVALID" && strings.Contains(err.Detail, "is not a valid cursor for this request") {
+		if err.Code == "PARAMETER_ERROR.INVALID" && strings.Contains(err.Detail, "is not a valid cursor for this request") {
 			return true
 		}
 	}

--- a/autocodesign/devportalclient/appstoreconnect/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnect/profiles.go
@@ -127,6 +127,7 @@ type ProfilesResponse struct {
 		Attributes serialized.Object `json:"attributes"`
 	} `json:"included"`
 	Links PagedDocumentLinks `json:"links,omitempty"`
+	Meta  PagingInformation  `json:"meta,omitempty"`
 }
 
 // ListProfiles ...

--- a/autocodesign/devportalclient/appstoreconnectclient/certificates.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/certificates.go
@@ -134,8 +134,8 @@ func list400Certificates(client *appstoreconnect.Client, certificateType appstor
 		}
 	}
 
-	if totalCount > 0 && totalCount > 400 {
-		log.Warnf("More than 400 certificates (%d) found", totalCount)
+	if totalCount > 400 {
+		log.Warnf("Unable to retrieve all certificates: more than 400 certificates available (%s)", totalCount)
 	}
 
 	var certificates []appstoreconnect.Certificate

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -60,7 +60,7 @@ func (d *DeviceClient) ListDevices(udid string, platform appstoreconnect.DeviceP
 }
 
 func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.DevicePlatform) ([]appstoreconnect.Device, error) {
-	var devices []appstoreconnect.Device
+	devicesByID := map[string]appstoreconnect.Device{}
 	var totalCount int
 	for _, sort := range []appstoreconnect.ListDevicesSortOption{appstoreconnect.ListDevicesSortOptionID, appstoreconnect.ListDevicesSortOptionIDDesc} {
 		response, err := d.client.Provisioning.ListDevices(&appstoreconnect.ListDevicesOptions{
@@ -76,7 +76,9 @@ func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.Devi
 			return nil, err
 		}
 
-		devices = append(devices, response.Data...)
+		for _, responseDevice := range response.Data {
+			devicesByID[responseDevice.ID] = responseDevice
+		}
 
 		if totalCount == 0 {
 			totalCount = response.Meta.Paging.Total
@@ -85,6 +87,11 @@ func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.Devi
 
 	if totalCount > 0 && totalCount > 400 {
 		log.Warnf("More than 400 devices (%d) found", totalCount)
+	}
+
+	var devices []appstoreconnect.Device
+	for _, device := range devicesByID {
+		devices = append(devices, device)
 	}
 
 	return devices, nil

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -40,7 +40,6 @@ func (d *DeviceClient) ListDevices(udid string, platform appstoreconnect.DeviceP
 			if ok := errors.As(err, &apiError); ok {
 				if apiError.IsCursorInvalid() {
 					log.Warnf("Cursor is invalid, falling back to listing devices with 400 limit")
-
 					return d.list400Devices(udid, platform)
 				}
 			}
@@ -61,7 +60,7 @@ func (d *DeviceClient) ListDevices(udid string, platform appstoreconnect.DeviceP
 }
 
 func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.DevicePlatform) ([]appstoreconnect.Device, error) {
-	var devicesByID map[string]appstoreconnect.Device
+	devicesByID := map[string]appstoreconnect.Device{}
 	var totalCount int
 	for _, sort := range []appstoreconnect.ListDevicesSortOption{appstoreconnect.ListDevicesSortOptionID, appstoreconnect.ListDevicesSortOptionIDDesc} {
 		response, err := d.client.Provisioning.ListDevices(&appstoreconnect.ListDevicesOptions{
@@ -78,7 +77,7 @@ func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.Devi
 		}
 
 		for _, responseDevice := range response.Data {
-			devicesByID[responseDevice.Attributes.UDID] = responseDevice
+			devicesByID[responseDevice.ID] = responseDevice
 		}
 
 		if totalCount == 0 {

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -60,7 +60,7 @@ func (d *DeviceClient) ListDevices(udid string, platform appstoreconnect.DeviceP
 }
 
 func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.DevicePlatform) ([]appstoreconnect.Device, error) {
-	devicesByID := map[string]appstoreconnect.Device{}
+	var devices []appstoreconnect.Device
 	var totalCount int
 	for _, sort := range []appstoreconnect.ListDevicesSortOption{appstoreconnect.ListDevicesSortOptionID, appstoreconnect.ListDevicesSortOptionIDDesc} {
 		response, err := d.client.Provisioning.ListDevices(&appstoreconnect.ListDevicesOptions{
@@ -76,9 +76,7 @@ func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.Devi
 			return nil, err
 		}
 
-		for _, responseDevice := range response.Data {
-			devicesByID[responseDevice.ID] = responseDevice
-		}
+		devices = append(devices, response.Data...)
 
 		if totalCount == 0 {
 			totalCount = response.Meta.Paging.Total
@@ -87,11 +85,6 @@ func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.Devi
 
 	if totalCount > 0 && totalCount > 400 {
 		log.Warnf("More than 400 devices (%d) found", totalCount)
-	}
-
-	var devices []appstoreconnect.Device
-	for _, device := range devicesByID {
-		devices = append(devices, device)
 	}
 
 	return devices, nil

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/bitrise-io/go-utils/log"
+
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
 	"github.com/bitrise-io/go-xcode/v2/devportalservice"
 )
@@ -34,6 +36,12 @@ func (d *DeviceClient) ListDevices(udid string, platform appstoreconnect.DeviceP
 			FilterStatus:   appstoreconnect.Enabled,
 		})
 		if err != nil {
+			var apiError *appstoreconnect.ErrorResponse
+			if ok := errors.As(err, &apiError); ok {
+				if apiError.IsCursorInvalid() {
+					return d.list400Devices(udid, platform)
+				}
+			}
 			return nil, err
 		}
 
@@ -44,6 +52,44 @@ func (d *DeviceClient) ListDevices(udid string, platform appstoreconnect.DeviceP
 			return devices, nil
 		}
 	}
+}
+
+func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.DevicePlatform) ([]appstoreconnect.Device, error) {
+	var devicesByID map[string]appstoreconnect.Device
+	var totalCount int
+	for _, sort := range []appstoreconnect.ListDevicesSortOption{appstoreconnect.ListDevicesSortOptionID, appstoreconnect.ListDevicesSortOptionIDDesc} {
+		response, err := d.client.Provisioning.ListDevices(&appstoreconnect.ListDevicesOptions{
+			PagingOptions: appstoreconnect.PagingOptions{
+				Limit: 200,
+			},
+			FilterUDID:     udid,
+			FilterPlatform: platform,
+			FilterStatus:   appstoreconnect.Enabled,
+			Sort:           sort,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, responseDevice := range response.Data {
+			devicesByID[responseDevice.Attributes.UDID] = responseDevice
+		}
+
+		if totalCount == 0 {
+			totalCount = response.Meta.Paging.Total
+		}
+	}
+
+	if totalCount > 0 && totalCount > 400 {
+		log.Warnf("More than 400 devices (%d) found", totalCount)
+	}
+
+	var devices []appstoreconnect.Device
+	for _, device := range devicesByID {
+		devices = append(devices, device)
+	}
+
+	return devices, nil
 }
 
 // RegisterDevice ...

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -59,6 +59,7 @@ func (d *DeviceClient) ListDevices(udid string, platform appstoreconnect.DeviceP
 	}
 }
 
+// list400Devices is used to work around a specific App Store Connect API bug
 func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.DevicePlatform) ([]appstoreconnect.Device, error) {
 	devicesByID := map[string]appstoreconnect.Device{}
 	var totalCount int

--- a/autocodesign/devportalclient/appstoreconnectclient/devices.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/devices.go
@@ -86,8 +86,8 @@ func (d *DeviceClient) list400Devices(udid string, platform appstoreconnect.Devi
 		}
 	}
 
-	if totalCount > 0 && totalCount > 400 {
-		log.Warnf("More than 400 devices (%d) found", totalCount)
+	if totalCount > 400 {
+		log.Warnf("Unable to retrieve all devices: more than 400 devices available (%s)", totalCount)
 	}
 
 	var devices []appstoreconnect.Device

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -67,33 +67,9 @@ func (p APIProfile) CertificateIDs() ([]string, error) {
 	return ids, nil
 }
 
-// DeviceIDs ...
-func (p APIProfile) DeviceIDs() ([]string, error) {
-	var nextPageURL string
-	var ids []string
-	for {
-		response, err := p.client.Provisioning.Devices(
-			p.profile.Relationships.Devices.Links.Related,
-			&appstoreconnect.PagingOptions{
-				Limit: 20,
-				Next:  nextPageURL,
-			},
-		)
-		if err != nil {
-			return nil, wrapInProfileError(err)
-		}
-
-		for _, device := range response.Data {
-			ids = append(ids, device.ID)
-		}
-
-		nextPageURL = response.Links.Next
-		if nextPageURL == "" {
-			break
-		}
-	}
-
-	return ids, nil
+// DeviceUDIDs ...
+func (p APIProfile) DeviceUDIDs() ([]string, error) {
+	return autocodesign.ParseRawProfileDeviceUDIDs(p.profile.Attributes.ProfileContent)
 }
 
 // BundleID ...

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -214,19 +214,20 @@ func (c *ProfileClient) deleteExpiredProfile(bundleID *appstoreconnect.BundleID,
 					for _, fallbackProfile := range fallbackProfiles {
 						if fallbackProfile.Attributes.Name == profileName {
 							profile = &fallbackProfile
-							// fix this break
-							break
+
+							return c.DeleteProfile(profile.ID)
 						}
 					}
+
+					return fmt.Errorf("failed to find profile: %s", profileName)
 				}
 			}
 			return err
 		}
 
-		for _, d := range response.Data {
-			if d.Attributes.Name == profileName {
-				profile = &d
-				break
+		for _, profile := range response.Data {
+			if profile.Attributes.Name == profileName {
+				return c.DeleteProfile(profile.ID)
 			}
 		}
 
@@ -236,11 +237,7 @@ func (c *ProfileClient) deleteExpiredProfile(bundleID *appstoreconnect.BundleID,
 		}
 	}
 
-	if profile == nil {
-		return fmt.Errorf("failed to find profile: %s", profileName)
-	}
-
-	return c.DeleteProfile(profile.ID)
+	return fmt.Errorf("failed to find profile: %s", profileName)
 }
 
 func (c *ProfileClient) list200Profiles(bundleID *appstoreconnect.BundleID) ([]appstoreconnect.Profile, error) {

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -87,7 +87,7 @@ func (p APIProfile) list200CertificateIDs() ([]string, error) {
 	}
 
 	if response.Meta.Paging.Total > 200 {
-		log.Warnf("More than 200 certificates (%d) found", response.Meta.Paging.Total)
+		log.Warnf("Unable to retrieve all certificates: more than 200 certificates available (%s)", response.Meta.Paging.Total)
 	}
 
 	var ids []string
@@ -248,7 +248,7 @@ func (c *ProfileClient) list200Profiles(bundleID *appstoreconnect.BundleID) ([]a
 		return nil, err
 	}
 	if response.Meta.Paging.Total > 200 {
-		log.Warnf("More than 200 profiles (%d) found", response.Meta.Paging.Total)
+		log.Warnf("Unable to retrieve all profiles: more than 200 profiles available (%s)", response.Meta.Paging.Total)
 	}
 
 	return response.Data, nil
@@ -351,7 +351,7 @@ func (c *ProfileClient) list400BundleIDs(bundleIDIdentifier string) ([]appstorec
 	}
 
 	if totalCount > 0 && totalCount > 400 {
-		log.Warnf("More than 400 bundleIDs (%d) found", totalCount)
+		log.Warnf("Unable to retrieve all bundleIDs: more than 400 bundleIDs available (%s)", totalCount)
 	}
 
 	var bundleIDs []appstoreconnect.BundleID

--- a/autocodesign/devportalclient/spaceship/profiles.go
+++ b/autocodesign/devportalclient/spaceship/profiles.go
@@ -46,9 +46,9 @@ func (p Profile) CertificateIDs() ([]string, error) {
 	return p.certificateIDs, nil
 }
 
-// DeviceIDs ...
-func (p Profile) DeviceIDs() ([]string, error) {
-	return p.deviceIDs, nil
+// DeviceUDIDs ...
+func (p Profile) DeviceUDIDs() ([]string, error) {
+	return autocodesign.ParseRawProfileDeviceUDIDs(p.attributes.ProfileContent)
 }
 
 // BundleID ...

--- a/autocodesign/localcodesignasset/localcodesignasset_test.go
+++ b/autocodesign/localcodesignasset/localcodesignasset_test.go
@@ -215,7 +215,7 @@ func profileFromModel(profileInfo profileutil.ProvisioningProfileInfoModel) auto
 		id:             "",
 		bundleID:       profileInfo.BundleID,
 		certificateIDs: nil,
-		deviceIDs:      nil,
+		deviceUDIDs:    nil,
 	}
 }
 

--- a/autocodesign/localcodesignasset/profile.go
+++ b/autocodesign/localcodesignasset/profile.go
@@ -29,7 +29,7 @@ func NewProfile(info profileutil.ProvisioningProfileInfoModel, content []byte) a
 		id:             "", // only in case of Developer Portal Profiles
 		bundleID:       info.BundleID,
 		certificateIDs: nil, // only in case of Developer Portal Profiles
-		deviceUDIDs:    nil, // (recheck this) only in case of Developer Portal Profiles
+		deviceUDIDs:    nil, // this is technically avaialble from the profile content, but we don't need it
 	}
 }
 

--- a/autocodesign/localcodesignasset/profile.go
+++ b/autocodesign/localcodesignasset/profile.go
@@ -12,7 +12,7 @@ type Profile struct {
 	attributes     appstoreconnect.ProfileAttributes
 	id             string
 	bundleID       string
-	deviceIDs      []string
+	deviceUDIDs    []string
 	certificateIDs []string
 }
 
@@ -29,7 +29,7 @@ func NewProfile(info profileutil.ProvisioningProfileInfoModel, content []byte) a
 		id:             "", // only in case of Developer Portal Profiles
 		bundleID:       info.BundleID,
 		certificateIDs: nil, // only in case of Developer Portal Profiles
-		deviceIDs:      nil, // only in case of Developer Portal Profiles
+		deviceUDIDs:    nil, // (recheck this) only in case of Developer Portal Profiles
 	}
 }
 
@@ -49,8 +49,8 @@ func (p Profile) CertificateIDs() ([]string, error) {
 }
 
 // DeviceIDs ...
-func (p Profile) DeviceIDs() ([]string, error) {
-	return p.deviceIDs, nil
+func (p Profile) DeviceUDIDs() ([]string, error) {
+	return p.deviceUDIDs, nil
 }
 
 // BundleID ...

--- a/autocodesign/localcodesignasset/profile.go
+++ b/autocodesign/localcodesignasset/profile.go
@@ -48,7 +48,7 @@ func (p Profile) CertificateIDs() ([]string, error) {
 	return p.certificateIDs, nil
 }
 
-// DeviceIDs ...
+// DeviceUDIDs ...
 func (p Profile) DeviceUDIDs() ([]string, error) {
 	return p.deviceUDIDs, nil
 }

--- a/autocodesign/localcodesignasset/profilelookup.go
+++ b/autocodesign/localcodesignasset/profilelookup.go
@@ -10,9 +10,9 @@ import (
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
 )
 
-func findProfile(localProfiles []profileutil.ProvisioningProfileInfoModel, platform autocodesign.Platform, distributionType autocodesign.DistributionType, bundleID string, entitlements autocodesign.Entitlements, minProfileDaysValid int, certSerials []string, deviceIDs []string) *profileutil.ProvisioningProfileInfoModel {
+func findProfile(localProfiles []profileutil.ProvisioningProfileInfoModel, platform autocodesign.Platform, distributionType autocodesign.DistributionType, bundleID string, entitlements autocodesign.Entitlements, minProfileDaysValid int, certSerials []string, deviceUDIDs []string) *profileutil.ProvisioningProfileInfoModel {
 	for _, profile := range localProfiles {
-		if isProfileMatching(profile, platform, distributionType, bundleID, entitlements, minProfileDaysValid, certSerials, deviceIDs) {
+		if isProfileMatching(profile, platform, distributionType, bundleID, entitlements, minProfileDaysValid, certSerials, deviceUDIDs) {
 			return &profile
 		}
 	}
@@ -20,7 +20,7 @@ func findProfile(localProfiles []profileutil.ProvisioningProfileInfoModel, platf
 	return nil
 }
 
-func isProfileMatching(profile profileutil.ProvisioningProfileInfoModel, platform autocodesign.Platform, distributionType autocodesign.DistributionType, bundleID string, entitlements autocodesign.Entitlements, minProfileDaysValid int, certSerials []string, deviceIDs []string) bool {
+func isProfileMatching(profile profileutil.ProvisioningProfileInfoModel, platform autocodesign.Platform, distributionType autocodesign.DistributionType, bundleID string, entitlements autocodesign.Entitlements, minProfileDaysValid int, certSerials []string, deviceUDIDs []string) bool {
 	if !isActive(profile, minProfileDaysValid) {
 		return false
 	}
@@ -45,7 +45,7 @@ func isProfileMatching(profile profileutil.ProvisioningProfileInfoModel, platfor
 		return false
 	}
 
-	if !provisionsDevices(profile, deviceIDs) {
+	if !provisionsDevices(profile, deviceUDIDs) {
 		return false
 	}
 
@@ -118,8 +118,8 @@ func hasMatchingPlatform(profile profileutil.ProvisioningProfileInfoModel, platf
 	return strings.ToLower(string(platform)) == string(profile.Type)
 }
 
-func provisionsDevices(profile profileutil.ProvisioningProfileInfoModel, deviceIDs []string) bool {
-	if profile.ProvisionsAllDevices || len(deviceIDs) == 0 {
+func provisionsDevices(profile profileutil.ProvisioningProfileInfoModel, deviceUDIDs []string) bool {
+	if profile.ProvisionsAllDevices || len(deviceUDIDs) == 0 {
 		return true
 	}
 
@@ -127,8 +127,8 @@ func provisionsDevices(profile profileutil.ProvisioningProfileInfoModel, deviceI
 		return false
 	}
 
-	for _, deviceID := range deviceIDs {
-		if contains(profile.ProvisionedDevices, deviceID) {
+	for _, deviceUDID := range deviceUDIDs {
+		if contains(profile.ProvisionedDevices, deviceUDID) {
 			continue
 		}
 		return false

--- a/autocodesign/mock_Profile.go
+++ b/autocodesign/mock_Profile.go
@@ -76,8 +76,8 @@ func (_m *MockProfile) CertificateIDs() ([]string, error) {
 	return r0, r1
 }
 
-// DeviceIDs provides a mock function with given fields:
-func (_m *MockProfile) DeviceIDs() ([]string, error) {
+// DeviceUDIDs provides a mock function with given fields:
+func (_m *MockProfile) DeviceUDIDs() ([]string, error) {
 	ret := _m.Called()
 
 	var r0 []string

--- a/autocodesign/profiles.go
+++ b/autocodesign/profiles.go
@@ -463,6 +463,16 @@ func validDeviceUDID(udid string) string {
 	return r.ReplaceAllLiteralString(udid, "")
 }
 
+// Available UDIDs (for more info see https://theapplewiki.com/wiki/UDID)
+// iDevice example:
+// - 00008020-008D4548007B4F26
+// - 9f9bb1b742882152fb1746aab7db415cea979232
+// Mac example:
+// - 0D990E91-F2D3-430D-8405-A054CEF983CF
+// For comparing UDIDs, we ignore casing as did see cases when the UDIDs mismatched, when accepting freehand UDIDs on a form.
+// This should not happen when using UDIDs returned by Apple API and also when reading the UDIDs from the provisioning profile,
+// as the provisioning profile is also created by Apple, and did not see mismatches.
+// But to be on the safe side, we ignore casing and the '-' separator.
 func normalizeDeviceUDID(udid string) string {
 	return strings.ToLower(strings.ReplaceAll(validDeviceUDID(udid), "-", ""))
 }

--- a/autocodesign/profiles_test.go
+++ b/autocodesign/profiles_test.go
@@ -271,11 +271,11 @@ func Test_checkProfileDevices(t *testing.T) {
 		{
 			name: "devices present, even when casing is different",
 			profileDeviceIDs: DeviceUDIDs{
-				"device1",
+				"00008020-008D4548007B4F26",
 				"device2",
 			},
 			deviceUDIDs: DeviceUDIDs{
-				"DEVICE1",
+				"00008020008d4548007b4f26",
 			},
 		},
 		{

--- a/autocodesign/profiles_test.go
+++ b/autocodesign/profiles_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 	"time"
 
-	devportaltime "github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
-
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/appstoreconnect"
+	devportaltime "github.com/bitrise-io/go-xcode/v2/autocodesign/devportalclient/time"
 	"github.com/stretchr/testify/require"
 )
 
@@ -241,6 +240,60 @@ func Test_IsProfileExpired(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isProfileExpired(tt.prof, tt.minProfileDaysValid); got != tt.want {
 				t.Errorf("checkProfileExpiry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_checkProfileDevices(t *testing.T) {
+	tests := []struct {
+		name             string
+		profileDeviceIDs DeviceUDIDs
+		deviceUDIDs      DeviceUDIDs
+		wantErr          bool
+	}{
+		{
+			name:             "no devices",
+			profileDeviceIDs: DeviceUDIDs{},
+			deviceUDIDs:      DeviceUDIDs{},
+			wantErr:          false,
+		},
+		{
+			name: "devices present",
+			profileDeviceIDs: DeviceUDIDs{
+				"device1",
+				"device2",
+			},
+			deviceUDIDs: DeviceUDIDs{
+				"device1",
+			},
+		},
+		{
+			name: "devices present, even when casing is different",
+			profileDeviceIDs: DeviceUDIDs{
+				"device1",
+				"device2",
+			},
+			deviceUDIDs: DeviceUDIDs{
+				"DEVICE1",
+			},
+		},
+		{
+			name: "devices not present",
+			profileDeviceIDs: DeviceUDIDs{
+				"device2",
+				"device3",
+			},
+			deviceUDIDs: DeviceUDIDs{
+				"DEVICE1",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := checkProfileDevices(tt.profileDeviceIDs, tt.deviceUDIDs); (err != nil) != tt.wantErr {
+				t.Errorf("checkProfileDevices() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
- Added fallbacks for paging API error (invalid cursor). In case the existing paging logic fails, we use workarounds such as fetch400Profiles.
- Removed API calls for devices included in profiles, this should help with rate limits in the long term. To do this we use the UDIDs to check for profile validity, instead of the opaque ID from the API.