### PR TITLE
Do not overwrite build settings

### DIFF
--- a/xcodebuild/show_build_settings.go
+++ b/xcodebuild/show_build_settings.go
@@ -96,6 +96,9 @@ func (c ShowBuildSettingsCommandModel) PrintableCmd() string {
 	return command.PrintableCommandArgs(false, cmdSlice)
 }
 
+// parseBuildSettings parses xcodebuild -showBuildSettings output into a map of build settings.
+// When using multi-target schemes, the output may contain multiple entries for the same key.
+// In this case, the first occurrence of each key is used, which corresponds to the main target.
 func parseBuildSettings(out string) (serialized.Object, error) {
 	settings := serialized.Object{}
 
@@ -122,7 +125,10 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 				value := strings.TrimSpace(strings.Join(split[1:], "="))
 				value = strings.Trim(value, `"`)
 
-				settings[key] = value
+				// Use the first occurrence of each key (the main target in case of multi-target schemes)
+				if _, exists := settings[key]; !exists {
+					settings[key] = value
+				}
 			}
 
 			buffer.Reset()


### PR DESCRIPTION
The main issue was in parseBuildSettings() where duplicate keys were being overwritten. In multi-target schemes, xcodebuild -showBuildSettings outputs settings for all targets sequentially:

Build settings for action build and target "MainApp":
    PRODUCT_BUNDLE_IDENTIFIER = com.company.app
    DEVELOPMENT_TEAM = ABC123

Build settings for action build and target "NotificationService":
    PRODUCT_BUNDLE_IDENTIFIER = com.company.app.notifications
    DEVELOPMENT_TEAM = XYZ789
    
The parser was keeping the last occurrence (last target in scheme build targets list), but we need the first occurrence (first target in scheme build targets list) for correct bundle ID resolution.