### PR TITLE
Step 2170 codesigngroups refactor filtering

### DIFF
--- a/exportoptionsgenerator/codesign_group_provider.go
+++ b/exportoptionsgenerator/codesign_group_provider.go
@@ -62,7 +62,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 	if len(bundleIDToEntitlements) > 0 {
 		g.logger.Printf("Filtering code signing groups for target capabilities")
 
-		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateEntitlementsFilter(convertToV1PlistData(bundleIDToEntitlements)))
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateEntitlementsFilter(bundleIDToEntitlements))
 
 		g.logger.Debugf("\nGroups after filtering for target capabilities:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))

--- a/exportoptionsgenerator/codesign_group_provider.go
+++ b/exportoptionsgenerator/codesign_group_provider.go
@@ -65,7 +65,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 	if len(bundleIDEntitlementsMap) > 0 {
 		g.logger.Printf("Filtering code signing groups for target capabilities")
 
-		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateEntitlementsSelectableCodeSignGroupFilter(convertToV1PlistData(bundleIDEntitlementsMap)))
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateEntitlementsFilter(convertToV1PlistData(bundleIDEntitlementsMap)))
 
 		g.logger.Debugf("\nGroups after filtering for target capabilities:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -73,7 +73,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 
 	g.logger.Printf("Filtering code signing groups for export method %s", exportMethod)
 
-	codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateExportMethodSelectableCodeSignGroupFilter(exportMethod))
+	codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateExportMethodFilter(exportMethod))
 
 	g.logger.Debugf("\nGroups after filtering for export method:")
 	g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -81,7 +81,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 	if teamID != "" {
 		g.logger.Printf("Development team specified: %s, filtering groups...", teamID)
 
-		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateTeamSelectableCodeSignGroupFilter(teamID))
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateTeamIDFilter(teamID))
 
 		g.logger.Debugf("\nGroups after filtering for team ID:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -92,7 +92,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 			"only NON Xcode managed profiles are allowed to sign when exporting the archive.\n" +
 			"Removing Xcode managed code signing groups")
 
-		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateNotXcodeManagedSelectableCodeSignGroupFilter())
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateNonXcodeManagedFilter())
 
 		g.logger.Debugf("\nGroups after filtering for NON Xcode managed profiles:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -101,7 +101,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 	if teamID == "" && defaultProfile != nil {
 		g.logger.Debugf("\ndefault profile: %v\n", defaultProfile)
 		filteredCodeSignGroups := codesigngroup.MapGroups(codeSignGroups,
-			codesigngroup.CreateExcludeProfileNameSelectableCodeSignGroupFilter(defaultProfile.Name))
+			codesigngroup.CreateExcludeProfileNameFilter(defaultProfile.Name))
 		if len(filteredCodeSignGroups) > 0 {
 			codeSignGroups = filteredCodeSignGroups
 			g.logger.Printf("Removed default profile '%s' from code signing groups", defaultProfile.Name)

--- a/exportoptionsgenerator/codesign_group_provider.go
+++ b/exportoptionsgenerator/codesign_group_provider.go
@@ -28,13 +28,10 @@ func NewCodeSignGroupProvider(logger log.Logger) CodeSignGroupProvider {
 }
 
 // DetermineCodesignGroup ....
-func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, defaultProfile *profileutil.ProvisioningProfileInfoModel, bundleIDEntitlementsMap map[string]plistutil.PlistData, exportMethod exportoptions.Method, teamID string, xcodeManaged bool) (*codesigngroup.Ios, error) {
+func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, defaultProfile *profileutil.ProvisioningProfileInfoModel, bundleIDToEntitlements map[string]plistutil.PlistData, exportMethod exportoptions.Method, teamID string, xcodeManaged bool) (*codesigngroup.Ios, error) {
 	g.logger.Println()
 	g.logger.Printf("Target Bundle ID - Entitlements map")
-	var bundleIDs []string
-	for bundleID, entitlements := range bundleIDEntitlementsMap {
-		bundleIDs = append(bundleIDs, bundleID)
-
+	for bundleID, entitlements := range bundleIDToEntitlements {
 		var entitlementKeys []string
 		for key := range entitlements {
 			entitlementKeys = append(entitlementKeys, key)
@@ -54,7 +51,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 
 	g.logger.Println()
 	g.logger.Printf("Resolving code signing groups...")
-	codeSignGroups := codesigngroup.BuildFilterableList(certificates, profiles, bundleIDs)
+	codeSignGroups := codesigngroup.BuildFilterableList(certificates, profiles, bundleIDToEntitlements)
 	if len(codeSignGroups) == 0 {
 		g.logger.Errorf("Failed to find code signing groups for specified export method (%s)", exportMethod)
 	}
@@ -62,10 +59,10 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 	g.logger.Debugf("\nGroups:")
 	g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
 
-	if len(bundleIDEntitlementsMap) > 0 {
+	if len(bundleIDToEntitlements) > 0 {
 		g.logger.Printf("Filtering code signing groups for target capabilities")
 
-		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateEntitlementsFilter(convertToV1PlistData(bundleIDEntitlementsMap)))
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateEntitlementsFilter(convertToV1PlistData(bundleIDToEntitlements)))
 
 		g.logger.Debugf("\nGroups after filtering for target capabilities:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))

--- a/exportoptionsgenerator/codesign_group_provider.go
+++ b/exportoptionsgenerator/codesign_group_provider.go
@@ -65,7 +65,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 	if len(bundleIDEntitlementsMap) > 0 {
 		g.logger.Printf("Filtering code signing groups for target capabilities")
 
-		codeSignGroups = codesigngroup.Filter(codeSignGroups, codesigngroup.CreateEntitlementsSelectableCodeSignGroupFilter(convertToV1PlistData(bundleIDEntitlementsMap)))
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateEntitlementsSelectableCodeSignGroupFilter(convertToV1PlistData(bundleIDEntitlementsMap)))
 
 		g.logger.Debugf("\nGroups after filtering for target capabilities:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -73,7 +73,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 
 	g.logger.Printf("Filtering code signing groups for export method %s", exportMethod)
 
-	codeSignGroups = codesigngroup.Filter(codeSignGroups, codesigngroup.CreateExportMethodSelectableCodeSignGroupFilter(exportMethod))
+	codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateExportMethodSelectableCodeSignGroupFilter(exportMethod))
 
 	g.logger.Debugf("\nGroups after filtering for export method:")
 	g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -81,7 +81,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 	if teamID != "" {
 		g.logger.Printf("Development team specified: %s, filtering groups...", teamID)
 
-		codeSignGroups = codesigngroup.Filter(codeSignGroups, codesigngroup.CreateTeamSelectableCodeSignGroupFilter(teamID))
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateTeamSelectableCodeSignGroupFilter(teamID))
 
 		g.logger.Debugf("\nGroups after filtering for team ID:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -92,7 +92,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 			"only NON Xcode managed profiles are allowed to sign when exporting the archive.\n" +
 			"Removing Xcode managed code signing groups")
 
-		codeSignGroups = codesigngroup.Filter(codeSignGroups, codesigngroup.CreateNotXcodeManagedSelectableCodeSignGroupFilter())
+		codeSignGroups = codesigngroup.MapGroups(codeSignGroups, codesigngroup.CreateNotXcodeManagedSelectableCodeSignGroupFilter())
 
 		g.logger.Debugf("\nGroups after filtering for NON Xcode managed profiles:")
 		g.logger.Debugf("%s", g.printer.ListToDebugString(codeSignGroups))
@@ -100,7 +100,7 @@ func (g codeSignGroupProvider) DetermineCodesignGroup(certificates []certificate
 
 	if teamID == "" && defaultProfile != nil {
 		g.logger.Debugf("\ndefault profile: %v\n", defaultProfile)
-		filteredCodeSignGroups := codesigngroup.Filter(codeSignGroups,
+		filteredCodeSignGroups := codesigngroup.MapGroups(codeSignGroups,
 			codesigngroup.CreateExcludeProfileNameSelectableCodeSignGroupFilter(defaultProfile.Name))
 		if len(filteredCodeSignGroups) > 0 {
 			codeSignGroups = filteredCodeSignGroups

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup.go
@@ -55,11 +55,10 @@ func BuildFilterableList(installedCertificates []certificateutil.CertificateInfo
 		}
 
 		if len(bundleIDToProfiles) == len(bundleIDToEntitlements) {
-			group := Selectable{
+			groups = append(groups, Selectable{
 				Certificate:         certificate,
 				BundleIDProfilesMap: bundleIDToProfiles,
-			}
-			groups = append(groups, group)
+			})
 		}
 	}
 

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bitrise-io/go-xcode/certificateutil"
 	"github.com/bitrise-io/go-xcode/profileutil"
+	"github.com/bitrise-io/go-xcode/v2/plistutil"
 	"github.com/ryanuber/go-glob"
 )
 
@@ -15,7 +16,7 @@ type Selectable struct {
 }
 
 // BuildFilterableList ...
-func BuildFilterableList(installedCertificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, bundleIDs []string) []Selectable {
+func BuildFilterableList(installedCertificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, bundleIDToEntitlements map[string]plistutil.PlistData) []Selectable {
 	var groups []Selectable
 
 	serialToProfiles := map[string][]profileutil.ProvisioningProfileInfoModel{}
@@ -35,7 +36,7 @@ func BuildFilterableList(installedCertificates []certificateutil.CertificateInfo
 		certificate := serialToCertificate[serial]
 
 		bundleIDToProfiles := map[string][]profileutil.ProvisioningProfileInfoModel{}
-		for _, bundleID := range bundleIDs {
+		for bundleID := range bundleIDToEntitlements {
 			var matchingProfiles []profileutil.ProvisioningProfileInfoModel
 			for _, profile := range profiles {
 				if !glob.Glob(profile.BundleID, bundleID) {
@@ -53,7 +54,7 @@ func BuildFilterableList(installedCertificates []certificateutil.CertificateInfo
 			}
 		}
 
-		if len(bundleIDToProfiles) == len(bundleIDs) {
+		if len(bundleIDToProfiles) == len(bundleIDToEntitlements) {
 			group := Selectable{
 				Certificate:         certificate,
 				BundleIDProfilesMap: bundleIDToProfiles,

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup.go
@@ -8,15 +8,15 @@ import (
 	"github.com/ryanuber/go-glob"
 )
 
-// SelectableCodeSignGroup ...
-type SelectableCodeSignGroup struct {
+// Selectable ...
+type Selectable struct {
 	Certificate         certificateutil.CertificateInfoModel
 	BundleIDProfilesMap map[string][]profileutil.ProvisioningProfileInfoModel
 }
 
 // BuildFilterableList ...
-func BuildFilterableList(installedCertificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, bundleIDs []string) []SelectableCodeSignGroup {
-	var groups []SelectableCodeSignGroup
+func BuildFilterableList(installedCertificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, bundleIDs []string) []Selectable {
+	var groups []Selectable
 
 	serialToProfiles := map[string][]profileutil.ProvisioningProfileInfoModel{}
 	serialToCertificate := map[string]certificateutil.CertificateInfoModel{}
@@ -54,7 +54,7 @@ func BuildFilterableList(installedCertificates []certificateutil.CertificateInfo
 		}
 
 		if len(bundleIDToProfiles) == len(bundleIDs) {
-			group := SelectableCodeSignGroup{
+			group := Selectable{
 				Certificate:         certificate,
 				BundleIDProfilesMap: bundleIDToProfiles,
 			}

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/go-xcode/exportoptions"
 	"github.com/bitrise-io/go-xcode/profileutil"
 	"github.com/bitrise-io/go-xcode/v2/exportoptionsgenerator/internal/codesigngroup"
+	"github.com/bitrise-io/go-xcode/v2/plistutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,7 +55,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 		name         string
 		certificates []certificateutil.CertificateInfoModel
 		profiles     []profileutil.ProvisioningProfileInfoModel
-		bundleIDs    []string
+		bundleIDs    map[string]plistutil.PlistData
 		filter       codesigngroup.GroupMapFunc
 		want         []codesigngroup.Selectable
 	}{
@@ -62,14 +63,16 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			name:         "empty inputs",
 			certificates: []certificateutil.CertificateInfoModel{},
 			profiles:     []profileutil.ProvisioningProfileInfoModel{},
-			bundleIDs:    []string{},
+			bundleIDs:    map[string]plistutil.PlistData{},
 			want:         []codesigngroup.Selectable(nil),
 		},
 		{
 			name:         "single matching profile and certificate",
 			certificates: []certificateutil.CertificateInfoModel{certDev},
 			profiles:     []profileutil.ProvisioningProfileInfoModel{profileDev},
-			bundleIDs:    []string{"io.bitrise.testapp"},
+			bundleIDs: map[string]plistutil.PlistData{
+				"io.bitrise.testapp": {},
+			},
 			want: []codesigngroup.Selectable{
 				{
 					Certificate: certDev,
@@ -87,7 +90,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			profiles: []profileutil.ProvisioningProfileInfoModel{
 				profileDev,
 			},
-			bundleIDs: []string{"io.bitrise.testapp"},
+			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
 			filter:    codesigngroup.CreateTeamIDFilter("WRONGID"),
 			want:      []codesigngroup.Selectable(nil),
 		},
@@ -101,8 +104,11 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileExt,
 				wildcarDev,
 			},
-			bundleIDs: []string{"io.bitrise.testapp", "io.bitrise.testapp.appext"},
-			filter:    codesigngroup.CreateTeamIDFilter("ABCD1234"),
+			bundleIDs: map[string]plistutil.PlistData{
+				"io.bitrise.testapp":        {},
+				"io.bitrise.testapp.appext": {},
+			},
+			filter: codesigngroup.CreateTeamIDFilter("ABCD1234"),
 			want: []codesigngroup.Selectable{
 				{
 					Certificate: certDev,
@@ -121,7 +127,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			profiles: []profileutil.ProvisioningProfileInfoModel{
 				profileDev,
 			},
-			bundleIDs: []string{"io.bitrise.testapp"},
+			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
 			filter:    codesigngroup.CreateExportMethodFilter(exportoptions.MethodAdHoc),
 			want:      []codesigngroup.Selectable(nil),
 		},
@@ -135,9 +141,9 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileExt,
 				managedProflile,
 			},
-			bundleIDs: []string{
-				"io.bitrise.testapp",
-				"io.bitrise.testapp.appext", // no managed profile provided
+			bundleIDs: map[string]plistutil.PlistData{
+				"io.bitrise.testapp":        {},
+				"io.bitrise.testapp.appext": {}, // no managed profile provided
 			},
 			filter: codesigngroup.CreateXcodeManagedFilter(),
 			want:   []codesigngroup.Selectable(nil),
@@ -151,7 +157,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileDev,
 				managedProflile,
 			},
-			bundleIDs: []string{"io.bitrise.testapp"},
+			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
 			filter:    codesigngroup.CreateNonXcodeManagedFilter(),
 			want: []codesigngroup.Selectable{
 				{
@@ -171,7 +177,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileDev,
 				profileExt,
 			},
-			bundleIDs: []string{"io.bitrise.testapp"},
+			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
 			filter:    codesigngroup.CreateExcludeProfileNameFilter("Nonmathcing Profile"),
 			want: []codesigngroup.Selectable{
 				{
@@ -191,9 +197,12 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileDev,
 				profileExt,
 			},
-			bundleIDs: []string{"io.bitrise.testapp", "io.bitrise.testapp.appext"},
-			filter:    codesigngroup.CreateExcludeProfileNameFilter("Bitrise Test Profile"),
-			want:      nil,
+			bundleIDs: map[string]plistutil.PlistData{
+				"io.bitrise.testapp":        {},
+				"io.bitrise.testapp.appext": {},
+			},
+			filter: codesigngroup.CreateExcludeProfileNameFilter("Bitrise Test Profile"),
+			want:   nil,
 		},
 	}
 	for _, tt := range tests {

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-xcode/certificateutil"
 	"github.com/bitrise-io/go-xcode/exportoptions"
+	v1plistutil "github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-io/go-xcode/profileutil"
 	"github.com/bitrise-io/go-xcode/v2/exportoptionsgenerator/internal/codesigngroup"
 	"github.com/bitrise-io/go-xcode/v2/plistutil"
@@ -18,8 +19,9 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 		CommonName: "iPhone Distribution: Bitrise Test (ABCD1234)",
 		TeamID:     "ABCD1234",
 	}
-	profileDev := profileutil.ProvisioningProfileInfoModel{
+	profile := profileutil.ProvisioningProfileInfoModel{
 		Name:                  "Bitrise Test Profile",
+		Type:                  profileutil.ProfileTypeIos,
 		UUID:                  "PROFILE-UUID-1234",
 		TeamID:                "ABCD1234",
 		BundleID:              "io.bitrise.testapp",
@@ -28,6 +30,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 	}
 	profileExt := profileutil.ProvisioningProfileInfoModel{
 		Name:                  "Bitrise Test Profile 2",
+		Type:                  profileutil.ProfileTypeIos,
 		UUID:                  "PROFILE-UUID-1235",
 		TeamID:                "ABCD1234",
 		BundleID:              "io.bitrise.testapp.appext",
@@ -36,6 +39,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 	}
 	wildcarDev := profileutil.ProvisioningProfileInfoModel{
 		Name:                  "Bitrise Test Profile *",
+		Type:                  profileutil.ProfileTypeIos,
 		UUID:                  "PROFILE-UUID-1236",
 		TeamID:                "ABCD1234",
 		BundleID:              "io.bitrise.*",
@@ -44,11 +48,22 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 	}
 	managedProflile := profileutil.ProvisioningProfileInfoModel{
 		Name:                  "iOS Team Provisioning Profile: io.bitrise.testapp", // managed by Xcode
+		Type:                  profileutil.ProfileTypeIos,
 		UUID:                  "PROFILE-UUID-1237",
 		TeamID:                "ABCD1234",
 		BundleID:              "io.bitrise.testapp",
 		ExportType:            exportoptions.MethodAppStore,
 		DeveloperCertificates: []certificateutil.CertificateInfoModel{certDev},
+	}
+	profileWithEntitlement := profileutil.ProvisioningProfileInfoModel{
+		Name:                  "Bitrise Test Profile",
+		Type:                  profileutil.ProfileTypeIos,
+		UUID:                  "PROFILE-UUID-1234",
+		TeamID:                "ABCD1234",
+		BundleID:              "io.bitrise.testapp",
+		ExportType:            exportoptions.MethodAppStore,
+		DeveloperCertificates: []certificateutil.CertificateInfoModel{certDev},
+		Entitlements:          v1plistutil.PlistData{"aps-environment": "value1"},
 	}
 
 	tests := []struct {
@@ -69,7 +84,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 		{
 			name:         "single matching profile and certificate",
 			certificates: []certificateutil.CertificateInfoModel{certDev},
-			profiles:     []profileutil.ProvisioningProfileInfoModel{profileDev},
+			profiles:     []profileutil.ProvisioningProfileInfoModel{profile},
 			bundleIDs: map[string]plistutil.PlistData{
 				"io.bitrise.testapp": {},
 			},
@@ -77,7 +92,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
-						"io.bitrise.testapp": {profileDev},
+						"io.bitrise.testapp": {profile},
 					},
 				},
 			},
@@ -88,7 +103,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
-				profileDev,
+				profile,
 			},
 			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
 			filter:    codesigngroup.CreateTeamIDFilter("WRONGID"),
@@ -100,7 +115,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
-				profileDev,
+				profile,
 				profileExt,
 				wildcarDev,
 			},
@@ -113,7 +128,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
-						"io.bitrise.testapp":        {profileDev, wildcarDev},
+						"io.bitrise.testapp":        {profile, wildcarDev},
 						"io.bitrise.testapp.appext": {profileExt, wildcarDev},
 					},
 				},
@@ -125,7 +140,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
-				profileDev,
+				profile,
 			},
 			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
 			filter:    codesigngroup.CreateExportMethodFilter(exportoptions.MethodAdHoc),
@@ -137,7 +152,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
-				profileDev,
+				profile,
 				profileExt,
 				managedProflile,
 			},
@@ -154,7 +169,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
-				profileDev,
+				profile,
 				managedProflile,
 			},
 			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
@@ -163,7 +178,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
-						"io.bitrise.testapp": {profileDev},
+						"io.bitrise.testapp": {profile},
 					},
 				},
 			},
@@ -174,7 +189,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
-				profileDev,
+				profile,
 				profileExt,
 			},
 			bundleIDs: map[string]plistutil.PlistData{"io.bitrise.testapp": {}},
@@ -183,7 +198,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
-						"io.bitrise.testapp": {profileDev},
+						"io.bitrise.testapp": {profile},
 					},
 				},
 			},
@@ -194,7 +209,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
-				profileDev,
+				profile,
 				profileExt,
 			},
 			bundleIDs: map[string]plistutil.PlistData{
@@ -203,6 +218,53 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			},
 			filter: codesigngroup.CreateExcludeProfileNameFilter("Bitrise Test Profile"),
 			want:   nil,
+		},
+		{
+			name: "enitlements filter - no match",
+			certificates: []certificateutil.CertificateInfoModel{
+				certDev,
+			},
+			profiles: []profileutil.ProvisioningProfileInfoModel{
+				profile,
+				profileExt,
+			},
+			bundleIDs: map[string]plistutil.PlistData{
+				"io.bitrise.testapp":        {"aps-environment": "value1"},
+				"io.bitrise.testapp.appext": {},
+			},
+			filter: codesigngroup.CreateEntitlementsFilter(map[string]plistutil.PlistData{
+				"io.bitrise.testapp":        {"aps-environment": "value1"},
+				"io.bitrise.testapp.appext": {},
+			}),
+			want: []codesigngroup.Selectable(nil),
+		},
+		{
+			name: "enitlements filter - match",
+			certificates: []certificateutil.CertificateInfoModel{
+				certDev,
+			},
+			profiles: []profileutil.ProvisioningProfileInfoModel{
+				profile,
+				profileWithEntitlement,
+				profileExt,
+			},
+			bundleIDs: map[string]plistutil.PlistData{
+				"io.bitrise.testapp":        {"aps-environment": "value1"},
+				"io.bitrise.testapp.appext": {},
+			},
+			filter: codesigngroup.CreateEntitlementsFilter(map[string]plistutil.PlistData{
+				"io.bitrise.testapp":        {"aps-environment": "value1"},
+				"io.bitrise.testapp.appext": {},
+			}),
+			want: []codesigngroup.Selectable{
+				{
+					Certificate: certDev,
+					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
+						"io.bitrise.testapp":        {profileWithEntitlement},
+						"io.bitrise.testapp.appext": {profileExt},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
@@ -3,6 +3,7 @@ package codesigngroup_test
 import (
 	"testing"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-xcode/certificateutil"
 	"github.com/bitrise-io/go-xcode/exportoptions"
 	"github.com/bitrise-io/go-xcode/profileutil"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestCreateSelectableCodeSignGroups(t *testing.T) {
+	printer := codesigngroup.NewPrinter(log.NewLogger())
 	certDev := certificateutil.CertificateInfoModel{
 		CommonName: "iPhone Distribution: Bitrise Test (ABCD1234)",
 		TeamID:     "ABCD1234",
@@ -18,6 +20,30 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 	profileDev := profileutil.ProvisioningProfileInfoModel{
 		Name:                  "Bitrise Test Profile",
 		UUID:                  "PROFILE-UUID-1234",
+		TeamID:                "ABCD1234",
+		BundleID:              "io.bitrise.testapp",
+		ExportType:            exportoptions.MethodAppStore,
+		DeveloperCertificates: []certificateutil.CertificateInfoModel{certDev},
+	}
+	profileExt := profileutil.ProvisioningProfileInfoModel{
+		Name:                  "Bitrise Test Profile 2",
+		UUID:                  "PROFILE-UUID-1235",
+		TeamID:                "ABCD1234",
+		BundleID:              "io.bitrise.testapp.appext",
+		ExportType:            exportoptions.MethodAppStore,
+		DeveloperCertificates: []certificateutil.CertificateInfoModel{certDev},
+	}
+	wildcarDev := profileutil.ProvisioningProfileInfoModel{
+		Name:                  "Bitrise Test Profile *",
+		UUID:                  "PROFILE-UUID-1236",
+		TeamID:                "ABCD1234",
+		BundleID:              "io.bitrise.*",
+		ExportType:            exportoptions.MethodAppStore,
+		DeveloperCertificates: []certificateutil.CertificateInfoModel{certDev},
+	}
+	managedProflile := profileutil.ProvisioningProfileInfoModel{
+		Name:                  "iOS Team Provisioning Profile: io.bitrise.testapp", // managed by Xcode
+		UUID:                  "PROFILE-UUID-1237",
 		TeamID:                "ABCD1234",
 		BundleID:              "io.bitrise.testapp",
 		ExportType:            exportoptions.MethodAppStore,
@@ -66,26 +92,29 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			want:      []codesigngroup.SelectableCodeSignGroup(nil),
 		},
 		{
-			name: "filter by team ID, match",
+			name: "filter by team ID, match. prefers longer bundle ID match",
 			certificates: []certificateutil.CertificateInfoModel{
 				certDev,
 			},
 			profiles: []profileutil.ProvisioningProfileInfoModel{
 				profileDev,
+				profileExt,
+				wildcarDev,
 			},
-			bundleIDs: []string{"io.bitrise.testapp"},
+			bundleIDs: []string{"io.bitrise.testapp", "io.bitrise.testapp.appext"},
 			filter:    codesigngroup.CreateTeamSelectableCodeSignGroupFilter("ABCD1234"),
 			want: []codesigngroup.SelectableCodeSignGroup{
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
-						"io.bitrise.testapp": {profileDev},
+						"io.bitrise.testapp":        {profileDev, wildcarDev},
+						"io.bitrise.testapp.appext": {profileExt, wildcarDev},
 					},
 				},
 			},
 		},
 		{
-			name: "filter out app store distribution",
+			name: "filter for ad-hoc dist, no match",
 			certificates: []certificateutil.CertificateInfoModel{
 				certDev,
 			},
@@ -96,12 +125,84 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			filter:    codesigngroup.CreateExportMethodSelectableCodeSignGroupFilter(exportoptions.MethodAdHoc),
 			want:      []codesigngroup.SelectableCodeSignGroup(nil),
 		},
+		{
+			name: "filter out non xcode managed profiles, no match",
+			certificates: []certificateutil.CertificateInfoModel{
+				certDev,
+			},
+			profiles: []profileutil.ProvisioningProfileInfoModel{
+				profileDev,
+				profileExt,
+				managedProflile,
+			},
+			bundleIDs: []string{
+				"io.bitrise.testapp",
+				"io.bitrise.testapp.appext", // no managed profile provided
+			},
+			filter: codesigngroup.CreateXcodeManagedSelectableCodeSignGroupFilter(),
+			want:   []codesigngroup.SelectableCodeSignGroup(nil),
+		},
+		{
+			name: "filter out xcode managed profiles, match",
+			certificates: []certificateutil.CertificateInfoModel{
+				certDev,
+			},
+			profiles: []profileutil.ProvisioningProfileInfoModel{
+				profileDev,
+				managedProflile,
+			},
+			bundleIDs: []string{"io.bitrise.testapp"},
+			filter:    codesigngroup.CreateNotXcodeManagedSelectableCodeSignGroupFilter(),
+			want: []codesigngroup.SelectableCodeSignGroup{
+				{
+					Certificate: certDev,
+					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
+						"io.bitrise.testapp": {profileDev},
+					},
+				},
+			},
+		},
+		{
+			name: "filter out profile by name, match",
+			certificates: []certificateutil.CertificateInfoModel{
+				certDev,
+			},
+			profiles: []profileutil.ProvisioningProfileInfoModel{
+				profileDev,
+				profileExt,
+			},
+			bundleIDs: []string{"io.bitrise.testapp"},
+			filter:    codesigngroup.CreateExcludeProfileNameSelectableCodeSignGroupFilter("Nonmathcing Profile"),
+			want: []codesigngroup.SelectableCodeSignGroup{
+				{
+					Certificate: certDev,
+					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
+						"io.bitrise.testapp": {profileDev},
+					},
+				},
+			},
+		},
+		{
+			name: "filter out profile by name, no match",
+			certificates: []certificateutil.CertificateInfoModel{
+				certDev,
+			},
+			profiles: []profileutil.ProvisioningProfileInfoModel{
+				profileDev,
+				profileExt,
+			},
+			bundleIDs: []string{"io.bitrise.testapp", "io.bitrise.testapp.appext"},
+			filter:    codesigngroup.CreateExcludeProfileNameSelectableCodeSignGroupFilter("Bitrise Test Profile"),
+			want:      nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := codesigngroup.BuildFilterableList(tt.certificates, tt.profiles, tt.bundleIDs)
-			got = codesigngroup.Filter(got, tt.filter)
-			require.Equal(t, tt.want, got)
+			t.Logf("groups: %s", printer.ListToDebugString(got))
+			got = codesigngroup.MapGroups(got, tt.filter)
+			t.Logf("filtered groups: %s", printer.ListToDebugString(got))
+			require.JSONEq(t, printer.ListToDebugString(tt.want), printer.ListToDebugString(got))
 		})
 	}
 }

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
@@ -55,7 +55,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 		certificates []certificateutil.CertificateInfoModel
 		profiles     []profileutil.ProvisioningProfileInfoModel
 		bundleIDs    []string
-		filter       codesigngroup.SelectableCodeSignGroupFilter
+		filter       codesigngroup.GroupMapFunc
 		want         []codesigngroup.SelectableCodeSignGroup
 	}{
 		{
@@ -88,7 +88,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileDev,
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
-			filter:    codesigngroup.CreateTeamSelectableCodeSignGroupFilter("WRONGID"),
+			filter:    codesigngroup.CreateTeamIDFilter("WRONGID"),
 			want:      []codesigngroup.SelectableCodeSignGroup(nil),
 		},
 		{
@@ -102,7 +102,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				wildcarDev,
 			},
 			bundleIDs: []string{"io.bitrise.testapp", "io.bitrise.testapp.appext"},
-			filter:    codesigngroup.CreateTeamSelectableCodeSignGroupFilter("ABCD1234"),
+			filter:    codesigngroup.CreateTeamIDFilter("ABCD1234"),
 			want: []codesigngroup.SelectableCodeSignGroup{
 				{
 					Certificate: certDev,
@@ -122,7 +122,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileDev,
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
-			filter:    codesigngroup.CreateExportMethodSelectableCodeSignGroupFilter(exportoptions.MethodAdHoc),
+			filter:    codesigngroup.CreateExportMethodFilter(exportoptions.MethodAdHoc),
 			want:      []codesigngroup.SelectableCodeSignGroup(nil),
 		},
 		{
@@ -139,7 +139,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				"io.bitrise.testapp",
 				"io.bitrise.testapp.appext", // no managed profile provided
 			},
-			filter: codesigngroup.CreateXcodeManagedSelectableCodeSignGroupFilter(),
+			filter: codesigngroup.CreateXcodeManagedFilter(),
 			want:   []codesigngroup.SelectableCodeSignGroup(nil),
 		},
 		{
@@ -152,7 +152,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				managedProflile,
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
-			filter:    codesigngroup.CreateNotXcodeManagedSelectableCodeSignGroupFilter(),
+			filter:    codesigngroup.CreateNonXcodeManagedFilter(),
 			want: []codesigngroup.SelectableCodeSignGroup{
 				{
 					Certificate: certDev,
@@ -172,7 +172,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileExt,
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
-			filter:    codesigngroup.CreateExcludeProfileNameSelectableCodeSignGroupFilter("Nonmathcing Profile"),
+			filter:    codesigngroup.CreateExcludeProfileNameFilter("Nonmathcing Profile"),
 			want: []codesigngroup.SelectableCodeSignGroup{
 				{
 					Certificate: certDev,
@@ -192,7 +192,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				profileExt,
 			},
 			bundleIDs: []string{"io.bitrise.testapp", "io.bitrise.testapp.appext"},
-			filter:    codesigngroup.CreateExcludeProfileNameSelectableCodeSignGroupFilter("Bitrise Test Profile"),
+			filter:    codesigngroup.CreateExcludeProfileNameFilter("Bitrise Test Profile"),
 			want:      nil,
 		},
 	}

--- a/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
+++ b/exportoptionsgenerator/internal/codesigngroup/codesigngroup_test.go
@@ -56,21 +56,21 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 		profiles     []profileutil.ProvisioningProfileInfoModel
 		bundleIDs    []string
 		filter       codesigngroup.GroupMapFunc
-		want         []codesigngroup.SelectableCodeSignGroup
+		want         []codesigngroup.Selectable
 	}{
 		{
 			name:         "empty inputs",
 			certificates: []certificateutil.CertificateInfoModel{},
 			profiles:     []profileutil.ProvisioningProfileInfoModel{},
 			bundleIDs:    []string{},
-			want:         []codesigngroup.SelectableCodeSignGroup(nil),
+			want:         []codesigngroup.Selectable(nil),
 		},
 		{
 			name:         "single matching profile and certificate",
 			certificates: []certificateutil.CertificateInfoModel{certDev},
 			profiles:     []profileutil.ProvisioningProfileInfoModel{profileDev},
 			bundleIDs:    []string{"io.bitrise.testapp"},
-			want: []codesigngroup.SelectableCodeSignGroup{
+			want: []codesigngroup.Selectable{
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
@@ -89,7 +89,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
 			filter:    codesigngroup.CreateTeamIDFilter("WRONGID"),
-			want:      []codesigngroup.SelectableCodeSignGroup(nil),
+			want:      []codesigngroup.Selectable(nil),
 		},
 		{
 			name: "filter by team ID, match. prefers longer bundle ID match",
@@ -103,7 +103,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			},
 			bundleIDs: []string{"io.bitrise.testapp", "io.bitrise.testapp.appext"},
 			filter:    codesigngroup.CreateTeamIDFilter("ABCD1234"),
-			want: []codesigngroup.SelectableCodeSignGroup{
+			want: []codesigngroup.Selectable{
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
@@ -123,7 +123,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
 			filter:    codesigngroup.CreateExportMethodFilter(exportoptions.MethodAdHoc),
-			want:      []codesigngroup.SelectableCodeSignGroup(nil),
+			want:      []codesigngroup.Selectable(nil),
 		},
 		{
 			name: "filter out non xcode managed profiles, no match",
@@ -140,7 +140,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 				"io.bitrise.testapp.appext", // no managed profile provided
 			},
 			filter: codesigngroup.CreateXcodeManagedFilter(),
-			want:   []codesigngroup.SelectableCodeSignGroup(nil),
+			want:   []codesigngroup.Selectable(nil),
 		},
 		{
 			name: "filter out xcode managed profiles, match",
@@ -153,7 +153,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
 			filter:    codesigngroup.CreateNonXcodeManagedFilter(),
-			want: []codesigngroup.SelectableCodeSignGroup{
+			want: []codesigngroup.Selectable{
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{
@@ -173,7 +173,7 @@ func TestCreateSelectableCodeSignGroups(t *testing.T) {
 			},
 			bundleIDs: []string{"io.bitrise.testapp"},
 			filter:    codesigngroup.CreateExcludeProfileNameFilter("Nonmathcing Profile"),
-			want: []codesigngroup.SelectableCodeSignGroup{
+			want: []codesigngroup.Selectable{
 				{
 					Certificate: certDev,
 					BundleIDProfilesMap: map[string][]profileutil.ProvisioningProfileInfoModel{

--- a/exportoptionsgenerator/internal/codesigngroup/filter.go
+++ b/exportoptionsgenerator/internal/codesigngroup/filter.go
@@ -6,10 +6,10 @@ import (
 	"github.com/bitrise-io/go-xcode/profileutil"
 )
 
-// SelectableCodeSignGroupFilter ...
-type SelectableCodeSignGroupFilter func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool)
+// GroupMapFunc ...
+type GroupMapFunc func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool)
 
-func MapGroups(groups []SelectableCodeSignGroup, mapFunc SelectableCodeSignGroupFilter) []SelectableCodeSignGroup {
+func MapGroups(groups []SelectableCodeSignGroup, mapFunc GroupMapFunc) []SelectableCodeSignGroup {
 	if mapFunc == nil {
 		return groups
 	}
@@ -25,8 +25,8 @@ func MapGroups(groups []SelectableCodeSignGroup, mapFunc SelectableCodeSignGroup
 	return mappedGroups
 }
 
-// CreateEntitlementsSelectableCodeSignGroupFilter ...
-func CreateEntitlementsSelectableCodeSignGroupFilter(bundleIDEntitlementsMap map[string]plistutil.PlistData) SelectableCodeSignGroupFilter {
+// CreateEntitlementsFilter ...
+func CreateEntitlementsFilter(bundleIDEntitlementsMap map[string]plistutil.PlistData) GroupMapFunc {
 	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
 		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
 
@@ -56,8 +56,8 @@ func CreateEntitlementsSelectableCodeSignGroupFilter(bundleIDEntitlementsMap map
 	}
 }
 
-// CreateExportMethodSelectableCodeSignGroupFilter ...
-func CreateExportMethodSelectableCodeSignGroupFilter(exportMethod exportoptions.Method) SelectableCodeSignGroupFilter {
+// CreateExportMethodFilter ...
+func CreateExportMethodFilter(exportMethod exportoptions.Method) GroupMapFunc {
 	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.ExportType == exportMethod
@@ -65,8 +65,8 @@ func CreateExportMethodSelectableCodeSignGroupFilter(exportMethod exportoptions.
 	}
 }
 
-// CreateTeamSelectableCodeSignGroupFilter ...
-func CreateTeamSelectableCodeSignGroupFilter(teamID string) SelectableCodeSignGroupFilter {
+// CreateTeamIDFilter ...
+func CreateTeamIDFilter(teamID string) GroupMapFunc {
 	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
 		if group.Certificate.TeamID == teamID {
 			return group, true
@@ -75,8 +75,8 @@ func CreateTeamSelectableCodeSignGroupFilter(teamID string) SelectableCodeSignGr
 	}
 }
 
-// CreateNotXcodeManagedSelectableCodeSignGroupFilter ...
-func CreateNotXcodeManagedSelectableCodeSignGroupFilter() SelectableCodeSignGroupFilter {
+// CreateNonXcodeManagedFilter ...
+func CreateNonXcodeManagedFilter() GroupMapFunc {
 	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return !profile.IsXcodeManaged()
@@ -84,8 +84,8 @@ func CreateNotXcodeManagedSelectableCodeSignGroupFilter() SelectableCodeSignGrou
 	}
 }
 
-// CreateXcodeManagedSelectableCodeSignGroupFilter ...
-func CreateXcodeManagedSelectableCodeSignGroupFilter() SelectableCodeSignGroupFilter {
+// CreateXcodeManagedFilter ...
+func CreateXcodeManagedFilter() GroupMapFunc {
 	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.IsXcodeManaged()
@@ -93,8 +93,8 @@ func CreateXcodeManagedSelectableCodeSignGroupFilter() SelectableCodeSignGroupFi
 	}
 }
 
-// CreateExcludeProfileNameSelectableCodeSignGroupFilter ...
-func CreateExcludeProfileNameSelectableCodeSignGroupFilter(name string) SelectableCodeSignGroupFilter {
+// CreateExcludeProfileNameFilter ...
+func CreateExcludeProfileNameFilter(name string) GroupMapFunc {
 	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.Name != name

--- a/exportoptionsgenerator/internal/codesigngroup/filter.go
+++ b/exportoptionsgenerator/internal/codesigngroup/filter.go
@@ -7,27 +7,27 @@ import (
 )
 
 // SelectableCodeSignGroupFilter ...
-type SelectableCodeSignGroupFilter func(group *SelectableCodeSignGroup) bool
+type SelectableCodeSignGroupFilter func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool)
 
-// Filter ...
-func Filter(groups []SelectableCodeSignGroup, filterFunc SelectableCodeSignGroupFilter) []SelectableCodeSignGroup {
-	if filterFunc == nil {
+func MapGroups(groups []SelectableCodeSignGroup, mapFunc SelectableCodeSignGroupFilter) []SelectableCodeSignGroup {
+	if mapFunc == nil {
 		return groups
 	}
 
-	var filteredGroups []SelectableCodeSignGroup
+	var mappedGroups []SelectableCodeSignGroup
 	for _, group := range groups {
-		if filterFunc(&group) {
-			filteredGroups = append(filteredGroups, group)
+		groupWithFilteredProfiles, ok := mapFunc(group)
+		if ok {
+			mappedGroups = append(mappedGroups, groupWithFilteredProfiles)
 		}
 	}
 
-	return filteredGroups
+	return mappedGroups
 }
 
 // CreateEntitlementsSelectableCodeSignGroupFilter ...
 func CreateEntitlementsSelectableCodeSignGroupFilter(bundleIDEntitlementsMap map[string]plistutil.PlistData) SelectableCodeSignGroupFilter {
-	return func(group *SelectableCodeSignGroup) bool {
+	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
 		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
 
 		for bundleID, profiles := range group.BundleIDProfilesMap {
@@ -49,136 +49,84 @@ func CreateEntitlementsSelectableCodeSignGroupFilter(bundleIDEntitlementsMap map
 
 		if len(filteredBundleIDProfilesMap) == len(group.BundleIDProfilesMap) {
 			group.BundleIDProfilesMap = filteredBundleIDProfilesMap
-			return true
+			return group, true
 		}
 
-		return false
+		return group, false
 	}
 }
 
 // CreateExportMethodSelectableCodeSignGroupFilter ...
 func CreateExportMethodSelectableCodeSignGroupFilter(exportMethod exportoptions.Method) SelectableCodeSignGroupFilter {
-	return func(group *SelectableCodeSignGroup) bool {
-		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
-
-		for bundleID, profiles := range group.BundleIDProfilesMap {
-			var filteredProfiles []profileutil.ProvisioningProfileInfoModel
-
-			for _, profile := range profiles {
-				if profile.ExportType == exportMethod {
-					filteredProfiles = append(filteredProfiles, profile)
-				}
-			}
-
-			if len(filteredProfiles) == 0 {
-				break
-			}
-
-			filteredBundleIDProfilesMap[bundleID] = filteredProfiles
-		}
-
-		if len(filteredBundleIDProfilesMap) == len(group.BundleIDProfilesMap) {
-			group.BundleIDProfilesMap = filteredBundleIDProfilesMap
-			return true
-		}
-
-		return false
+	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+			return profile.ExportType == exportMethod
+		})
 	}
 }
 
 // CreateTeamSelectableCodeSignGroupFilter ...
 func CreateTeamSelectableCodeSignGroupFilter(teamID string) SelectableCodeSignGroupFilter {
-	return func(group *SelectableCodeSignGroup) bool {
-		return group.Certificate.TeamID == teamID
+	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+		if group.Certificate.TeamID == teamID {
+			return group, true
+		}
+		return group, false
 	}
 }
 
 // CreateNotXcodeManagedSelectableCodeSignGroupFilter ...
 func CreateNotXcodeManagedSelectableCodeSignGroupFilter() SelectableCodeSignGroupFilter {
-	return func(group *SelectableCodeSignGroup) bool {
-		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
-
-		for bundleID, profiles := range group.BundleIDProfilesMap {
-			var filteredProfiles []profileutil.ProvisioningProfileInfoModel
-
-			for _, profile := range profiles {
-				if !profile.IsXcodeManaged() {
-					filteredProfiles = append(filteredProfiles, profile)
-				}
-			}
-
-			if len(filteredProfiles) == 0 {
-				break
-			}
-
-			filteredBundleIDProfilesMap[bundleID] = filteredProfiles
-		}
-
-		if len(filteredBundleIDProfilesMap) == len(group.BundleIDProfilesMap) {
-			group.BundleIDProfilesMap = filteredBundleIDProfilesMap
-			return true
-		}
-
-		return false
+	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+			return !profile.IsXcodeManaged()
+		})
 	}
 }
 
 // CreateXcodeManagedSelectableCodeSignGroupFilter ...
 func CreateXcodeManagedSelectableCodeSignGroupFilter() SelectableCodeSignGroupFilter {
-	return func(group *SelectableCodeSignGroup) bool {
-		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
-
-		for bundleID, profiles := range group.BundleIDProfilesMap {
-			var filteredProfiles []profileutil.ProvisioningProfileInfoModel
-
-			for _, profile := range profiles {
-				if profile.IsXcodeManaged() {
-					filteredProfiles = append(filteredProfiles, profile)
-				}
-			}
-
-			if len(filteredProfiles) == 0 {
-				break
-			}
-
-			filteredBundleIDProfilesMap[bundleID] = filteredProfiles
-		}
-
-		if len(filteredBundleIDProfilesMap) == len(group.BundleIDProfilesMap) {
-			group.BundleIDProfilesMap = filteredBundleIDProfilesMap
-			return true
-		}
-
-		return false
+	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+			return profile.IsXcodeManaged()
+		})
 	}
 }
 
 // CreateExcludeProfileNameSelectableCodeSignGroupFilter ...
 func CreateExcludeProfileNameSelectableCodeSignGroupFilter(name string) SelectableCodeSignGroupFilter {
-	return func(group *SelectableCodeSignGroup) bool {
-		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
-
-		for bundleID, profiles := range group.BundleIDProfilesMap {
-			var filteredProfiles []profileutil.ProvisioningProfileInfoModel
-
-			for _, profile := range profiles {
-				if profile.Name != name {
-					filteredProfiles = append(filteredProfiles, profile)
-				}
-			}
-
-			if len(filteredProfiles) == 0 {
-				break
-			}
-
-			filteredBundleIDProfilesMap[bundleID] = filteredProfiles
-		}
-
-		if len(filteredBundleIDProfilesMap) == len(group.BundleIDProfilesMap) {
-			group.BundleIDProfilesMap = filteredBundleIDProfilesMap
-			return true
-		}
-
-		return false
+	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+			return profile.Name != name
+		})
 	}
+}
+
+// filter - returns a slice containing only the elements
+// that satisfy the predicate function filterFunc.
+func filter[T any](slice []T, filterFunc func(T) bool) []T {
+	if filterFunc == nil {
+		return slice
+	}
+
+	filtered := make([]T, 0, len(slice))
+	for _, item := range slice {
+		if filterFunc(item) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func filterGroupProfiles(group SelectableCodeSignGroup, filterFunc func(profile profileutil.ProvisioningProfileInfoModel) bool) (SelectableCodeSignGroup, bool) {
+	filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
+	for bundleID, profiles := range group.BundleIDProfilesMap {
+		filteredBundleIDProfilesMap[bundleID] = filter(profiles, filterFunc)
+		if len(filteredBundleIDProfilesMap[bundleID]) == 0 {
+			return group, false
+		}
+	}
+
+	group.BundleIDProfilesMap = filteredBundleIDProfilesMap
+	return group, true
 }

--- a/exportoptionsgenerator/internal/codesigngroup/filter.go
+++ b/exportoptionsgenerator/internal/codesigngroup/filter.go
@@ -9,6 +9,7 @@ import (
 // GroupMapFunc ...
 type GroupMapFunc func(group Selectable) (Selectable, bool)
 
+// MapGroups returns a slice containing the results of applying the given mapFunc to each element of the input slice, filtering out any elements for which mapFunc returns false.
 func MapGroups(groups []Selectable, mapFunc GroupMapFunc) []Selectable {
 	if mapFunc == nil {
 		return groups

--- a/exportoptionsgenerator/internal/codesigngroup/filter.go
+++ b/exportoptionsgenerator/internal/codesigngroup/filter.go
@@ -2,8 +2,8 @@ package codesigngroup
 
 import (
 	"github.com/bitrise-io/go-xcode/exportoptions"
-	"github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-io/go-xcode/profileutil"
+	"github.com/bitrise-io/go-xcode/v2/plistutil"
 )
 
 // GroupMapFunc ...
@@ -28,38 +28,18 @@ func MapGroups(groups []Selectable, mapFunc GroupMapFunc) []Selectable {
 // CreateEntitlementsFilter ...
 func CreateEntitlementsFilter(bundleIDEntitlementsMap map[string]plistutil.PlistData) GroupMapFunc {
 	return func(group Selectable) (Selectable, bool) {
-		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
-
-		for bundleID, profiles := range group.BundleIDProfilesMap {
-			var filteredProfiles []profileutil.ProvisioningProfileInfoModel
-
-			for _, profile := range profiles {
-				missingEntitlements := profileutil.MatchTargetAndProfileEntitlements(bundleIDEntitlementsMap[bundleID], profile.Entitlements, profile.Type)
-				if len(missingEntitlements) == 0 {
-					filteredProfiles = append(filteredProfiles, profile)
-				}
-			}
-
-			if len(filteredProfiles) == 0 {
-				break
-			}
-
-			filteredBundleIDProfilesMap[bundleID] = filteredProfiles
-		}
-
-		if len(filteredBundleIDProfilesMap) == len(group.BundleIDProfilesMap) {
-			group.BundleIDProfilesMap = filteredBundleIDProfilesMap
-			return group, true
-		}
-
-		return group, false
+		return filterGroupProfiles(group, func(bundleID string, profile profileutil.ProvisioningProfileInfoModel) bool {
+			v1BundleIDEntitlementsMap := convertToV1PlistData(bundleIDEntitlementsMap)
+			missingEntitlements := profileutil.MatchTargetAndProfileEntitlements(v1BundleIDEntitlementsMap[bundleID], profile.Entitlements, profile.Type)
+			return len(missingEntitlements) == 0
+		})
 	}
 }
 
 // CreateExportMethodFilter ...
 func CreateExportMethodFilter(exportMethod exportoptions.Method) GroupMapFunc {
 	return func(group Selectable) (Selectable, bool) {
-		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+		return filterGroupProfiles(group, func(bundleID string, profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.ExportType == exportMethod
 		})
 	}
@@ -78,7 +58,7 @@ func CreateTeamIDFilter(teamID string) GroupMapFunc {
 // CreateNonXcodeManagedFilter ...
 func CreateNonXcodeManagedFilter() GroupMapFunc {
 	return func(group Selectable) (Selectable, bool) {
-		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+		return filterGroupProfiles(group, func(bundleID string, profile profileutil.ProvisioningProfileInfoModel) bool {
 			return !profile.IsXcodeManaged()
 		})
 	}
@@ -87,7 +67,7 @@ func CreateNonXcodeManagedFilter() GroupMapFunc {
 // CreateXcodeManagedFilter ...
 func CreateXcodeManagedFilter() GroupMapFunc {
 	return func(group Selectable) (Selectable, bool) {
-		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+		return filterGroupProfiles(group, func(bundleID string, profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.IsXcodeManaged()
 		})
 	}
@@ -96,7 +76,7 @@ func CreateXcodeManagedFilter() GroupMapFunc {
 // CreateExcludeProfileNameFilter ...
 func CreateExcludeProfileNameFilter(name string) GroupMapFunc {
 	return func(group Selectable) (Selectable, bool) {
-		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+		return filterGroupProfiles(group, func(bundleID string, profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.Name != name
 		})
 	}
@@ -118,10 +98,12 @@ func filter[T any](slice []T, filterFunc func(T) bool) []T {
 	return filtered
 }
 
-func filterGroupProfiles(group Selectable, filterFunc func(profile profileutil.ProvisioningProfileInfoModel) bool) (Selectable, bool) {
+func filterGroupProfiles(group Selectable, filterFunc func(bundleID string, profile profileutil.ProvisioningProfileInfoModel) bool) (Selectable, bool) {
 	filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
 	for bundleID, profiles := range group.BundleIDProfilesMap {
-		filteredBundleIDProfilesMap[bundleID] = filter(profiles, filterFunc)
+		filteredBundleIDProfilesMap[bundleID] = filter(profiles, func(profile profileutil.ProvisioningProfileInfoModel) bool {
+			return filterFunc(bundleID, profile)
+		})
 		if len(filteredBundleIDProfilesMap[bundleID]) == 0 {
 			return group, false
 		}

--- a/exportoptionsgenerator/internal/codesigngroup/filter.go
+++ b/exportoptionsgenerator/internal/codesigngroup/filter.go
@@ -7,14 +7,14 @@ import (
 )
 
 // GroupMapFunc ...
-type GroupMapFunc func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool)
+type GroupMapFunc func(group Selectable) (Selectable, bool)
 
-func MapGroups(groups []SelectableCodeSignGroup, mapFunc GroupMapFunc) []SelectableCodeSignGroup {
+func MapGroups(groups []Selectable, mapFunc GroupMapFunc) []Selectable {
 	if mapFunc == nil {
 		return groups
 	}
 
-	var mappedGroups []SelectableCodeSignGroup
+	var mappedGroups []Selectable
 	for _, group := range groups {
 		groupWithFilteredProfiles, ok := mapFunc(group)
 		if ok {
@@ -27,7 +27,7 @@ func MapGroups(groups []SelectableCodeSignGroup, mapFunc GroupMapFunc) []Selecta
 
 // CreateEntitlementsFilter ...
 func CreateEntitlementsFilter(bundleIDEntitlementsMap map[string]plistutil.PlistData) GroupMapFunc {
-	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+	return func(group Selectable) (Selectable, bool) {
 		filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
 
 		for bundleID, profiles := range group.BundleIDProfilesMap {
@@ -58,7 +58,7 @@ func CreateEntitlementsFilter(bundleIDEntitlementsMap map[string]plistutil.Plist
 
 // CreateExportMethodFilter ...
 func CreateExportMethodFilter(exportMethod exportoptions.Method) GroupMapFunc {
-	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+	return func(group Selectable) (Selectable, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.ExportType == exportMethod
 		})
@@ -67,7 +67,7 @@ func CreateExportMethodFilter(exportMethod exportoptions.Method) GroupMapFunc {
 
 // CreateTeamIDFilter ...
 func CreateTeamIDFilter(teamID string) GroupMapFunc {
-	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+	return func(group Selectable) (Selectable, bool) {
 		if group.Certificate.TeamID == teamID {
 			return group, true
 		}
@@ -77,7 +77,7 @@ func CreateTeamIDFilter(teamID string) GroupMapFunc {
 
 // CreateNonXcodeManagedFilter ...
 func CreateNonXcodeManagedFilter() GroupMapFunc {
-	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+	return func(group Selectable) (Selectable, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return !profile.IsXcodeManaged()
 		})
@@ -86,7 +86,7 @@ func CreateNonXcodeManagedFilter() GroupMapFunc {
 
 // CreateXcodeManagedFilter ...
 func CreateXcodeManagedFilter() GroupMapFunc {
-	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+	return func(group Selectable) (Selectable, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.IsXcodeManaged()
 		})
@@ -95,7 +95,7 @@ func CreateXcodeManagedFilter() GroupMapFunc {
 
 // CreateExcludeProfileNameFilter ...
 func CreateExcludeProfileNameFilter(name string) GroupMapFunc {
-	return func(group SelectableCodeSignGroup) (SelectableCodeSignGroup, bool) {
+	return func(group Selectable) (Selectable, bool) {
 		return filterGroupProfiles(group, func(profile profileutil.ProvisioningProfileInfoModel) bool {
 			return profile.Name != name
 		})
@@ -118,7 +118,7 @@ func filter[T any](slice []T, filterFunc func(T) bool) []T {
 	return filtered
 }
 
-func filterGroupProfiles(group SelectableCodeSignGroup, filterFunc func(profile profileutil.ProvisioningProfileInfoModel) bool) (SelectableCodeSignGroup, bool) {
+func filterGroupProfiles(group Selectable, filterFunc func(profile profileutil.ProvisioningProfileInfoModel) bool) (Selectable, bool) {
 	filteredBundleIDProfilesMap := map[string][]profileutil.ProvisioningProfileInfoModel{}
 	for bundleID, profiles := range group.BundleIDProfilesMap {
 		filteredBundleIDProfilesMap[bundleID] = filter(profiles, filterFunc)

--- a/exportoptionsgenerator/internal/codesigngroup/plistconverter.go
+++ b/exportoptionsgenerator/internal/codesigngroup/plistconverter.go
@@ -1,4 +1,4 @@
-package exportoptionsgenerator
+package codesigngroup
 
 import (
 	plistutilv1 "github.com/bitrise-io/go-xcode/plistutil"

--- a/exportoptionsgenerator/internal/codesigngroup/printer.go
+++ b/exportoptionsgenerator/internal/codesigngroup/printer.go
@@ -21,7 +21,7 @@ func NewPrinter(logger log.Logger) *Printer {
 }
 
 // ListToDebugString ...
-func (printer *Printer) ListToDebugString(groups []SelectableCodeSignGroup) string {
+func (printer *Printer) ListToDebugString(groups []Selectable) string {
 	var builder strings.Builder
 	builder.WriteString("[")
 	for i, group := range groups {
@@ -38,7 +38,7 @@ func (printer *Printer) ListToDebugString(groups []SelectableCodeSignGroup) stri
 }
 
 // ToDebugString ...
-func (printer *Printer) ToDebugString(group SelectableCodeSignGroup) string {
+func (printer *Printer) ToDebugString(group Selectable) string {
 	printable := map[string]any{}
 	printable["team"] = fmt.Sprintf("%s (%s)", group.Certificate.TeamName, group.Certificate.TeamID)
 	printable["certificate"] = fmt.Sprintf("%s (%s)", group.Certificate.CommonName, group.Certificate.Serial)

--- a/exportoptionsgenerator/internal/codesigngroup/printer.go
+++ b/exportoptionsgenerator/internal/codesigngroup/printer.go
@@ -23,9 +23,16 @@ func NewPrinter(logger log.Logger) *Printer {
 // ListToDebugString ...
 func (printer *Printer) ListToDebugString(groups []SelectableCodeSignGroup) string {
 	var builder strings.Builder
-	for _, group := range groups {
-		builder.WriteString(printer.ToDebugString(group) + "\n")
+	builder.WriteString("[")
+	for i, group := range groups {
+		builder.WriteString(printer.ToDebugString(group))
+		if i > 0 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("\n")
 	}
+
+	builder.WriteString("]")
 
 	return builder.String()
 }

--- a/exportoptionsgenerator/internal/codesigngroup/printer_test.go
+++ b/exportoptionsgenerator/internal/codesigngroup/printer_test.go
@@ -13,12 +13,12 @@ import (
 func TestPrinter_ToDebugString(t *testing.T) {
 	tests := []struct {
 		name  string
-		group codesigngroup.SelectableCodeSignGroup
+		group codesigngroup.Selectable
 		want  string
 	}{
 		{
 			name: "empty group",
-			group: codesigngroup.SelectableCodeSignGroup{
+			group: codesigngroup.Selectable{
 				Certificate: certificateutil.CertificateInfoModel{
 					CommonName: "CN",
 					Serial:     "SERIAL",


### PR DESCRIPTION
- Changed  `func (codesigngroup.Printer) ListToDebugString` to print a valid JSON array, for easier testing.
- Refactored codesigngroup filters to reduce duplication.
- Renamed SelectableCodeSignGroups to codesigngroups.Selectable.
- Renamed 'filters' to remove SelectableCodeSignGroup from the name