### PR TITLE
Improve error when App Store Connect API key download fails

### DIFF
--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -99,7 +99,8 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 			}
 		}(resp.Body)
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("downloading App Store Connect API key failed with exit status %d: %s", resp.StatusCode, resp.Body)
+			body, _ := io.ReadAll(resp.Body)
+			return nil, fmt.Errorf("downloading App Store Connect API key from the provided URL failed with HTTP status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 		}
 
 		key, err = io.ReadAll(resp.Body)


### PR DESCRIPTION
## Context

Investigating a failed `steps-xcode-archive` e2e run (`test_override_api_key_signing`), the build log showed this on a 404:

```
downloading App Store Connect API key failed with exit status 404: {%!s(*http.http2clientStream=&{0x14000141340 ...})}
```

Two problems in that one line (`codesign/inputparse.go`):

1. **`%s` on `resp.Body`** — `resp.Body` is an `io.ReadCloser`, not a string, so it prints an unreadable Go struct dump instead of the server's response.
2. **"exit status"** — misleading wording for an HTTP GET; it's an HTTP status code.

## Change

Read the response body and report the HTTP status:

```
downloading App Store Connect API key from the provided URL failed with HTTP status 404: <server response>
```

`io` and `strings` were already imported. `go build`, `go vet`, and the existing `codesign` tests all pass.

> Note: the download branch only triggers for `https://` URLs and builds its own `retryhttp` client internally, so exercising it in a unit test would need an HTTP-client injection refactor — out of scope for this message fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)