### PR TITLE
Skip unknown entitlement keys with a warning in SyncBundleID

### DIFF
--- a/autocodesign/devportalclient/appstoreconnect/appstoreconnect.go
+++ b/autocodesign/devportalclient/appstoreconnect/appstoreconnect.go
@@ -169,6 +169,12 @@ func NewClient(httpClient HTTPClient, keyID, issuerID string, privateKey []byte,
 	return c
 }
 
+// Tracker exposes the underlying analytics tracker so packages built on top
+// of this client can emit domain-specific events (e.g. unknown entitlements).
+func (c *Client) Tracker() Tracker {
+	return c.tracker
+}
+
 // ensureSignedToken makes sure that the JWT auth token is not expired
 // and return a signed key
 func (c *Client) ensureSignedToken() (string, error) {

--- a/autocodesign/devportalclient/appstoreconnect/appstoreconnect_test.go
+++ b/autocodesign/devportalclient/appstoreconnect/appstoreconnect_test.go
@@ -42,9 +42,10 @@ func TestNewEnterpriseClient(t *testing.T) {
 }
 
 type mockAnalyticsTracker struct {
-	apiRequests []apiRequestRecord
-	apiErrors   []apiErrorRecord
-	authErrors  []string
+	apiRequests        []apiRequestRecord
+	apiErrors          []apiErrorRecord
+	authErrors         []string
+	unknownEntitlements []string
 }
 
 type apiRequestRecord struct {
@@ -87,6 +88,10 @@ func (m *mockAnalyticsTracker) TrackAPIError(method, host, endpoint string, stat
 
 func (m *mockAnalyticsTracker) TrackAuthError(errorMessage string) {
 	m.authErrors = append(m.authErrors, errorMessage)
+}
+
+func (m *mockAnalyticsTracker) TrackUnknownEntitlement(key string) {
+	m.unknownEntitlements = append(m.unknownEntitlements, key)
 }
 
 type mockHTTPClient struct {

--- a/autocodesign/devportalclient/appstoreconnect/roundtripper_test.go
+++ b/autocodesign/devportalclient/appstoreconnect/roundtripper_test.go
@@ -44,6 +44,9 @@ func (a *attemptTracker) TrackAPIError(method, host, endpoint string, statusCode
 func (a *attemptTracker) TrackAuthError(errorMessage string) {
 }
 
+func (a *attemptTracker) TrackUnknownEntitlement(key string) {
+}
+
 func TestTrackingRoundTripper(t *testing.T) {
 	t.Run("tracks single successful request", func(t *testing.T) {
 		tracker := &attemptTracker{}

--- a/autocodesign/devportalclient/appstoreconnect/tracker.go
+++ b/autocodesign/devportalclient/appstoreconnect/tracker.go
@@ -17,6 +17,11 @@ type Tracker interface {
 
 	// TrackAuthError tracks authentication-specific errors
 	TrackAuthError(errorMessage string)
+
+	// TrackUnknownEntitlement is fired when a project uses an entitlement key
+	// not in ServiceTypeByKey. Feeds alerting so we can register newly
+	// introduced Apple entitlements before they become customer-facing errors.
+	TrackUnknownEntitlement(key string)
 }
 
 // NoOpAnalyticsTracker is a dummy implementation used in tests.
@@ -32,6 +37,9 @@ func (n NoOpAnalyticsTracker) TrackAPIError(method, host, endpoint string, statu
 
 // TrackAuthError ...
 func (n NoOpAnalyticsTracker) TrackAuthError(errorMessage string) {}
+
+// TrackUnknownEntitlement ...
+func (n NoOpAnalyticsTracker) TrackUnknownEntitlement(key string) {}
 
 // DefaultTracker is the main implementation of Tracker
 type DefaultTracker struct {
@@ -80,5 +88,14 @@ func (d *DefaultTracker) TrackAuthError(errorMessage string) {
 		"build_slug":        d.envRepo.Get("BITRISE_BUILD_SLUG"),
 		"step_execution_id": d.envRepo.Get("BITRISE_STEP_EXECUTION_ID"),
 		"error_message":     errorMessage,
+	})
+}
+
+// TrackUnknownEntitlement ...
+func (d *DefaultTracker) TrackUnknownEntitlement(key string) {
+	d.tracker.Enqueue("step_appstoreconnect_unknown_entitlement", analytics.Properties{
+		"build_slug":        d.envRepo.Get("BITRISE_BUILD_SLUG"),
+		"step_execution_id": d.envRepo.Get("BITRISE_STEP_EXECUTION_ID"),
+		"entitlement_key":   key,
 	})
 }

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -399,6 +399,10 @@ func (c *ProfileClient) SyncBundleID(bundleID appstoreconnect.BundleID, appEntit
 		ent := autocodesign.Entitlement{key: value}
 		cap, err := ent.Capability()
 		if err != nil {
+			if errors.Is(err, autocodesign.ErrUnknownEntitlementKey) {
+				log.Warnf("Skipping unknown entitlement key %q while syncing bundle ID capabilities. If this is a recognised Apple entitlement that should be registered on App Store Connect, please report it to bitrise-io/go-xcode so it can be added to ServiceTypeByKey.", key)
+				continue
+			}
 			return err
 		}
 		if cap == nil {

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles.go
@@ -400,6 +400,7 @@ func (c *ProfileClient) SyncBundleID(bundleID appstoreconnect.BundleID, appEntit
 		cap, err := ent.Capability()
 		if err != nil {
 			if errors.Is(err, autocodesign.ErrUnknownEntitlementKey) {
+				c.client.Tracker().TrackUnknownEntitlement(key)
 				log.Warnf("Skipping unknown entitlement key %q while syncing bundle ID capabilities. If this is a recognised Apple entitlement that should be registered on App Store Connect, please report it to bitrise-io/go-xcode so it can be added to ServiceTypeByKey.", key)
 				continue
 			}

--- a/autocodesign/devportalclient/appstoreconnectclient/profiles_test.go
+++ b/autocodesign/devportalclient/appstoreconnectclient/profiles_test.go
@@ -221,3 +221,30 @@ func Test_wrapInProfileError(t *testing.T) {
 		})
 	}
 }
+
+type recordingTracker struct {
+	appstoreconnect.NoOpAnalyticsTracker
+	unknownEntitlements []string
+}
+
+func (r *recordingTracker) TrackUnknownEntitlement(key string) {
+	r.unknownEntitlements = append(r.unknownEntitlements, key)
+}
+
+func TestSyncBundleID_UnknownEntitlement_TracksAndSkips(t *testing.T) {
+	logger := log.NewLogger(log.WithDebugLog(true))
+	tracker := &recordingTracker{}
+
+	client := appstoreconnect.NewClient(&MockClient{}, "keyID", "issueID", []byte("privateKey"), false, logger, tracker)
+	profileClient := NewProfileClient(client)
+
+	err := profileClient.SyncBundleID(
+		appstoreconnect.BundleID{Attributes: appstoreconnect.BundleIDAttributes{Identifier: "io.bitrise.testapp"}},
+		autocodesign.Entitlements(map[string]interface{}{
+			"com.apple.developer.made-up-entitlement": "",
+		}),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"com.apple.developer.made-up-entitlement"}, tracker.unknownEntitlements)
+}

--- a/autocodesign/entitlement.go
+++ b/autocodesign/entitlement.go
@@ -13,6 +13,14 @@ import (
 // ICloudIdentifiersEntitlementKey ...
 const ICloudIdentifiersEntitlementKey = "com.apple.developer.icloud-container-identifiers"
 
+// ErrUnknownEntitlementKey is returned by Entitlement.Capability and
+// Entitlement.Equal when an entitlement key is not present in
+// appstoreconnect.ServiceTypeByKey. Callers that iterate over a project's
+// full entitlement set (e.g. SyncBundleID) may wrap this with errors.Is to
+// skip unknown keys with a warning instead of aborting, so a single new
+// Apple-introduced key does not break the entire code signing flow.
+var ErrUnknownEntitlementKey = errors.New("unknown entitlement key")
+
 // DataProtections ...
 var DataProtections = map[string]appstoreconnect.CapabilityOptionKey{
 	"NSFileProtectionComplete":                             appstoreconnect.CompleteProtection,
@@ -44,7 +52,7 @@ func (e Entitlement) Capability() (*appstoreconnect.BundleIDCapability, error) {
 
 	capType, ok := appstoreconnect.ServiceTypeByKey[entKey]
 	if !ok {
-		return nil, errors.New("unknown entitlement key: " + entKey)
+		return nil, fmt.Errorf("%w: %s", ErrUnknownEntitlementKey, entKey)
 	}
 
 	if capType == appstoreconnect.Ignored {
@@ -144,7 +152,7 @@ func (e Entitlement) Equal(cap appstoreconnect.BundleIDCapability, allEntitlemen
 
 	capType, ok := appstoreconnect.ServiceTypeByKey[entKey]
 	if !ok {
-		return false, errors.New("unknown entitlement key: " + entKey)
+		return false, fmt.Errorf("%w: %s", ErrUnknownEntitlementKey, entKey)
 	}
 
 	if cap.Attributes.CapabilityType != capType {

--- a/autocodesign/entitlement.go
+++ b/autocodesign/entitlement.go
@@ -13,12 +13,10 @@ import (
 // ICloudIdentifiersEntitlementKey ...
 const ICloudIdentifiersEntitlementKey = "com.apple.developer.icloud-container-identifiers"
 
-// ErrUnknownEntitlementKey is returned by Entitlement.Capability and
-// Entitlement.Equal when an entitlement key is not present in
-// appstoreconnect.ServiceTypeByKey. Callers that iterate over a project's
-// full entitlement set (e.g. SyncBundleID) may wrap this with errors.Is to
-// skip unknown keys with a warning instead of aborting, so a single new
-// Apple-introduced key does not break the entire code signing flow.
+// ErrUnknownEntitlementKey signals that an entitlement key is not present in
+// appstoreconnect.ServiceTypeByKey. Callers iterating over a project's full
+// entitlement set (e.g. SyncBundleID) can use errors.Is to skip unknown keys
+// with a warning instead of aborting the code signing flow.
 var ErrUnknownEntitlementKey = errors.New("unknown entitlement key")
 
 // DataProtections ...

--- a/autocodesign/entitlement_test.go
+++ b/autocodesign/entitlement_test.go
@@ -1,6 +1,7 @@
 package autocodesign
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -106,6 +107,18 @@ func TestCapability_HealthKitAccessIgnored(t *testing.T) {
 	})
 	cap, err := ent.Capability()
 	require.NoError(t, err)
+	require.Nil(t, cap)
+}
+
+func TestCapability_UnknownKeyReturnsSentinel(t *testing.T) {
+	ent := Entitlement(map[string]interface{}{
+		"com.apple.developer.totally-made-up-entitlement": true,
+	})
+
+	cap, err := ent.Capability()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrUnknownEntitlementKey))
+	require.Contains(t, err.Error(), "com.apple.developer.totally-made-up-entitlement")
 	require.Nil(t, cap)
 }
 


### PR DESCRIPTION
> **Stacked on** #326 (`audit/service-type-by-key`) → #325 (`fix/healthkit-access-entitlement`). Merge in order; this PR's diff will collapse to its own changes once the base PRs land.

## Issue

`autocodesign.Entitlement.Capability()` hard-errors with `unknown entitlement key: <key>` whenever a project's entitlements file contains a key that is not in `appstoreconnect.ServiceTypeByKey`.

`ProfileClient.SyncBundleID` iterates the entire project entitlements map and returns the first such error unwrapped. As a result, **one unrecognised key anywhere in the project kills the entire code signing phase**, even when every other entitlement is well-known and in sync with App Store Connect:

```
failed to manage code signing: failed to ensure code signing assets:
failed to ensure profiles: failed to update bundle ID capabilities:
unknown entitlement key: <key>
```

This is the failure mode behind #325 (`com.apple.developer.healthkit.access`, iOS 17.5+). Apple adds entitlement keys routinely (see #326 for a recent batch); each addition is a latent, high-blast-radius break.

## Intent

Decouple the step's stability from Apple's entitlement release cadence. An entitlement key that we have not yet classified should log a warning and be skipped, not abort the entire sync. Other entitlements on the bundle ID still get registered correctly.

## Changes

1. **Exported sentinel error** (`autocodesign.ErrUnknownEntitlementKey`) in `autocodesign/entitlement.go`. Both `Capability()` and `Equal()` now wrap it with `fmt.Errorf(\"%w: %s\", …)`. The human-readable error message is unchanged — `unknown entitlement key: <key>` — so any log-scraping stays compatible, while callers gain `errors.Is` wiring for programmatic handling.
2. **`ProfileClient.SyncBundleID`** catches the sentinel with `errors.Is`, logs a warning that identifies the offending key and points at this repo, and `continue`s the loop to process the rest of the project's entitlements instead of aborting.
3. **Regression test** (`TestCapability_UnknownKeyReturnsSentinel`) in `autocodesign/entitlement_test.go` confirms sentinel wrapping + key attribution in the error message.

`Equal()` (called from `checkBundleIDEntitlements`) is not currently reachable with an unknown key because its caller gates on `AppearsOnDeveloperPortal()`, which already returns `false` for unknown keys. The sentinel is wired there anyway for consistency — so if that gate is ever relaxed, the behavior stays defensive.

## Risk / tradeoff

**Today:** an unrecognised entitlement = every affected build fails with an opaque error.

**After this PR:** an unrecognised entitlement = a warning in the log, the bundle ID is synced with every other capability, the build proceeds. If the unknown key *did* need ASC registration, the downstream provisioning step will fail with a more targeted error (missing capability on a specific profile) that is easier to attribute than today's \"unknown entitlement key\".

In other words: we trade a guaranteed hard-break for a soft-break with better attribution. The step becomes resilient to Apple's additions until the allow-list catches up.

## Test plan

- [x] `go test ./autocodesign/...`
- [x] `go vet ./autocodesign/...`
- [x] New `TestCapability_UnknownKeyReturnsSentinel` passes
- [ ] Integration: inject a synthetic unknown key into a project's entitlements, run `xcode-archive@6.x`, confirm warning is logged and other capabilities sync correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)