### PR TITLE
Getter for xcodebuild command arguments

### DIFF
--- a/xcodebuild/build.go
+++ b/xcodebuild/build.go
@@ -131,9 +131,16 @@ func (c *CommandBuilder) SetTestPlan(testPlan string) *CommandBuilder {
 	return c
 }
 
-func (c *CommandBuilder) cmdSlice() []string {
+func (c CommandBuilder) cmdSlice() []string {
 	slice := []string{toolName}
-	slice = append(slice, c.actions...)
+	slice = append(slice, c.CommandArgs()...)
+
+	return slice
+}
+
+// CommandArgs returns the xcodebuild command arguments, including actions and options
+func (c CommandBuilder) CommandArgs() []string {
+	slice := append([]string{}, c.actions...)
 
 	if c.projectPath != "" {
 		if filepath.Ext(c.projectPath) == XCWorkspaceExtension {

--- a/xcodebuild/build.go
+++ b/xcodebuild/build.go
@@ -131,7 +131,7 @@ func (c *CommandBuilder) SetTestPlan(testPlan string) *CommandBuilder {
 	return c
 }
 
-func (c CommandBuilder) cmdSlice() []string {
+func (c *CommandBuilder) cmdSlice() []string {
 	slice := []string{toolName}
 	slice = append(slice, c.CommandArgs()...)
 
@@ -139,7 +139,7 @@ func (c CommandBuilder) cmdSlice() []string {
 }
 
 // CommandArgs returns the xcodebuild command arguments, including actions and options
-func (c CommandBuilder) CommandArgs() []string {
+func (c *CommandBuilder) CommandArgs() []string {
 	slice := append([]string{}, c.actions...)
 
 	if c.projectPath != "" {
@@ -197,25 +197,25 @@ func (c CommandBuilder) CommandArgs() []string {
 }
 
 // PrintableCmd ...
-func (c CommandBuilder) PrintableCmd() string {
+func (c *CommandBuilder) PrintableCmd() string {
 	cmdSlice := c.cmdSlice()
 	return command.PrintableCommandArgs(false, cmdSlice)
 }
 
 // Command ...
-func (c CommandBuilder) Command() *command.Model {
+func (c *CommandBuilder) Command() *command.Model {
 	cmdSlice := c.cmdSlice()
 	return command.New(cmdSlice[0], cmdSlice[1:]...)
 }
 
 // ExecCommand ...
-func (c CommandBuilder) ExecCommand() *exec.Cmd {
+func (c *CommandBuilder) ExecCommand() *exec.Cmd {
 	command := c.Command()
 	return command.GetCmd()
 }
 
 // Run ...
-func (c CommandBuilder) Run() error {
+func (c *CommandBuilder) Run() error {
 	command := c.Command()
 
 	command.SetStdout(os.Stdout)

--- a/xcodebuild/build_test.go
+++ b/xcodebuild/build_test.go
@@ -1,9 +1,9 @@
 package xcodebuild
 
 import (
-	"reflect"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommandBuilder_cmdSlice(t *testing.T) {
@@ -187,9 +187,11 @@ func TestCommandBuilder_cmdSlice(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.builder().cmdSlice()
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CommandBuilder.cmdSlice() = %v\nwant %v", strings.Join(got, "\n"), strings.Join(tt.want, "\n"))
-			}
+			require.Equal(t, tt.want, got)
+
+			got = append(got, "extra")
+			got2 := tt.builder().cmdSlice()
+			require.Equal(t, tt.want, got2, "Second run after appending extra should not change the result")
 		})
 	}
 }

--- a/xcodebuild/build_test.go
+++ b/xcodebuild/build_test.go
@@ -189,7 +189,7 @@ func TestCommandBuilder_cmdSlice(t *testing.T) {
 			got := tt.builder().cmdSlice()
 			require.Equal(t, tt.want, got)
 
-			got = append(got, "extra")
+			got = append(got, "extra") // nolint:ineffassign
 			got2 := tt.builder().cmdSlice()
 			require.Equal(t, tt.want, got2, "Second run after appending extra should not change the result")
 		})

--- a/xcodebuild/build_test.go
+++ b/xcodebuild/build_test.go
@@ -189,9 +189,8 @@ func TestCommandBuilder_cmdSlice(t *testing.T) {
 			got := tt.builder().cmdSlice()
 			require.Equal(t, tt.want, got)
 
-			got = append(got, "extra") // nolint:ineffassign
 			got2 := tt.builder().cmdSlice()
-			require.Equal(t, tt.want, got2, "Second run after appending extra should not change the result")
+			require.Equal(t, tt.want, got2, "Second run should return the same result")
 		})
 	}
 }

--- a/xcodebuild/export.go
+++ b/xcodebuild/export.go
@@ -53,7 +53,7 @@ func (c *ExportCommandModel) SetAuthentication(authenticationParams Authenticati
 	return c
 }
 
-func (c ExportCommandModel) cmdSlice() []string {
+func (c *ExportCommandModel) cmdSlice() []string {
 	slice := []string{toolName}
 	slice = append(slice, c.CommandArgs()...)
 
@@ -61,7 +61,7 @@ func (c ExportCommandModel) cmdSlice() []string {
 }
 
 // CommandArgs returns the xcodebuild command arguments for the export action
-func (c ExportCommandModel) CommandArgs() []string {
+func (c *ExportCommandModel) CommandArgs() []string {
 	slice := []string{"-exportArchive"}
 	if c.archivePath != "" {
 		slice = append(slice, "-archivePath", c.archivePath)
@@ -83,25 +83,25 @@ func (c ExportCommandModel) CommandArgs() []string {
 }
 
 // PrintableCmd ...
-func (c ExportCommandModel) PrintableCmd() string {
+func (c *ExportCommandModel) PrintableCmd() string {
 	cmdSlice := c.cmdSlice()
 	return command.PrintableCommandArgs(false, cmdSlice)
 }
 
 // Command ...
-func (c ExportCommandModel) Command() *command.Model {
+func (c *ExportCommandModel) Command() *command.Model {
 	cmdSlice := c.cmdSlice()
 	return command.New(cmdSlice[0], cmdSlice[1:]...)
 }
 
 // Cmd ...
-func (c ExportCommandModel) Cmd() *exec.Cmd {
+func (c *ExportCommandModel) Cmd() *exec.Cmd {
 	command := c.Command()
 	return command.GetCmd()
 }
 
 // Run ...
-func (c ExportCommandModel) Run() error {
+func (c *ExportCommandModel) Run() error {
 	command := c.Command()
 
 	command.SetStdout(os.Stdout)
@@ -111,7 +111,7 @@ func (c ExportCommandModel) Run() error {
 }
 
 // RunAndReturnOutput ...
-func (c ExportCommandModel) RunAndReturnOutput() (string, error) {
+func (c *ExportCommandModel) RunAndReturnOutput() (string, error) {
 	command := c.Command()
 
 	var outBuffer bytes.Buffer

--- a/xcodebuild/export.go
+++ b/xcodebuild/export.go
@@ -54,7 +54,15 @@ func (c *ExportCommandModel) SetAuthentication(authenticationParams Authenticati
 }
 
 func (c ExportCommandModel) cmdSlice() []string {
-	slice := []string{toolName, "-exportArchive"}
+	slice := []string{toolName}
+	slice = append(slice, c.CommandArgs()...)
+
+	return slice
+}
+
+// CommandArgs returns the xcodebuild command arguments for the export action
+func (c ExportCommandModel) CommandArgs() []string {
+	slice := []string{"-exportArchive"}
 	if c.archivePath != "" {
 		slice = append(slice, "-archivePath", c.archivePath)
 	}

--- a/xcodebuild/export_test.go
+++ b/xcodebuild/export_test.go
@@ -1,0 +1,66 @@
+package xcodebuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportCommandModel_cmdSlice(t *testing.T) {
+	tests := []struct {
+		name               string
+		archivePath        string
+		exportDir          string
+		exportOptionsPlist string
+		authentication     *AuthenticationParams
+		want               []string
+	}{
+		{
+			name:               "basic export",
+			archivePath:        "sample.xcarchive",
+			exportDir:          "/var/exported",
+			exportOptionsPlist: "/var/export_options.plist",
+			want: []string{"xcodebuild",
+				"-exportArchive",
+				"-archivePath", "sample.xcarchive",
+				"-exportPath", "/var/exported",
+				"-exportOptionsPlist", "/var/export_options.plist",
+			},
+		},
+		{
+			name:        "export with authentication",
+			archivePath: "sample.xcarchive",
+			authentication: &AuthenticationParams{
+				KeyID:     "keyID",
+				IsssuerID: "issuerID",
+				KeyPath:   "/key/path",
+			},
+			want: []string{"xcodebuild",
+				"-exportArchive",
+				"-archivePath", "sample.xcarchive",
+				"-allowProvisioningUpdates",
+				"-authenticationKeyPath", "/key/path",
+				"-authenticationKeyID", "keyID",
+				"-authenticationKeyIssuerID", "issuerID",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewExportCommand()
+			c.SetArchivePath(tt.archivePath)
+			c.SetExportDir(tt.exportDir)
+			c.SetExportOptionsPlist(tt.exportOptionsPlist)
+			if tt.authentication != nil {
+				c.SetAuthentication(*tt.authentication)
+			}
+
+			got := c.cmdSlice()
+			require.Equal(t, tt.want, got)
+
+			got = append(got, "extra")
+			got2 := c.cmdSlice()
+			require.Equal(t, tt.want, got2, "result should not be modified")
+		})
+	}
+}

--- a/xcodebuild/export_test.go
+++ b/xcodebuild/export_test.go
@@ -58,7 +58,7 @@ func TestExportCommandModel_cmdSlice(t *testing.T) {
 			got := c.cmdSlice()
 			require.Equal(t, tt.want, got)
 
-			got = append(got, "extra")
+			got = append(got, "extra") // nolint:ineffassign
 			got2 := c.cmdSlice()
 			require.Equal(t, tt.want, got2, "result should not be modified")
 		})

--- a/xcodebuild/export_test.go
+++ b/xcodebuild/export_test.go
@@ -58,9 +58,8 @@ func TestExportCommandModel_cmdSlice(t *testing.T) {
 			got := c.cmdSlice()
 			require.Equal(t, tt.want, got)
 
-			got = append(got, "extra") // nolint:ineffassign
 			got2 := c.cmdSlice()
-			require.Equal(t, tt.want, got2, "result should not be modified")
+			require.Equal(t, tt.want, got2, "Second run should return the same result")
 		})
 	}
 }


### PR DESCRIPTION
Added CommandArgs function for the xcodebuild CommandBuilder, this removes the dependency on the v1 command package and helps with xcbeautify support integration.
The existing xcodecommand package only requires xcodebuild arguments, with this change we do no need:

```go
xcodebuildCmdWithArgs := archiveCmd.ExecCommand().Args
if len(xcodebuildCmdWithArgs) == 0 {
  panic("")
}
onlyArgs = xcodebuildCmdWithArgs[1:]
```

only:
```go
onlyArgs := archiveCmd.CommandArgs()
```