### PR TITLE
chore: migrate xcscheme to v2 (STEP-2198)

### DIFF
--- a/xcodeproject/xcscheme/errors.go
+++ b/xcodeproject/xcscheme/errors.go
@@ -1,0 +1,23 @@
+package xcscheme
+
+import "fmt"
+
+// NotFoundError represents that the given scheme was not found in the container
+type NotFoundError struct {
+	Scheme    string
+	Container string
+}
+
+// Error implements the error interface
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("scheme %s not found in %s", e.Scheme, e.Container)
+}
+
+// IsNotFoundError reports whatever the given error is an instance of NotFoundError
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(NotFoundError)
+	return ok
+}

--- a/xcodeproject/xcscheme/errors_test.go
+++ b/xcodeproject/xcscheme/errors_test.go
@@ -1,0 +1,40 @@
+package xcscheme
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSchemeNotFoundError_Error(t *testing.T) {
+	err := NotFoundError{Scheme: "Scheme", Container: "Workspace"}
+	want := "scheme Scheme not found in Workspace"
+	if err.Error() != want {
+		t.Errorf("SchemeNotFoundError.Error() = %v, want %v", err, want)
+	}
+}
+
+func TestIsSchemeNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "SchemeNotFoundError",
+			err:  NotFoundError{Scheme: "Scheme", Container: "Workspace"},
+			want: true,
+		},
+		{
+			name: "not SchemeNotFoundError",
+			err:  errors.New("other error"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFoundError(tt.err); got != tt.want {
+				t.Errorf("IsSchemeNotFoundError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/xcodeproject/xcscheme/example_test.go
+++ b/xcodeproject/xcscheme/example_test.go
@@ -1,0 +1,31 @@
+package xcscheme
+
+import (
+	"fmt"
+)
+
+func Example() {
+	scheme, err := Open("scheme.xcscheme")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("archive action's default configuration name: %s\n", scheme.ArchiveAction.BuildConfiguration)
+
+	for _, entry := range scheme.BuildAction.BuildActionEntries {
+		if entry.BuildForArchiving == "YES" {
+
+		}
+
+		if entry.BuildForTesting == "YES" {
+
+		}
+
+		targetContainerProjectPth, err := entry.BuildableReference.ReferencedContainerAbsPath("scheme_container_project.xcodeproj")
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("target with id: %s can be found in project: %s\n", entry.BuildableReference.BlueprintIdentifier, targetContainerProjectPth)
+	}
+}

--- a/xcodeproject/xcscheme/testdata/BullsEye.xcscheme
+++ b/xcodeproject/xcscheme/testdata/BullsEye.xcscheme
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2A5F1FF1F4A9144005CD714"
+               BuildableName = "BullsEye.app"
+               BlueprintName = "BullsEye"
+               ReferencedContainer = "container:BullsEye.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:FullTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UnitTests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UITests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:ParallelUITests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:FailingTests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:EventuallyFailingTests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:EventuallySucceedingTests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:EventuallyFailingInMemoryTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13FB7CED267726620084066F"
+               BuildableName = "BullsEyeTests.xctest"
+               BlueprintName = "BullsEyeTests"
+               ReferencedContainer = "container:BullsEye.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13FB7CFA2677288A0084066F"
+               BuildableName = "BullsEyeSlowTests.xctest"
+               BlueprintName = "BullsEyeSlowTests"
+               ReferencedContainer = "container:BullsEye.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13FB7D0B26773C570084066F"
+               BuildableName = "BullsEyeUITests.xctest"
+               BlueprintName = "BullsEyeUITests"
+               ReferencedContainer = "container:BullsEye.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "139E88A6268DBCDA0007755C"
+               BuildableName = "BullsEyeFailingTests.xctest"
+               BlueprintName = "BullsEyeFailingTests"
+               ReferencedContainer = "container:BullsEye.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2A5F1FF1F4A9144005CD714"
+            BuildableName = "BullsEye.app"
+            BlueprintName = "BullsEye"
+            ReferencedContainer = "container:BullsEye.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2A5F1FF1F4A9144005CD714"
+            BuildableName = "BullsEye.app"
+            BlueprintName = "BullsEye"
+            ReferencedContainer = "container:BullsEye.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcodeproject/xcscheme/testdata/ios-simple-objc.xcscheme
+++ b/xcodeproject/xcscheme/testdata/ios-simple-objc.xcscheme
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA3CBE7419F7A93800CED4D5"
+               BuildableName = "ios-simple-objc.app"
+               BlueprintName = "ios-simple-objc"
+               ReferencedContainer = "container:ios-simple-objc.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA3CBE9019F7A93900CED4D5"
+               BuildableName = "ios-simple-objcTests.xctest"
+               BlueprintName = "ios-simple-objcTests"
+               ReferencedContainer = "container:ios-simple-objc.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA3CBE9019F7A93900CED4D5"
+               BuildableName = "ios-simple-objcTests.xctest"
+               BlueprintName = "ios-simple-objcTests"
+               ReferencedContainer = "container:ios-simple-objc.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BA3CBE7419F7A93800CED4D5"
+            BuildableName = "ios-simple-objc.app"
+            BlueprintName = "ios-simple-objc"
+            ReferencedContainer = "container:ios-simple-objc.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BA3CBE7419F7A93800CED4D5"
+            BuildableName = "ios-simple-objc.app"
+            BlueprintName = "ios-simple-objc"
+            ReferencedContainer = "container:ios-simple-objc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BA3CBE7419F7A93800CED4D5"
+            BuildableName = "ios-simple-objc.app"
+            BlueprintName = "ios-simple-objc"
+            ReferencedContainer = "container:ios-simple-objc.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcodeproject/xcscheme/xcscheme.go
+++ b/xcodeproject/xcscheme/xcscheme.go
@@ -1,0 +1,308 @@
+package xcscheme
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/pathutil"
+)
+
+// BuildableReference ...
+type BuildableReference struct {
+	BuildableIdentifier string `xml:"BuildableIdentifier,attr"`
+	BlueprintIdentifier string `xml:"BlueprintIdentifier,attr"`
+	BuildableName       string `xml:"BuildableName,attr"`
+	BlueprintName       string `xml:"BlueprintName,attr"`
+	ReferencedContainer string `xml:"ReferencedContainer,attr"`
+}
+
+// IsAppReference ...
+func (r BuildableReference) IsAppReference() bool {
+	return filepath.Ext(r.BuildableName) == ".app"
+}
+
+func (r BuildableReference) isTestProduct() bool {
+	return filepath.Ext(r.BuildableName) == ".xctest"
+}
+
+// ReferencedContainerAbsPath ...
+func (r BuildableReference) ReferencedContainerAbsPath(schemeContainerDir string) (string, error) {
+	s := strings.Split(r.ReferencedContainer, ":")
+	if len(s) != 2 {
+		return "", fmt.Errorf("unknown referenced container (%s)", r.ReferencedContainer)
+	}
+
+	base := s[1]
+	absPth := filepath.Join(schemeContainerDir, base)
+
+	return pathutil.NewPathModifier().AbsPath(absPth)
+}
+
+// BuildActionEntry ...
+type BuildActionEntry struct {
+	BuildForTesting   string `xml:"buildForTesting,attr"`
+	BuildForRunning   string `xml:"buildForRunning,attr"`
+	BuildForProfiling string `xml:"buildForProfiling,attr"`
+	BuildForArchiving string `xml:"buildForArchiving,attr"`
+	BuildForAnalyzing string `xml:"buildForAnalyzing,attr"`
+
+	BuildableReference BuildableReference
+}
+
+// BuildAction ...
+type BuildAction struct {
+	ParallelizeBuildables     string             `xml:"parallelizeBuildables,attr"`
+	BuildImplicitDependencies string             `xml:"buildImplicitDependencies,attr"`
+	BuildActionEntries        []BuildActionEntry `xml:"BuildActionEntries>BuildActionEntry"`
+}
+
+// TestableReference ...
+type TestableReference struct {
+	Skipped        string `xml:"skipped,attr"`
+	Parallelizable string `xml:"parallelizable,attr,omitempty"`
+
+	BuildableReference BuildableReference
+}
+
+func (r TestableReference) isTestable() bool {
+	return r.Skipped == "NO" && r.BuildableReference.isTestProduct()
+}
+
+// TestPlanReference ...
+type TestPlanReference struct {
+	Reference string `xml:"reference,attr,omitempty"`
+	Default   string `xml:"default,attr,omitempty"`
+}
+
+// IsDefault ...
+func (r TestPlanReference) IsDefault() bool {
+	return r.Default == "YES"
+}
+
+// Name ...
+func (r TestPlanReference) Name() string {
+	// reference = "container:FullTests.xctestplan"
+	idx := strings.Index(r.Reference, ":")
+	testPlanFileName := r.Reference[idx+1:]
+	return strings.TrimSuffix(testPlanFileName, filepath.Ext(testPlanFileName))
+}
+
+// MacroExpansion ...
+type MacroExpansion struct {
+	BuildableReference BuildableReference
+}
+
+// AdditionalOptions ...
+type AdditionalOptions struct {
+}
+
+// TestPlans ...
+type TestPlans struct {
+	TestPlanReferences []TestPlanReference `xml:"TestPlanReference,omitempty"`
+}
+
+// TestAction ...
+type TestAction struct {
+	BuildConfiguration           string `xml:"buildConfiguration,attr"`
+	SelectedDebuggerIdentifier   string `xml:"selectedDebuggerIdentifier,attr"`
+	SelectedLauncherIdentifier   string `xml:"selectedLauncherIdentifier,attr"`
+	ShouldUseLaunchSchemeArgsEnv string `xml:"shouldUseLaunchSchemeArgsEnv,attr"`
+
+	// TODO: This property means that a TestPlan belongs to this test action.
+	//   As long as the related testPlan has default settings it is not created as a separate TestPlan file.
+	//   If any default test plan setting is changed, Xcode creates the TestPlan file, adds a TestPlans entry to the scheme and removes this property from the TestAction.
+	//   Code working with test plans should be updated to consider this new property.
+	ShouldAutocreateTestPlan string `xml:"shouldAutocreateTestPlan,attr,omitempty"`
+
+	Testables         []TestableReference `xml:"Testables>TestableReference"`
+	TestPlans         *TestPlans
+	MacroExpansion    MacroExpansion
+	AdditionalOptions AdditionalOptions
+}
+
+// BuildableProductRunnable ...
+type BuildableProductRunnable struct {
+	RunnableDebuggingMode string `xml:"runnableDebuggingMode,attr"`
+	BuildableReference    BuildableReference
+}
+
+// LaunchAction ...
+type LaunchAction struct {
+	BuildConfiguration             string `xml:"buildConfiguration,attr"`
+	SelectedDebuggerIdentifier     string `xml:"selectedDebuggerIdentifier,attr"`
+	SelectedLauncherIdentifier     string `xml:"selectedLauncherIdentifier,attr"`
+	LaunchStyle                    string `xml:"launchStyle,attr"`
+	UseCustomWorkingDirectory      string `xml:"useCustomWorkingDirectory,attr"`
+	IgnoresPersistentStateOnLaunch string `xml:"ignoresPersistentStateOnLaunch,attr"`
+	DebugDocumentVersioning        string `xml:"debugDocumentVersioning,attr"`
+	DebugServiceExtension          string `xml:"debugServiceExtension,attr"`
+	AllowLocationSimulation        string `xml:"allowLocationSimulation,attr"`
+	BuildableProductRunnable       BuildableProductRunnable
+	AdditionalOptions              AdditionalOptions
+}
+
+// ProfileAction ...
+type ProfileAction struct {
+	BuildConfiguration           string `xml:"buildConfiguration,attr"`
+	ShouldUseLaunchSchemeArgsEnv string `xml:"shouldUseLaunchSchemeArgsEnv,attr"`
+	SavedToolIdentifier          string `xml:"savedToolIdentifier,attr"`
+	UseCustomWorkingDirectory    string `xml:"useCustomWorkingDirectory,attr"`
+	DebugDocumentVersioning      string `xml:"debugDocumentVersioning,attr"`
+	BuildableProductRunnable     BuildableProductRunnable
+}
+
+// AnalyzeAction ...
+type AnalyzeAction struct {
+	BuildConfiguration string `xml:"buildConfiguration,attr"`
+}
+
+// ArchiveAction ...
+type ArchiveAction struct {
+	BuildConfiguration       string `xml:"buildConfiguration,attr"`
+	RevealArchiveInOrganizer string `xml:"revealArchiveInOrganizer,attr"`
+}
+
+// Scheme ...
+type Scheme struct {
+	// The last known Xcode version.
+	LastUpgradeVersion string `xml:"LastUpgradeVersion,attr"`
+	// The version of `.xcscheme` files supported.
+	Version string `xml:"version,attr"`
+
+	BuildAction   BuildAction
+	TestAction    TestAction
+	LaunchAction  LaunchAction
+	ProfileAction ProfileAction
+	AnalyzeAction AnalyzeAction
+	ArchiveAction ArchiveAction
+
+	Name     string `xml:"-"`
+	Path     string `xml:"-"`
+	IsShared bool   `xml:"-"`
+}
+
+// Open ...
+func Open(pth string) (Scheme, error) {
+	f, err := os.Open(pth)
+	if err != nil {
+		return Scheme{}, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	scheme, err := parse(f)
+	if err != nil {
+		return Scheme{}, fmt.Errorf("failed to unmarshal scheme file: %s: %s", pth, err)
+	}
+
+	scheme.Name = strings.TrimSuffix(filepath.Base(pth), filepath.Ext(pth))
+	scheme.Path = pth
+
+	return scheme, nil
+}
+
+func parse(reader io.Reader) (scheme Scheme, err error) {
+	err = xml.NewDecoder(reader).Decode(&scheme)
+	return
+}
+
+// XMLToken ...
+type XMLToken int
+
+const (
+	// XMLStart ...
+	XMLStart XMLToken = 1
+	// XMLEnd ...
+	XMLEnd XMLToken = 2
+	// XMLAttribute ...
+	XMLAttribute XMLToken = 3
+)
+
+// Marshal ...
+func (s Scheme) Marshal() ([]byte, error) {
+	contents, err := xml.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Scheme: %v", err)
+	}
+
+	contentsNewline := strings.ReplaceAll(string(contents), "><", ">\n<")
+
+	// Place XML Attributes on separate lines
+	re := regexp.MustCompile(`\s([^=<>/]*)\s?=\s?"([^=<>/]*)"`)
+	contentsNewline = re.ReplaceAllString(contentsNewline, "\n$1 = \"$2\"")
+
+	var contentsIndented string
+
+	indent := 0
+	for _, line := range strings.Split(contentsNewline, "\n") {
+		currentLine := XMLAttribute
+		if strings.HasPrefix(line, "</") {
+			currentLine = XMLEnd
+		} else if strings.HasPrefix(line, "<") {
+			currentLine = XMLStart
+		}
+
+		if currentLine == XMLEnd && indent != 0 {
+			indent--
+		}
+
+		contentsIndented += strings.Repeat("   ", indent)
+		contentsIndented += line + "\n"
+
+		if currentLine == XMLStart {
+			indent++
+		}
+	}
+
+	return []byte(xml.Header + contentsIndented), nil
+}
+
+// AppBuildActionEntry ...
+func (s Scheme) AppBuildActionEntry() (BuildActionEntry, bool) {
+	var entry BuildActionEntry
+	for _, e := range s.BuildAction.BuildActionEntries {
+		if e.BuildForArchiving != "YES" {
+			continue
+		}
+		if !e.BuildableReference.IsAppReference() {
+			continue
+		}
+		entry = e
+		break
+	}
+
+	return entry, (entry.BuildableReference.BlueprintIdentifier != "")
+}
+
+// IsTestable returns true if Test is a valid action
+func (s Scheme) IsTestable() bool {
+	for _, testEntry := range s.TestAction.Testables {
+		if testEntry.isTestable() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DefaultTestPlan ...
+func (s Scheme) DefaultTestPlan() *TestPlanReference {
+	if s.TestAction.TestPlans == nil {
+		return nil
+	}
+
+	testPlans := *s.TestAction.TestPlans
+
+	for _, testPlanRef := range testPlans.TestPlanReferences {
+		if testPlanRef.IsDefault() {
+			return &testPlanRef
+		}
+	}
+	return nil
+}

--- a/xcodeproject/xcscheme/xcscheme_test.go
+++ b/xcodeproject/xcscheme/xcscheme_test.go
@@ -1,0 +1,99 @@
+package xcscheme
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GivenScheme_WhenMarshal_ThenContentRemain(t *testing.T) {
+	// Given
+	schemePth := "testdata/ios-simple-objc.xcscheme"
+
+	f, err := os.Open(schemePth)
+	require.NoError(t, err)
+
+	scheme, err := parse(f)
+	require.NoError(t, err)
+
+	// When
+	content, err := scheme.Marshal()
+
+	// Then
+	require.NoError(t, err)
+
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	schemeContent, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, string(schemeContent), string(content))
+}
+
+func Test_GivenSchemeWithTestPlan_WhenOpen_ThenDefaultTestPlanSet(t *testing.T) {
+	// Given
+	schemePth := "testdata/BullsEye.xcscheme"
+
+	// When
+	scheme, err := Open(schemePth)
+
+	// Then
+	require.NoError(t, err)
+
+	testPlan := scheme.DefaultTestPlan()
+	require.NotNil(t, testPlan)
+	require.Equal(t, "FullTests", testPlan.Name())
+}
+
+func Test_GivenSimpleScheme_WhenOpen(t *testing.T) {
+	// Given
+	schemePth := "testdata/ios-simple-objc.xcscheme"
+
+	// When
+	scheme, err := Open(schemePth)
+
+	// Then
+	require.NoError(t, err)
+
+	require.Equal(t, "ios-simple-objc", scheme.Name)
+	require.Equal(t, schemePth, scheme.Path)
+
+	require.Equal(t, "Release", scheme.ArchiveAction.BuildConfiguration)
+	require.Equal(t, 2, len(scheme.BuildAction.BuildActionEntries))
+
+	assertIosSimpleObjCSchemeAppBuildActionEntry(scheme, t)
+	assertIosSimpleObjCSchemeTestActionEntry(scheme, t)
+}
+
+func assertIosSimpleObjCSchemeAppBuildActionEntry(scheme Scheme, t *testing.T) {
+	entry, ok := scheme.AppBuildActionEntry()
+	require.True(t, ok)
+
+	require.Equal(t, "YES", entry.BuildForArchiving)
+	require.Equal(t, "YES", entry.BuildForTesting)
+	require.Equal(t, "BA3CBE7419F7A93800CED4D5", entry.BuildableReference.BlueprintIdentifier)
+	require.Equal(t, "ios-simple-objc.app", entry.BuildableReference.BuildableName)
+	require.Equal(t, "ios-simple-objc", entry.BuildableReference.BlueprintName)
+	require.Equal(t, "container:ios-simple-objc.xcodeproj", entry.BuildableReference.ReferencedContainer)
+
+	pth, err := entry.BuildableReference.ReferencedContainerAbsPath("/project.xcodeproj")
+	require.NoError(t, err)
+	require.Equal(t, "/project.xcodeproj/ios-simple-objc.xcodeproj", pth)
+
+	require.True(t, entry.BuildableReference.IsAppReference())
+}
+
+func assertIosSimpleObjCSchemeTestActionEntry(scheme Scheme, t *testing.T) {
+	require.Equal(t, "Debug", scheme.TestAction.BuildConfiguration)
+	require.Equal(t, 1, len(scheme.TestAction.Testables))
+	require.Equal(t, "NO", scheme.TestAction.Testables[0].Skipped)
+	require.Equal(t, "BA3CBE9019F7A93900CED4D5", scheme.TestAction.Testables[0].BuildableReference.BlueprintIdentifier)
+
+	require.False(t, scheme.TestAction.Testables[0].BuildableReference.IsAppReference())
+
+	require.Nil(t, scheme.TestAction.TestPlans)
+	testPlan := scheme.DefaultTestPlan()
+	require.Nil(t, testPlan)
+}


### PR DESCRIPTION
## Summary

Adds `xcscheme` as a v2 package under `xcodeproject/xcscheme/` so v2 consumers no longer have to reach back into v1 for `xcscheme.Scheme`, `xcscheme.Open`, and related types. Stage 1 of the [v1→v2 migration plan](https://bitrise.atlassian.net/browse/STEP-2166) — unblocks the xcodeproj migration ([STEP-2169](https://bitrise.atlassian.net/browse/STEP-2169)), which in turn unblocks pathfilters and xcworkspace.

Jira: [STEP-2198](https://bitrise.atlassian.net/browse/STEP-2198)

## What changed

- New package `xcodeproject/xcscheme/` ported from v1.
- Module imports updated to `/v2`.
- `go-utils/log` calls dropped from `Open()`:
  - The `log.Warnf("Failed to close scheme: …")` on deferred close is replaced with `_ = f.Close()` — the v1 code was already swallowing the close error, just logging it; same semantics minus the log line.
  - The `log.Printf("Read %s scheme in %s.", …)` timing line is dropped (informational only).
- `pathutil.AbsPath(pth)` swapped for `pathutil.NewPathModifier().AbsPath(pth)` (v2 PathModifier interface).

## What did NOT change

The two v2 files that import v1 `xcscheme` stay on v1 for now:

- `exportoptionsgenerator/targets.go`
- `autocodesign/projectmanager/projecthelper.go`

Both consume `xcscheme.Scheme` returned by v1 `xcodeproj.XcodeProj.Schemes()`. Switching them requires v2 `xcodeproj`, which is gated on [STEP-2169](https://bitrise.atlassian.net/browse/STEP-2169). They'll move as part of that ticket.

## Test plan

- [x] `go test ./xcodeproject/xcscheme/...` — all 5 tests pass (errors, marshalling round-trip, test plan parsing, simple scheme parsing).
- [x] `go build ./...` — whole repo compiles.
- [x] `gofmt -l xcodeproject/xcscheme/` — clean.
- [x] `go vet ./xcodeproject/xcscheme/...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2169]: https://bitrise.atlassian.net/browse/STEP-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STEP-2198]: https://bitrise.atlassian.net/browse/STEP-2198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STEP-2169]: https://bitrise.atlassian.net/browse/STEP-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ