### PR TITLE
[STEP-2148] Try go-utils/v2 httputil — do not merge

### DIFF
--- a/autocodesign/devportalclient/appstoreconnect/appstoreconnect.go
+++ b/autocodesign/devportalclient/appstoreconnect/appstoreconnect.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitrise-io/go-utils/httputil"
+	"github.com/bitrise-io/go-utils/v2/httputil"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retryhttp"
 	"github.com/golang-jwt/jwt/v4"
@@ -268,7 +268,7 @@ func (c *Client) Debugf(format string, v ...interface{}) {
 func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	c.Debugf("Request:")
 	if c.EnableDebugLogs {
-		if err := httputil.PrintRequest(req); err != nil {
+		if err := httputil.PrintRequest(c.logger, req); err != nil {
 			c.Debugf("Failed to print request: %s", err)
 		}
 	}
@@ -277,7 +277,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 
 	c.Debugf("Response:")
 	if c.EnableDebugLogs {
-		if err := httputil.PrintResponse(resp); err != nil {
+		if err := httputil.PrintResponse(c.logger, resp); err != nil {
 			c.Debugf("Failed to print response: %s", err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.49
 	github.com/bitrise-io/go-utils v1.0.13
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260423153815-d6b3a15893f9
 	github.com/bitrise-io/go-xcode v1.3.3
 	github.com/globocom/go-buffer/v2 v2.0.0
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.49/go.mod h1:hK2zMovlJg7+FLdJ
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=
 github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34 h1:xsLfhItfs4SCCAesbv7UtKpldNqievDvtHggSuBI2+w=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260423153815-d6b3a15893f9 h1:DIgrZ/QJLhZnT7WFbBpdEL9lsWqR4gZBZTT3B6O0/3E=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260423153815-d6b3a15893f9/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/go-xcode v1.3.3 h1:aYkSMWP+1/n2ZabRy3OMfeaWmE4l1gAPq63azx06LIw=
 github.com/bitrise-io/go-xcode v1.3.3/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
## Purpose

End-to-end validation for **bitrise-io/go-utils#227** ([STEP-2148](https://bitrise.atlassian.net/browse/STEP-2148)). Pins \`go-utils/v2\` to the feature branch and switches \`autocodesign/devportalclient/appstoreconnect/appstoreconnect.go\` from v1 \`httputil\` to the newly-added v2 \`httputil\` package.

**DO NOT MERGE** — dependency is pinned to a non-main branch of \`bitrise-io/go-utils\`.

## Changes

- \`go.mod\`: \`github.com/bitrise-io/go-utils/v2\` → \`v2.0.0-alpha.34.0.20260423153815-d6b3a15893f9\` (branch \`STEP-2148-httputil\`, commit \`d6b3a158\`).
- \`appstoreconnect.go\`:
  - Import path: \`github.com/bitrise-io/go-utils/httputil\` → \`github.com/bitrise-io/go-utils/v2/httputil\`.
  - Call sites: \`httputil.PrintRequest(c.logger, req)\` / \`httputil.PrintResponse(c.logger, resp)\` — the v2 API takes a \`log.Logger\` as the first argument instead of using a package-level logger. \`c.logger\` already exists on the \`Client\` struct.

## Expected

- \`go test ./autocodesign/...\` passes locally.
- CI exercises the v2 \`httputil\` Print helpers during any autocodesign flow that runs with \`EnableDebugLogs\` on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2148]: https://bitrise.atlassian.net/browse/STEP-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ