### PR TITLE
chore: migrate exportoptions to v2 (STEP-2175)

### DIFF
--- a/exportoptions/appstore_options.go
+++ b/exportoptions/appstore_options.go
@@ -1,0 +1,115 @@
+package exportoptions
+
+import (
+	"fmt"
+
+	"howett.net/plist"
+)
+
+// AppStoreOptionsModel ...
+type AppStoreOptionsModel struct {
+	Method                             Method
+	TeamID                             string
+	BundleIDProvisioningProfileMapping map[string]string
+	SigningCertificate                 string
+	InstallerSigningCertificate        string
+	SigningStyle                       SigningStyle
+	Destination                        Destination
+	ICloudContainerEnvironment         ICloudContainerEnvironment
+	DistributionBundleIdentifier       string
+
+	// for app-store exports
+	UploadBitcode bool
+	UploadSymbols bool
+	// Should Xcode manage the app's build number when uploading to App Store Connect? Defaults to YES.
+	ManageAppVersion bool
+
+	TestFlightInternalTestingOnly bool
+}
+
+// NewAppStoreOptions sets "app-store" as the export method
+// deprecated: use NewAppStoreConnectOptions instead
+func NewAppStoreOptions() AppStoreOptionsModel {
+	return NewAppStoreConnectOptions(MethodAppStore)
+}
+
+// NewAppStoreConnectOptions sets either "app-store" or "app-store-connect" as the export method
+func NewAppStoreConnectOptions(method Method) AppStoreOptionsModel {
+	if !method.IsAppStore() {
+		panic("non app-store method passed to NewAppStoreConnectOptions")
+	}
+	return AppStoreOptionsModel{
+		Method:                        method,
+		UploadBitcode:                 UploadBitcodeDefault,
+		UploadSymbols:                 UploadSymbolsDefault,
+		ManageAppVersion:              manageAppVersionDefault,
+		TestFlightInternalTestingOnly: TestFlightInternalTestingOnlyDefault,
+	}
+}
+
+// Hash ...
+func (options AppStoreOptionsModel) Hash() map[string]interface{} {
+	hash := map[string]interface{}{}
+	hash[MethodKey] = options.Method
+	if options.TeamID != "" {
+		hash[TeamIDKey] = options.TeamID
+	}
+	//nolint:gosimple
+	if options.UploadBitcode != UploadBitcodeDefault {
+		hash[UploadBitcodeKey] = options.UploadBitcode
+	}
+	//nolint:gosimple
+	if options.UploadSymbols != UploadSymbolsDefault {
+		hash[UploadSymbolsKey] = options.UploadSymbols
+	}
+	//nolint:gosimple
+	if options.ManageAppVersion != manageAppVersionDefault {
+		hash[manageAppVersionKey] = options.ManageAppVersion
+	}
+	if options.ICloudContainerEnvironment != "" {
+		hash[ICloudContainerEnvironmentKey] = options.ICloudContainerEnvironment
+	}
+	if options.DistributionBundleIdentifier != "" {
+		hash[DistributionBundleIdentifier] = options.DistributionBundleIdentifier
+	}
+	if len(options.BundleIDProvisioningProfileMapping) > 0 {
+		hash[ProvisioningProfilesKey] = options.BundleIDProvisioningProfileMapping
+	}
+	if options.SigningCertificate != "" {
+		hash[SigningCertificateKey] = options.SigningCertificate
+	}
+	if options.InstallerSigningCertificate != "" {
+		hash[InstallerSigningCertificateKey] = options.InstallerSigningCertificate
+	}
+	if options.SigningStyle != "" {
+		hash[SigningStyleKey] = options.SigningStyle
+	}
+	if options.Destination != "" {
+		hash[DestinationKey] = options.Destination
+	}
+	//nolint:gosimple
+	if options.TestFlightInternalTestingOnly != TestFlightInternalTestingOnlyDefault {
+		hash[TestFlightInternalTestingOnlyKey] = options.TestFlightInternalTestingOnly
+	}
+	return hash
+}
+
+// String ...
+func (options AppStoreOptionsModel) String() (string, error) {
+	hash := options.Hash()
+	plistBytes, err := plist.MarshalIndent(hash, plist.XMLFormat, "\t")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal export options model, error: %s", err)
+	}
+	return string(plistBytes), err
+}
+
+// WriteToFile ...
+func (options AppStoreOptionsModel) WriteToFile(pth string) error {
+	return WritePlistToFile(options.Hash(), pth)
+}
+
+// WriteToTmpFile ...
+func (options AppStoreOptionsModel) WriteToTmpFile() (string, error) {
+	return WritePlistToTmpFile(options.Hash())
+}

--- a/exportoptions/exportoptions.go
+++ b/exportoptions/exportoptions.go
@@ -1,0 +1,46 @@
+package exportoptions
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
+	"howett.net/plist"
+)
+
+// ExportOptions ...
+type ExportOptions interface {
+	Hash() map[string]interface{}
+	String() (string, error)
+	WriteToFile(pth string) error
+	WriteToTmpFile() (string, error)
+}
+
+// WritePlistToFile ...
+func WritePlistToFile(options map[string]interface{}, pth string) error {
+	plistBytes, err := plist.MarshalIndent(options, plist.XMLFormat, "\t")
+	if err != nil {
+		return fmt.Errorf("failed to marshal export options model, error: %s", err)
+	}
+	if err := fileutil.NewFileManager().WriteBytes(pth, plistBytes); err != nil {
+		return fmt.Errorf("failed to write export options, error: %s", err)
+	}
+
+	return nil
+}
+
+// WritePlistToTmpFile ...
+func WritePlistToTmpFile(options map[string]interface{}) (string, error) {
+	tmpDir, err := pathutil.NewPathProvider().CreateTempDir("output")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir, error: %s", err)
+	}
+	pth := filepath.Join(tmpDir, "exportOptions.plist")
+
+	if err := WritePlistToFile(options, pth); err != nil {
+		return "", fmt.Errorf("failed to write to file options, error: %s", err)
+	}
+
+	return pth, nil
+}

--- a/exportoptions/exportoptions_test.go
+++ b/exportoptions/exportoptions_test.go
@@ -1,0 +1,440 @@
+package exportoptions
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifestIsEmpty(t *testing.T) {
+	t.Log("returns true if empty manifest")
+	{
+		manifest := Manifest{}
+		require.Equal(t, true, manifest.IsEmpty())
+	}
+
+	t.Log("returns false if not empty manifest")
+	{
+		manifest := Manifest{
+			AppURL: "appURL",
+		}
+		require.Equal(t, false, manifest.IsEmpty())
+	}
+	{
+		manifest := Manifest{
+			DisplayImageURL: "displayImageURL",
+		}
+		require.Equal(t, false, manifest.IsEmpty())
+	}
+	{
+		manifest := Manifest{
+			FullSizeImageURL: "fullSizeImageURL.",
+		}
+		require.Equal(t, false, manifest.IsEmpty())
+	}
+	{
+		manifest := Manifest{
+			AssetPackManifestURL: "assetPackManifestURL.",
+		}
+		require.Equal(t, false, manifest.IsEmpty())
+	}
+}
+
+func TestManifestToHash(t *testing.T) {
+	t.Log("empty manifest creates empty hash")
+	{
+		manifest := Manifest{}
+		hash := manifest.ToHash()
+		require.Equal(t, 0, len(hash))
+		{
+			value, ok := hash[ManifestAppURLKey]
+			require.Equal(t, false, ok)
+			require.Equal(t, "", value)
+		}
+		{
+			value, ok := hash[ManifestDisplayImageURLKey]
+			require.Equal(t, false, ok)
+			require.Equal(t, "", value)
+		}
+		{
+			value, ok := hash[ManifestFullSizeImageURLKey]
+			require.Equal(t, false, ok)
+			require.Equal(t, "", value)
+		}
+		{
+			value, ok := hash[ManifestAssetPackManifestURLKey]
+			require.Equal(t, false, ok)
+			require.Equal(t, "", value)
+		}
+	}
+
+	t.Log("creates hash from manifest")
+	{
+		manifest := Manifest{
+			AppURL:               "appURL",
+			DisplayImageURL:      "displayImageURL",
+			FullSizeImageURL:     "fullSizeImageURL",
+			AssetPackManifestURL: "assetPackManifestURL",
+		}
+		hash := manifest.ToHash()
+		require.Equal(t, 4, len(hash))
+		{
+			value, ok := hash[ManifestAppURLKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, "appURL", value)
+		}
+		{
+			value, ok := hash[ManifestDisplayImageURLKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, "displayImageURL", value)
+		}
+		{
+			value, ok := hash[ManifestFullSizeImageURLKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, "fullSizeImageURL", value)
+		}
+		{
+			value, ok := hash[ManifestAssetPackManifestURLKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, "assetPackManifestURL", value)
+		}
+	}
+}
+
+func TestNewAppStoreConnectOptions(t *testing.T) {
+	t.Log("create app-store type export options with default values")
+	{
+		options := NewAppStoreConnectOptions(MethodAppStoreConnect)
+		require.Equal(t, UploadBitcodeDefault, options.UploadBitcode)
+		require.Equal(t, UploadSymbolsDefault, options.UploadSymbols)
+		require.Equal(t, TestFlightInternalTestingOnlyDefault, options.TestFlightInternalTestingOnly)
+	}
+}
+
+func TestAppStoreOptionsToHash(t *testing.T) {
+	t.Log("default app-store type options creates hash with legacy method")
+	{
+		options := NewAppStoreOptions()
+		options.ManageAppVersion = true
+		hash := options.Hash()
+		require.Equal(t, 1, len(hash), fmt.Sprintf("Hash: %+v", hash))
+
+		{
+			value, ok := hash[MethodKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, MethodAppStore, value)
+		}
+	}
+
+	t.Log("default app-store type options creates hash with new method")
+	{
+		options := NewAppStoreConnectOptions(MethodAppStoreConnect)
+		options.ManageAppVersion = true
+		hash := options.Hash()
+		require.Equal(t, 1, len(hash), fmt.Sprintf("Hash: %+v", hash))
+
+		{
+			value, ok := hash[MethodKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, MethodAppStoreConnect, value)
+		}
+	}
+
+	t.Log("custom app-store type option's generated hash contains all properties")
+	{
+		options := NewAppStoreOptions()
+		options.TeamID = "123"
+		options.UploadBitcode = false
+		options.UploadSymbols = false
+		options.ManageAppVersion = false
+		options.TestFlightInternalTestingOnly = true
+
+		hash := options.Hash()
+		require.Equal(t, 6, len(hash))
+
+		{
+			value, ok := hash[MethodKey]
+			require.True(t, ok)
+			require.Equal(t, MethodAppStore, value)
+		}
+		{
+			value, ok := hash[TeamIDKey]
+			require.True(t, ok)
+			require.Equal(t, "123", value)
+		}
+		{
+			value, ok := hash[UploadBitcodeKey]
+			require.True(t, ok)
+			require.Equal(t, false, value)
+		}
+		{
+			value, ok := hash[UploadSymbolsKey]
+			require.True(t, ok)
+			require.Equal(t, false, value)
+		}
+		{
+			value, ok := hash[manageAppVersionKey]
+			require.True(t, ok)
+			require.Equal(t, false, value)
+		}
+		{
+			value, ok := hash[TestFlightInternalTestingOnlyKey]
+			require.True(t, ok)
+			require.Equal(t, true, value)
+		}
+	}
+}
+
+func TestAppStoreOptionsWriteToFile(t *testing.T) {
+	t.Log("default app-store type options overrides only method")
+	{
+		tmpDir, err := pathutil.NewPathProvider().CreateTempDir("output")
+		require.NoError(t, err)
+		pth := filepath.Join(tmpDir, "exportOptions.plist")
+
+		options := NewAppStoreConnectOptions(MethodAppStoreConnect)
+		options.ManageAppVersion = true
+		require.NoError(t, options.WriteToFile(pth))
+
+		content, err := os.ReadFile(pth)
+		require.NoError(t, err)
+		desired := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>app-store-connect</string>
+	</dict>
+</plist>`
+		require.Equal(t, desired, string(content))
+	}
+
+	t.Log("custom app-store type options overrides all properties")
+	{
+		tmpDir, err := pathutil.NewPathProvider().CreateTempDir("output")
+		require.NoError(t, err)
+		pth := filepath.Join(tmpDir, "exportOptions.plist")
+
+		options := NewAppStoreOptions()
+		options.TeamID = "123"
+		options.UploadBitcode = false
+		options.UploadSymbols = false
+		options.ManageAppVersion = false
+		require.NoError(t, options.WriteToFile(pth))
+
+		content, err := os.ReadFile(pth)
+		require.NoError(t, err)
+		desired := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>manageAppVersionAndBuildNumber</key>
+		<false/>
+		<key>method</key>
+		<string>app-store</string>
+		<key>teamID</key>
+		<string>123</string>
+		<key>uploadBitcode</key>
+		<false/>
+		<key>uploadSymbols</key>
+		<false/>
+	</dict>
+</plist>`
+		require.Equal(t, desired, string(content))
+	}
+}
+
+func TestNonNewAppStoreOptions(t *testing.T) {
+	t.Log("create NON app-store type export options with default values")
+	{
+		options := NewNonAppStoreOptions(MethodDevelopment)
+		require.Equal(t, MethodDevelopment, options.Method)
+		require.Equal(t, CompileBitcodeDefault, options.CompileBitcode)
+		require.Equal(t, EmbedOnDemandResourcesAssetPacksInBundleDefault, options.EmbedOnDemandResourcesAssetPacksInBundle)
+		require.Equal(t, ICloudContainerEnvironment(""), options.ICloudContainerEnvironment)
+		require.Equal(t, ThinningDefault, options.Thinning)
+	}
+}
+
+func TestNonAppStoreOptionsToHash(t *testing.T) {
+	t.Log("default NON app-store type options creates hash with method")
+	{
+		options := NewNonAppStoreOptions(MethodDevelopment)
+		hash := options.Hash()
+		require.Equal(t, 1, len(hash))
+
+		{
+			value, ok := hash[MethodKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, MethodDevelopment, value)
+		}
+	}
+
+	t.Log("custom NON app-store type option's generated hash contains all properties")
+	{
+		options := NewNonAppStoreOptions(MethodEnterprise)
+		options.TeamID = "123"
+		options.CompileBitcode = false
+		options.EmbedOnDemandResourcesAssetPacksInBundle = false
+		options.ICloudContainerEnvironment = ICloudContainerEnvironmentProduction
+		options.OnDemandResourcesAssetPacksBaseURL = "url"
+		options.Thinning = ThinningThinForAllVariants
+		options.Manifest = Manifest{
+			AppURL:               "appURL",
+			DisplayImageURL:      "displayImageURL",
+			FullSizeImageURL:     "fullSizeImageURL",
+			AssetPackManifestURL: "assetPackManifestURL",
+		}
+
+		hash := options.Hash()
+		require.Equal(t, 8, len(hash))
+
+		{
+			value, ok := hash[MethodKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, MethodEnterprise, value)
+		}
+		{
+			value, ok := hash[TeamIDKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, "123", value)
+		}
+		{
+			value, ok := hash[CompileBitcodeKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, false, value)
+		}
+		{
+			value, ok := hash[EmbedOnDemandResourcesAssetPacksInBundleKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, false, value)
+		}
+		{
+			value, ok := hash[ICloudContainerEnvironmentKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, ICloudContainerEnvironmentProduction, value)
+		}
+		{
+			value, ok := hash[OnDemandResourcesAssetPacksBaseURLKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, "url", value)
+		}
+		{
+			value, ok := hash[ThinningKey]
+			require.Equal(t, true, ok)
+			require.Equal(t, ThinningThinForAllVariants, value)
+		}
+		{
+			manifestHash, ok := hash[ManifestKey].(map[string]string)
+			require.Equal(t, true, ok)
+			require.Equal(t, 4, len(manifestHash))
+
+			{
+				value, ok := manifestHash[ManifestAppURLKey]
+				require.Equal(t, true, ok)
+				require.Equal(t, "appURL", value)
+			}
+			{
+				value, ok := manifestHash[ManifestDisplayImageURLKey]
+				require.Equal(t, true, ok)
+				require.Equal(t, "displayImageURL", value)
+			}
+			{
+				value, ok := manifestHash[ManifestFullSizeImageURLKey]
+				require.Equal(t, true, ok)
+				require.Equal(t, "fullSizeImageURL", value)
+			}
+			{
+				value, ok := manifestHash[ManifestAssetPackManifestURLKey]
+				require.Equal(t, true, ok)
+				require.Equal(t, "assetPackManifestURL", value)
+			}
+		}
+	}
+}
+
+func TestNonAppStoreOptionsWriteToFile(t *testing.T) {
+	t.Log("default NON app-store type options overrides only method")
+	{
+		tmpDir, err := pathutil.NewPathProvider().CreateTempDir("output")
+		require.NoError(t, err)
+		pth := filepath.Join(tmpDir, "exportOptions.plist")
+
+		options := NewNonAppStoreOptions(MethodEnterprise)
+		require.NoError(t, options.WriteToFile(pth))
+
+		content, err := os.ReadFile(pth)
+		require.NoError(t, err)
+		desired := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>method</key>
+		<string>enterprise</string>
+	</dict>
+</plist>`
+		require.Equal(t, desired, string(content))
+	}
+
+	t.Log("custom app-store type options overrides all properties")
+	{
+		tmpDir, err := pathutil.NewPathProvider().CreateTempDir("output")
+		require.NoError(t, err)
+		pth := filepath.Join(tmpDir, "exportOptions.plist")
+
+		options := NewNonAppStoreOptions(MethodEnterprise)
+		options.TeamID = "123"
+		options.CompileBitcode = false
+		options.EmbedOnDemandResourcesAssetPacksInBundle = false
+		options.ICloudContainerEnvironment = ICloudContainerEnvironmentProduction
+		options.OnDemandResourcesAssetPacksBaseURL = "url"
+		options.Thinning = ThinningThinForAllVariants
+		options.Manifest = Manifest{
+			AppURL:               "appURL",
+			DisplayImageURL:      "displayImageURL",
+			FullSizeImageURL:     "fullSizeImageURL",
+			AssetPackManifestURL: "assetPackManifestURL",
+		}
+
+		require.NoError(t, options.WriteToFile(pth))
+
+		content, err := os.ReadFile(pth)
+		require.NoError(t, err)
+		desired := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>compileBitcode</key>
+		<false/>
+		<key>embedOnDemandResourcesAssetPacksInBundle</key>
+		<false/>
+		<key>iCloudContainerEnvironment</key>
+		<string>Production</string>
+		<key>manifest</key>
+		<dict>
+			<key>appURL</key>
+			<string>appURL</string>
+			<key>assetPackManifestURL</key>
+			<string>assetPackManifestURL</string>
+			<key>displayImageURL</key>
+			<string>displayImageURL</string>
+			<key>fullSizeImageURL</key>
+			<string>fullSizeImageURL</string>
+		</dict>
+		<key>method</key>
+		<string>enterprise</string>
+		<key>onDemandResourcesAssetPacksBaseURL</key>
+		<string>url</string>
+		<key>teamID</key>
+		<string>123</string>
+		<key>thinning</key>
+		<string>thin-for-all-variants</string>
+	</dict>
+</plist>`
+		require.Equal(t, desired, string(content))
+	}
+}

--- a/exportoptions/non_appstore_options.go
+++ b/exportoptions/non_appstore_options.go
@@ -1,0 +1,103 @@
+package exportoptions
+
+import (
+	"fmt"
+
+	"howett.net/plist"
+)
+
+// NonAppStoreOptionsModel ...
+type NonAppStoreOptionsModel struct {
+	Method                             Method
+	TeamID                             string
+	BundleIDProvisioningProfileMapping map[string]string
+	SigningCertificate                 string
+	SigningStyle                       SigningStyle
+	Destination                        Destination
+	ICloudContainerEnvironment         ICloudContainerEnvironment
+	DistributionBundleIdentifier       string
+
+	// for non app-store exports
+	CompileBitcode                           bool
+	EmbedOnDemandResourcesAssetPacksInBundle bool
+	Manifest                                 Manifest
+	OnDemandResourcesAssetPacksBaseURL       string
+	Thinning                                 string
+}
+
+// NewNonAppStoreOptions ...
+func NewNonAppStoreOptions(method Method) NonAppStoreOptionsModel {
+	return NonAppStoreOptionsModel{
+		Method:                                   method,
+		CompileBitcode:                           CompileBitcodeDefault,
+		EmbedOnDemandResourcesAssetPacksInBundle: EmbedOnDemandResourcesAssetPacksInBundleDefault,
+		Thinning:                                 ThinningDefault,
+	}
+}
+
+// Hash ...
+func (options NonAppStoreOptionsModel) Hash() map[string]interface{} {
+	hash := map[string]interface{}{}
+	if options.Method != "" {
+		hash[MethodKey] = options.Method
+	}
+	if options.TeamID != "" {
+		hash[TeamIDKey] = options.TeamID
+	}
+	//nolint:gosimple
+	if options.CompileBitcode != CompileBitcodeDefault {
+		hash[CompileBitcodeKey] = options.CompileBitcode
+	}
+	//nolint:gosimple
+	if options.EmbedOnDemandResourcesAssetPacksInBundle != EmbedOnDemandResourcesAssetPacksInBundleDefault {
+		hash[EmbedOnDemandResourcesAssetPacksInBundleKey] = options.EmbedOnDemandResourcesAssetPacksInBundle
+	}
+	if options.ICloudContainerEnvironment != "" {
+		hash[ICloudContainerEnvironmentKey] = options.ICloudContainerEnvironment
+	}
+	if options.DistributionBundleIdentifier != "" {
+		hash[DistributionBundleIdentifier] = options.DistributionBundleIdentifier
+	}
+	if !options.Manifest.IsEmpty() {
+		hash[ManifestKey] = options.Manifest.ToHash()
+	}
+	if options.OnDemandResourcesAssetPacksBaseURL != "" {
+		hash[OnDemandResourcesAssetPacksBaseURLKey] = options.OnDemandResourcesAssetPacksBaseURL
+	}
+	if options.Thinning != ThinningDefault {
+		hash[ThinningKey] = options.Thinning
+	}
+	if len(options.BundleIDProvisioningProfileMapping) > 0 {
+		hash[ProvisioningProfilesKey] = options.BundleIDProvisioningProfileMapping
+	}
+	if options.SigningCertificate != "" {
+		hash[SigningCertificateKey] = options.SigningCertificate
+	}
+	if options.SigningStyle != "" {
+		hash[SigningStyleKey] = options.SigningStyle
+	}
+	if options.Destination != "" {
+		hash[DestinationKey] = options.Destination
+	}
+	return hash
+}
+
+// String ...
+func (options NonAppStoreOptionsModel) String() (string, error) {
+	hash := options.Hash()
+	plistBytes, err := plist.MarshalIndent(hash, plist.XMLFormat, "\t")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal export options model, error: %s", err)
+	}
+	return string(plistBytes), err
+}
+
+// WriteToFile ...
+func (options NonAppStoreOptionsModel) WriteToFile(pth string) error {
+	return WritePlistToFile(options.Hash(), pth)
+}
+
+// WriteToTmpFile ...
+func (options NonAppStoreOptionsModel) WriteToTmpFile() (string, error) {
+	return WritePlistToTmpFile(options.Hash())
+}

--- a/exportoptions/properties.go
+++ b/exportoptions/properties.go
@@ -1,0 +1,225 @@
+package exportoptions
+
+import "fmt"
+
+// CompileBitcodeKey ...
+const CompileBitcodeKey = "compileBitcode"
+
+// CompileBitcodeDefault ...
+const CompileBitcodeDefault = true
+
+// EmbedOnDemandResourcesAssetPacksInBundleKey ...
+const EmbedOnDemandResourcesAssetPacksInBundleKey = "embedOnDemandResourcesAssetPacksInBundle"
+
+// EmbedOnDemandResourcesAssetPacksInBundleDefault ...
+const EmbedOnDemandResourcesAssetPacksInBundleDefault = true
+
+// ICloudContainerEnvironmentKey ...
+const ICloudContainerEnvironmentKey = "iCloudContainerEnvironment"
+
+// ICloudContainerEnvironment ...
+type ICloudContainerEnvironment string
+
+const (
+	// ICloudContainerEnvironmentDevelopment ...
+	ICloudContainerEnvironmentDevelopment ICloudContainerEnvironment = "Development"
+	// ICloudContainerEnvironmentProduction ...
+	ICloudContainerEnvironmentProduction ICloudContainerEnvironment = "Production"
+)
+
+// DistributionBundleIdentifier ...
+const DistributionBundleIdentifier = "distributionBundleIdentifier"
+
+// ManifestKey ...
+const ManifestKey = "manifest"
+
+// ManifestAppURLKey ...
+const ManifestAppURLKey = "appURL"
+
+// ManifestDisplayImageURLKey ...
+const ManifestDisplayImageURLKey = "displayImageURL"
+
+// ManifestFullSizeImageURLKey ...
+const ManifestFullSizeImageURLKey = "fullSizeImageURL"
+
+// ManifestAssetPackManifestURLKey ...
+const ManifestAssetPackManifestURLKey = "assetPackManifestURL"
+
+// Manifest ...
+type Manifest struct {
+	AppURL               string
+	DisplayImageURL      string
+	FullSizeImageURL     string
+	AssetPackManifestURL string
+}
+
+// IsEmpty ...
+func (manifest Manifest) IsEmpty() bool {
+	return (manifest.AppURL == "" && manifest.DisplayImageURL == "" && manifest.FullSizeImageURL == "" && manifest.AssetPackManifestURL == "")
+}
+
+// ToHash ...
+func (manifest Manifest) ToHash() map[string]string {
+	hash := map[string]string{}
+	if manifest.AppURL != "" {
+		hash[ManifestAppURLKey] = manifest.AppURL
+	}
+	if manifest.DisplayImageURL != "" {
+		hash[ManifestDisplayImageURLKey] = manifest.DisplayImageURL
+	}
+	if manifest.FullSizeImageURL != "" {
+		hash[ManifestFullSizeImageURLKey] = manifest.FullSizeImageURL
+	}
+	if manifest.AssetPackManifestURL != "" {
+		hash[ManifestAssetPackManifestURLKey] = manifest.AssetPackManifestURL
+	}
+	return hash
+}
+
+// MethodKey ...
+const MethodKey = "method"
+
+// Method ...
+type Method string
+
+const (
+	// MethodAppStore is deprecated since Xcode 15.3, its new name is MethodAppStoreConnect
+	MethodAppStore Method = "app-store"
+	// MethodAdHoc is deprecated since Xcode 15.3, its new name is MethodReleaseTesting
+	MethodAdHoc Method = "ad-hoc"
+	// MethodPackage ...
+	MethodPackage Method = "package"
+	// MethodEnterprise ...
+	MethodEnterprise Method = "enterprise"
+	// MethodDevelopment is deprecated since Xcode 15.3, its new name is MethodDebugging
+	MethodDevelopment Method = "development"
+	// MethodDeveloperID ...
+	MethodDeveloperID Method = "developer-id"
+	// MethodDebugging is the new name for MethodDevelopment since Xcode 15.3
+	MethodDebugging Method = "debugging"
+	// MethodAppStoreConnect is the new name for MethodAppStore since Xcode 15.3
+	MethodAppStoreConnect Method = "app-store-connect"
+	// MethodReleaseTesting is the new name for MethodAdHoc since Xcode 15.3
+	MethodReleaseTesting Method = "release-testing"
+	// MethodDefault ...
+	MethodDefault Method = MethodDevelopment
+)
+
+func (m Method) IsAppStore() bool {
+	return m == MethodAppStore || m == MethodAppStoreConnect
+}
+
+func (m Method) IsAdHoc() bool {
+	return m == MethodAdHoc || m == MethodReleaseTesting
+}
+
+func (m Method) IsDevelopment() bool {
+	return m == MethodDevelopment || m == MethodDebugging
+}
+
+func (m Method) IsEnterprise() bool {
+	return m == MethodEnterprise
+}
+
+// ParseMethod parses Step input and returns the corresponding Method.
+func ParseMethod(method string) (Method, error) {
+	switch method {
+	case "app-store":
+		return MethodAppStore, nil
+	case "ad-hoc":
+		return MethodAdHoc, nil
+	case "package":
+		return MethodPackage, nil
+	case "enterprise":
+		return MethodEnterprise, nil
+	case "development":
+		return MethodDevelopment, nil
+	case "developer-id":
+		return MethodDeveloperID, nil
+	default:
+		return Method(""), fmt.Errorf("unkown method (%s)", method)
+	}
+}
+
+// UpgradeToXcode15_3MethodName replaces the legacy export method strings with the ones available in Xcode 15.3 and later.
+func UpgradeToXcode15_3MethodName(method Method) Method {
+	switch method {
+	case MethodAppStore:
+		return MethodAppStoreConnect
+	case MethodAdHoc:
+		return MethodReleaseTesting
+	case MethodDevelopment:
+		return MethodDebugging
+	default:
+		return method
+	}
+}
+
+// OnDemandResourcesAssetPacksBaseURLKey ....
+const OnDemandResourcesAssetPacksBaseURLKey = "onDemandResourcesAssetPacksBaseURL"
+
+// TeamIDKey ...
+const TeamIDKey = "teamID"
+
+// ThinningKey ...
+const ThinningKey = "thinning"
+
+const (
+	// ThinningNone ...
+	ThinningNone = "none"
+	// ThinningThinForAllVariants ...
+	ThinningThinForAllVariants = "thin-for-all-variants"
+	// ThinningDefault ...
+	ThinningDefault = ThinningNone
+)
+
+// UploadBitcodeKey ....
+const UploadBitcodeKey = "uploadBitcode"
+
+// UploadBitcodeDefault ...
+const UploadBitcodeDefault = true
+
+// UploadSymbolsKey ...
+const UploadSymbolsKey = "uploadSymbols"
+
+// UploadSymbolsDefault ...
+const UploadSymbolsDefault = true
+
+const (
+	manageAppVersionKey     = "manageAppVersionAndBuildNumber"
+	manageAppVersionDefault = true
+)
+
+// ProvisioningProfilesKey ...
+const ProvisioningProfilesKey = "provisioningProfiles"
+
+// SigningCertificateKey ...
+const SigningCertificateKey = "signingCertificate"
+
+// InstallerSigningCertificateKey ...
+const InstallerSigningCertificateKey = "installerSigningCertificate"
+
+// SigningStyleKey ...
+const SigningStyleKey = "signingStyle"
+
+// SigningStyle ...
+type SigningStyle string
+
+// SigningStyle ...
+const (
+	SigningStyleManual    SigningStyle = "manual"
+	SigningStyleAutomatic SigningStyle = "automatic"
+)
+
+const DestinationKey = "destination"
+
+const TestFlightInternalTestingOnlyDefault = false
+const TestFlightInternalTestingOnlyKey = "testFlightInternalTestingOnly"
+
+type Destination string
+
+// Destination ...
+const (
+	DestinationExport  Destination = "export"
+	DestinationDefault Destination = DestinationExport
+)

--- a/exportoptions/properties.go
+++ b/exportoptions/properties.go
@@ -105,18 +105,22 @@ const (
 	MethodDefault Method = MethodDevelopment
 )
 
+// IsAppStore ...
 func (m Method) IsAppStore() bool {
 	return m == MethodAppStore || m == MethodAppStoreConnect
 }
 
+// IsAdHoc ...
 func (m Method) IsAdHoc() bool {
 	return m == MethodAdHoc || m == MethodReleaseTesting
 }
 
+// IsDevelopment ...
 func (m Method) IsDevelopment() bool {
 	return m == MethodDevelopment || m == MethodDebugging
 }
 
+// IsEnterprise ...
 func (m Method) IsEnterprise() bool {
 	return m == MethodEnterprise
 }
@@ -211,11 +215,16 @@ const (
 	SigningStyleAutomatic SigningStyle = "automatic"
 )
 
+// DestinationKey ...
 const DestinationKey = "destination"
 
+// TestFlightInternalTestingOnlyDefault ...
 const TestFlightInternalTestingOnlyDefault = false
+
+// TestFlightInternalTestingOnlyKey ...
 const TestFlightInternalTestingOnlyKey = "testFlightInternalTestingOnly"
 
+// Destination ...
 type Destination string
 
 // Destination ...

--- a/exportoptions/properties_test.go
+++ b/exportoptions/properties_test.go
@@ -1,0 +1,45 @@
+package exportoptions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeToXcode15_3MethodName(t *testing.T) {
+	tests := []struct {
+		name   string
+		method Method
+		want   Method
+	}{
+		{
+			method: "app-store",
+			want:   "app-store-connect",
+		},
+		{
+			method: "ad-hoc",
+			want:   "release-testing",
+		},
+		{
+			method: "development",
+			want:   "debugging",
+		},
+		{
+			method: "enterprise",
+			want:   "enterprise",
+		},
+		{
+			method: "developer-id",
+			want:   "developer-id",
+		},
+		{
+			method: "package",
+			want:   "package",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, UpgradeToXcode15_3MethodName(tt.method))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `exportoptions` as a v2 package under `exportoptions/`. Self-contained leaf migration — no internal go-xcode dependencies, only `howett.net/plist` + go-utils basics.

Jira: [STEP-2175](https://bitrise.atlassian.net/browse/STEP-2175) (taking over from @lpusok — no branch/PR in flight)

## What changed

- New package `exportoptions/` ported from v1 (4 source + 2 test files, ~975 LOC).
- Module imports updated to `/v2`.
- API swap inside `WritePlistToFile` / `WritePlistToTmpFile`:
  - `fileutil.WriteBytesToFile(pth, b)` → `fileutil.NewFileManager().WriteBytes(pth, b)`
  - `pathutil.NormalizedOSTempDirPath("output")` → `pathutil.NewPathProvider().CreateTempDir("output")`
- Tests:
  - `fileutil.ReadStringFromFile` has no v2 equivalent on `FileManager`, so reads were switched to stdlib `os.ReadFile` with a `string(content)` conversion at the assertion site.

The public surface (`ExportOptions` interface, `WritePlistToFile`, `WritePlistToTmpFile`, `AppStoreOptionsModel`, `NonAppStoreOptionsModel`, all `Method` / key constants) is unchanged from v1.

## What did NOT change

~15 v2 files still import v1 `exportoptions` (`exportoptionsgenerator/`, `metaparser/`, `codesign/`, `autocodesign/localcodesignasset/`, plus `profileutil`). Switching them is mechanical because public signatures match v1 — left for a follow-up PR to keep this one reviewable.

## Test plan

- [x] `go test ./exportoptions/...` — all tests green (Manifest, AppStoreOptions, NonAppStoreOptions, WriteToFile golden plist, Upgrade method name).
- [x] `go build ./...` — whole repo compiles.
- [x] `gofmt -l exportoptions/` — clean.
- [x] `go vet ./exportoptions/...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2175]: https://bitrise.atlassian.net/browse/STEP-2175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ