### PR TITLE
chore: migrate sliceutil v1 to v2

### DIFF
--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/sliceutil"
+	"github.com/bitrise-io/go-utils/v2/sliceutil"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retryhttp"
@@ -163,8 +163,12 @@ func splitCertificatesAndPassphrases(certURLList string, certPassphraseList stri
 }
 
 // SplitAndClean ...
-func splitAndClean(list string, sep string, omitEmpty bool) (items []string) {
-	return sliceutil.CleanWhitespace(strings.Split(list, sep), omitEmpty)
+func splitAndClean(list string, sep string, omitEmpty bool) []string {
+	items := sliceutil.Map(strings.Split(list, sep), strings.TrimSpace)
+	if omitEmpty {
+		items = sliceutil.Filter(items, func(s string) bool { return len(s) > 0 })
+	}
+	return items
 }
 
 // parseFallbackProvisioningProfiles validates and expands profilesList.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.49
 	github.com/bitrise-io/go-utils v1.0.13
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260424152942-70f02e371123
 	github.com/bitrise-io/go-xcode v1.3.3
 	github.com/globocom/go-buffer/v2 v2.0.0
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJ
 github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34 h1:xsLfhItfs4SCCAesbv7UtKpldNqievDvtHggSuBI2+w=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260424152942-70f02e371123 h1:cdCGv8opOOiswNWkX6PZLcfzp6RES2iF3ahupMEdLuk=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260424152942-70f02e371123/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/go-xcode v1.3.3 h1:aYkSMWP+1/n2ZabRy3OMfeaWmE4l1gAPq63azx06LIw=
 github.com/bitrise-io/go-xcode v1.3.3/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
Replace `github.com/bitrise-io/go-utils/sliceutil` (v1) usages:
- `IsStringInSlice` → `slices.Contains` (stdlib)
- `IndexOfStringInSlice` → `slices.Index` (stdlib)
- `CleanWhitespace` → `sliceutil.Map` + `sliceutil.Filter` (v2)