### PR TITLE
Audit ServiceTypeByKey — add Ignored entries for newer Apple entitlements

### DIFF
--- a/autocodesign/devportalclient/appstoreconnect/capabilities.go
+++ b/autocodesign/devportalclient/appstoreconnect/capabilities.go
@@ -79,10 +79,13 @@ var ServiceTypeByKey = map[string]CapabilityType{
 	"com.apple.developer.ClassKit-environment":                                 Classkit,
 	"com.apple.developer.coremedia.hls.low-latency":                            CoremediaHLSLowLatency,
 	// does not appear on developer portal
-	"com.apple.developer.icloud-container-identifiers":   Ignored,
-	"com.apple.developer.ubiquity-container-identifiers": Ignored,
-	"com.apple.developer.healthkit.access":               Ignored,
-	ParentApplicationIdentifierEntitlementKey:            Ignored,
+	"com.apple.developer.icloud-container-identifiers":                   Ignored,
+	"com.apple.developer.ubiquity-container-identifiers":                 Ignored,
+	"com.apple.developer.healthkit.access":                               Ignored,
+	"com.apple.developer.kernel.extended-virtual-addressing":             Ignored,
+	"com.apple.developer.kernel.increased-memory-limit":                  Ignored,
+	"com.apple.developer.authentication-services.credential-provider-ui": Ignored,
+	ParentApplicationIdentifierEntitlementKey:                            Ignored,
 	// These are entitlements not supported via the API and this step,
 	// profile needs to be manually generated on Apple Developer Portal.
 	"com.apple.developer.contacts.notes":         ProfileAttachedEntitlement,

--- a/autocodesign/entitlement_test.go
+++ b/autocodesign/entitlement_test.go
@@ -108,3 +108,20 @@ func TestCapability_HealthKitAccessIgnored(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, cap)
 }
+
+func TestCapability_IgnoredKeys(t *testing.T) {
+	keys := []string{
+		"com.apple.developer.kernel.extended-virtual-addressing",
+		"com.apple.developer.kernel.increased-memory-limit",
+		"com.apple.developer.authentication-services.credential-provider-ui",
+	}
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			ent := Entitlement(map[string]interface{}{key: true})
+			cap, err := ent.Capability()
+			require.NoError(t, err)
+			require.Nil(t, cap)
+			require.False(t, ent.AppearsOnDeveloperPortal())
+		})
+	}
+}


### PR DESCRIPTION
> **Stacked on** #325 (`fix/healthkit-access-entitlement`). Merge that one first; then this PR's diff collapses to its own three entries.

## Issue

Any iOS/macOS entitlement key that is not present in `ServiceTypeByKey` (`autocodesign/devportalclient/appstoreconnect/capabilities.go`) causes `autocodesign.Entitlement.Capability()` to return:

```
unknown entitlement key: <key>
```

That error propagates up through `ProfileClient.SyncBundleID` → `autocodesign/profiles.go#ensureBundleID` and aborts the entire automatic-code-signing phase with:

```
failed to manage code signing: failed to ensure code signing assets:
failed to ensure profiles: failed to update bundle ID capabilities:
unknown entitlement key: <key>
```

The map currently has 34 entries. Apple has added a number of entitlement keys since it was last extended (see [current entitlements reference](https://developer.apple.com/documentation/bundleresources/entitlements)), and each such addition is a latent production break the moment a user project declares that key. #325 is the most recently reported instance (`com.apple.developer.healthkit.access`, iOS 17.5+).

## Intent

Audit `ServiceTypeByKey` for entitlement keys that should be safely mapped to `Ignored` because they do not require App Store Connect registration (matching the existing treatment of e.g. `com.apple.developer.icloud-container-identifiers`). Flag keys that likely need a real `CapabilityType` mapping for maintainer review in a follow-up.

## Changes

Three new `Ignored` entries — build/runtime entitlements, not App Store Connect-registrable:

| Key | Apple doc | Why Ignored |
| --- | --- | --- |
| `com.apple.developer.kernel.extended-virtual-addressing` | [link](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_extended-virtual-addressing) | Build-time memory entitlement; no ASC capability |
| `com.apple.developer.kernel.increased-memory-limit` | [link](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_increased-memory-limit) | Build-time memory entitlement; no ASC capability |
| `com.apple.developer.authentication-services.credential-provider-ui` | [link](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_authentication-services_credential-provider-ui) | UI-hook companion to the already-mapped `AutofillCredentialProvider` capability; metadata-only |

Plus a table-driven regression test (`TestCapability_IgnoredKeys`) covering both `Capability()` and `AppearsOnDeveloperPortal()` for each new key.

## Intentionally out of scope

Flagging for maintainer decision — these likely need a real `CapabilityType`, not `Ignored`:

- `com.apple.developer.weatherkit` — WeatherKit is a registrable service (appears under **Services → WeatherKit** in App Store Connect). Needs a new `CapabilityType` constant (e.g. `WeatherKit`) and a decision on whether the step should auto-register it.
- `com.apple.developer.matter.allow-setup-payload` — Matter companion entitlement for HomePod/Apple TV setup payloads; ASC registration requirements unclear from public docs. Worth checking against the ASC API before classifying.

Anything else currently missing from the map that you'd like folded in here, happy to add — just flagging in review.

## Follow-up

There is also a structural hardening worth considering — making `Capability()` warn-and-skip on unknown keys rather than hard-erroring — so a fresh Apple entitlement does not break every affected build until the allow-list catches up. Proposing that as a separate stacked PR after this one.

## Test plan

- [x] `go test ./autocodesign/...`
- [x] `go vet ./autocodesign/...`
- [x] New `TestCapability_IgnoredKeys` passes for all three keys
- [ ] Integration: build a target declaring `kernel.increased-memory-limit` via `xcode-archive@6.x` after dep bump; confirm no `unknown entitlement key` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)