### PR TITLE
chore: migrate utility.FindFileInAppDir to v2 (STEP-2171)

### DIFF
--- a/devportalservice/mock_filemanager.go
+++ b/devportalservice/mock_filemanager.go
@@ -2,6 +2,7 @@ package devportalservice
 
 import (
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -60,6 +61,11 @@ func (r *mockFileReader) FileSizeInBytes(pth string) (int64, error) {
 
 // CopyFile stub...
 func (r *mockFileReader) CopyFile(src, dst string, opts *fileutil.CopyOptions) error {
+	panic("implement me")
+}
+
+// CopyFileFS stub...
+func (r *mockFileReader) CopyFileFS(fsys fs.FS, src, dst string, opts *fileutil.CopyOptions) error {
 	panic("implement me")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.49
 	github.com/bitrise-io/go-utils v1.0.13
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260424152942-70f02e371123
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.35
 	github.com/bitrise-io/go-xcode v1.3.3
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/globocom/go-buffer/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,8 @@ github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.49/go.mod h1:hK2zMovlJg7+FLdJ
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=
 github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34 h1:xsLfhItfs4SCCAesbv7UtKpldNqievDvtHggSuBI2+w=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260424152942-70f02e371123 h1:cdCGv8opOOiswNWkX6PZLcfzp6RES2iF3ahupMEdLuk=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34.0.20260424152942-70f02e371123/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.35 h1:oo8FBVwXGmFH6ED2jXh7kSzwX8YBqfZshRSjpEIR41I=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.35/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/go-xcode v1.3.3 h1:aYkSMWP+1/n2ZabRy3OMfeaWmE4l1gAPq63azx06LIw=
 github.com/bitrise-io/go-xcode v1.3.3/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/mocks/FileManager.go
+++ b/mocks/FileManager.go
@@ -55,6 +55,24 @@ func (_m *FileManager) CopyFile(src string, dst string, opts *fileutil.CopyOptio
 	return r0
 }
 
+// CopyFileFS provides a mock function with given fields: fsys, src, dst, opts
+func (_m *FileManager) CopyFileFS(fsys fs.FS, src string, dst string, opts *fileutil.CopyOptions) error {
+	ret := _m.Called(fsys, src, dst, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CopyFileFS")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(fs.FS, string, string, *fileutil.CopyOptions) error); ok {
+		r0 = rf(fsys, src, dst, opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // FileSizeInBytes provides a mock function with given fields: pth
 func (_m *FileManager) FileSizeInBytes(pth string) (int64, error) {
 	ret := _m.Called(pth)

--- a/utility/path.go
+++ b/utility/path.go
@@ -1,0 +1,42 @@
+// Package utility hosts cross-cutting helpers that did not fit a more specific
+// package during the v1 → v2 migration.
+package utility
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/v2/pathutil"
+)
+
+// FindFileInAppDir locates fileName inside appDir. If appDir/fileName exists,
+// the path is returned directly; otherwise every `*.app` bundle under appDir
+// is searched for an entry whose base name equals fileName, and the first
+// match (joined back onto appDir) is returned.
+func FindFileInAppDir(appDir, fileName string) (string, error) {
+	directPth := filepath.Join(appDir, fileName)
+	if exist, err := pathutil.NewPathChecker().IsPathExists(directPth); err != nil {
+		return "", err
+	} else if exist {
+		return directPth, nil
+	}
+
+	appDirFS := os.DirFS(appDir)
+	apps, err := pathutil.FilterFS(appDirFS, pathutil.ExtensionFilter(".app", true))
+	if err != nil {
+		return "", err
+	}
+
+	for _, app := range apps {
+		matches, err := pathutil.FilterFS(os.DirFS(filepath.Join(appDir, app)), pathutil.BaseFilter(fileName, true))
+		if err != nil {
+			return "", err
+		}
+		if len(matches) > 0 {
+			return filepath.Join(appDir, app, matches[0]), nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find %s", fileName)
+}

--- a/utility/path_test.go
+++ b/utility/path_test.go
@@ -1,0 +1,68 @@
+package utility
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindFileInAppDir(t *testing.T) {
+	t.Run("direct match at appDir root", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "Info.plist")
+		require.NoError(t, os.WriteFile(target, []byte(""), 0o600))
+
+		got, err := FindFileInAppDir(dir, "Info.plist")
+		require.NoError(t, err)
+		require.Equal(t, target, got)
+	})
+
+	t.Run("match inside a .app bundle", func(t *testing.T) {
+		dir := t.TempDir()
+		bundle := filepath.Join(dir, "MyApp.app")
+		require.NoError(t, os.MkdirAll(bundle, 0o755))
+		target := filepath.Join(bundle, "embedded.mobileprovision")
+		require.NoError(t, os.WriteFile(target, []byte(""), 0o600))
+
+		got, err := FindFileInAppDir(dir, "embedded.mobileprovision")
+		require.NoError(t, err)
+		require.Equal(t, target, got)
+	})
+
+	t.Run("match inside a nested directory within .app bundle", func(t *testing.T) {
+		dir := t.TempDir()
+		nested := filepath.Join(dir, "MyApp.app", "Frameworks", "Foo.framework")
+		require.NoError(t, os.MkdirAll(nested, 0o755))
+		target := filepath.Join(nested, "Info.plist")
+		require.NoError(t, os.WriteFile(target, []byte(""), 0o600))
+
+		got, err := FindFileInAppDir(dir, "Info.plist")
+		require.NoError(t, err)
+		require.Equal(t, target, got)
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "Other.app"), 0o755))
+
+		_, err := FindFileInAppDir(dir, "missing.file")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing.file")
+	})
+
+	t.Run("direct match takes precedence over .app search", func(t *testing.T) {
+		dir := t.TempDir()
+		direct := filepath.Join(dir, "shared")
+		require.NoError(t, os.WriteFile(direct, []byte("root"), 0o600))
+
+		bundle := filepath.Join(dir, "MyApp.app")
+		require.NoError(t, os.MkdirAll(bundle, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(bundle, "shared"), []byte("bundle"), 0o600))
+
+		got, err := FindFileInAppDir(dir, "shared")
+		require.NoError(t, err)
+		require.Equal(t, direct, got)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `utility/` as a v2 package with `FindFileInAppDir` ported from v1. `GetXcodeVersion` is intentionally not migrated — `xcodeversion.Reader.GetVersion` already covers the same surface in v2.

Jira: [STEP-2171](https://bitrise.atlassian.net/browse/STEP-2171)

## What changed

### `utility/path.go`
- New file. `FindFileInAppDir(appDir, fileName) (string, error)` with v1-equivalent behavior:
  1. If `appDir/fileName` exists → return it.
  2. Otherwise walk every `*.app` bundle under `appDir` and return the first basename match.
  3. Else error.

v1 → v2 API swaps inside the function:
- `pathutil.IsPathExists(pth)` → `pathutil.NewPathChecker().IsPathExists(pth)`
- `pathutil.ListEntries(dir, filter)` → `pathutil.FilterFS(os.DirFS(dir), filter)`

The filter constructors (`ExtensionFilter`, `BaseFilter`) are reused verbatim from v2 — same names, slightly different `FilterFunc` signature (now takes `fs.DirEntry`).

### `utility/path_test.go`
Five subtests covering: direct match at root, match inside `.app`, match inside a nested directory within a `.app`, not-found error, and direct-match-takes-precedence-over-bundle-search.

### Drive-by: go-utils/v2 dependency bump
Bumped `go-utils/v2` from `alpha.34.0-pseudo` to `v2.0.0-alpha.35`. `FilterFS`, `ExtensionFilter`, and `BaseFilter` landed in that tag via [STEP-2135](https://bitrise.atlassian.net/browse/STEP-2135) / [go-utils#224](https://github.com/bitrise-io/go-utils/pull/224).

### Drive-by: regenerate `mocks/FileManager.go` + extend `devportalservice/mock_filemanager.go`
The bump added `CopyFileFS` to `fileutil.FileManager`. Regenerated the mockery mock for `mocks/FileManager.go`, and added a hand-written `CopyFileFS` panic stub to the hand-rolled `devportalservice/mock_filemanager.go` to keep both internal mocks satisfying the interface.

## Test plan

- [x] `go test ./utility/...` — all 5 subtests pass.
- [x] `go test ./...` — whole repo green (xcarchive + xcodecache exercises take a couple of minutes; both pass).
- [x] `go build ./...` — clean.
- [x] `gofmt -l utility/ devportalservice/mock_filemanager.go` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2171]: https://bitrise.atlassian.net/browse/STEP-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STEP-2135]: https://bitrise.atlassian.net/browse/STEP-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ