### PR TITLE
fix(target): treat dependencies and buildPhases as optional keys

### DIFF
--- a/xcodeproject/xcodeproj/target.go
+++ b/xcodeproject/xcodeproj/target.go
@@ -129,7 +129,10 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 
 	dependencyIDs, err := rawTarget.StringSlice("dependencies")
 	if err != nil {
-		return Target{}, err
+		if !serialized.IsKeyNotFoundError(err) {
+			return Target{}, err
+		}
+		dependencyIDs = []string{}
 	}
 
 	var dependencies []TargetDependency
@@ -168,7 +171,10 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 
 	buildPhaseIDs, err := rawTarget.StringSlice("buildPhases")
 	if err != nil {
-		return Target{}, err
+		if !serialized.IsKeyNotFoundError(err) {
+			return Target{}, err
+		}
+		buildPhaseIDs = []string{}
 	}
 
 	return Target{


### PR DESCRIPTION
## Summary

Xcode 16.2+ omits the `dependencies` key from `project.pbxproj` when a target has no dependencies (instead of writing `dependencies = ();`). This causes `parseTarget()` to fail with a `KeyNotFoundError`.

## Changes

Apply the same `IsKeyNotFoundError` guard already used for `productType` and `productReference` to:
- `dependencies` — fixes the immediate breakage
- `buildPhases` — forward-compatibility (Xcode may optimize this away too)

## Testing

- Existing tests pass (`go test ./xcodeproject/xcodeproj/...`)
- Verified locally against a real Xcode 16.2 project with 6 affected targets

Fixes #330