### PR TITLE
Handle omitted dependencies key

### DIFF
--- a/xcodeproject/xcodeproj/target.go
+++ b/xcodeproject/xcodeproj/target.go
@@ -129,7 +129,10 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 
 	dependencyIDs, err := rawTarget.StringSlice("dependencies")
 	if err != nil {
-		return Target{}, err
+		if !serialized.IsKeyNotFoundError(err) {
+			return Target{}, err
+		}
+		dependencyIDs = []string{} // If the key is omitted, there are no dependencies.
 	}
 
 	var dependencies []TargetDependency


### PR DESCRIPTION
Newer versions of Xcode may omit the dependencies key when a target has no dependencies.