### PR TITLE
Fix file:// path parsing for local App Store Connect API key

### DIFF
--- a/codesign/inputparse.go
+++ b/codesign/inputparse.go
@@ -109,14 +109,20 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 	} else {
 		trimmedPath := string(keyPathOrURL)
 		if strings.HasPrefix(string(keyPathOrURL), "file://") {
-			trimmedPath = strings.TrimPrefix(string(keyPathOrURL), "file://")
+			// Parse as a URL so that a percent-encoded path (e.g. spaces as %20) is decoded and any
+			// host component (file://localhost/path) is dropped, leaving the bare filesystem path.
+			u, err := url.Parse(string(keyPathOrURL))
+			if err != nil {
+				return nil, fmt.Errorf("invalid file:// URL for App Store Connect API key: %w", err)
+			}
+			trimmedPath = u.Path
 		}
 		var err error
 		key, err = os.ReadFile(trimmedPath)
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("App Store Connect API does not exist at %s", trimmedPath)
+			return nil, fmt.Errorf("App Store Connect API key does not exist at %s", trimmedPath)
 		} else if err != nil {
-			return nil, fmt.Errorf("failed to read App Store Connect API at %s: %w", trimmedPath, err)
+			return nil, fmt.Errorf("failed to read App Store Connect API key at %s: %w", trimmedPath, err)
 		}
 	}
 

--- a/codesign/inputparse_test.go
+++ b/codesign/inputparse_test.go
@@ -2,6 +2,7 @@ package codesign
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -223,4 +224,23 @@ func Test_ParseConnectionOverrideConfig(t *testing.T) {
 		EnterpriseAccount: true,
 	}
 	require.Equal(t, expected, *connection)
+}
+
+func Test_ParseConnectionOverrideConfig_fileURLWithEncodedPath(t *testing.T) {
+	// Given: a key file whose path contains a space, referenced via a file:// URL.
+	// url.URL.String() percent-encodes the space (e.g. .../private%20key.p8).
+	path := filepath.Join(t.TempDir(), "private key.p8")
+	fileContent := "this is a private key"
+	require.NoError(t, os.WriteFile(path, []byte(fileContent), 0666))
+
+	fileURL := (&url.URL{Scheme: "file", Path: path}).String()
+
+	// When
+	connection, err := parseConnectionOverrideConfig(stepconf.Secret(fileURL), "ABC123", "ABC456", false, log.NewLogger())
+
+	// Then: the encoded path is decoded back to the real path and the file is read.
+	// (The previous strings.TrimPrefix implementation left "%20" in the path and failed to open it.)
+	require.NoError(t, err)
+	require.NotNil(t, connection)
+	require.Equal(t, fileContent, connection.PrivateKey)
 }


### PR DESCRIPTION
## Problem

When the App Store Connect API key is supplied as a local `file://` URL, `parseConnectionOverrideConfig` extracted the filesystem path with:

```go
trimmedPath = strings.TrimPrefix(string(keyPathOrURL), "file://")
```

Two genuine problems with that:

1. **Percent-encoding is not decoded.** A path with a space — common on macOS CI (`file:///Users/bot/deploy/my%20key.p8`) — is handed to `os.ReadFile` verbatim, including the literal `%20`, so it fails as "does not exist" even though the file is present.
2. **A host component is not dropped.** `file://localhost/Users/bot/key.p8` becomes the bogus relative path `localhost/Users/bot/key.p8`.

## Fix

Parse the value with `url.Parse` and use `u.Path`, which is already percent-decoded and host-free. `net/url` was already imported.

Also corrects the two local-file error messages: "App Store Connect **API**" → "App Store Connect **API key**".

## Test

Adds `Test_ParseConnectionOverrideConfig_fileURLWithEncodedPath`, which writes a key file with a space in its name and references it via a `file://` URL (space encoded as `%20`). It passes with the fix and fails under the old `TrimPrefix` implementation. `go build`, `go vet`, and the full `codesign` suite pass.

## Related

Split out from the discussion on #338 (which fixes the `https://` download error message). This PR is independent — it touches the local-file `else` branch, not the download branch, so the two don't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)