### PR TITLE
[STEP-2166] Add serialized package

### DIFF
--- a/xcodeproject/serialized/serialized.go
+++ b/xcodeproject/serialized/serialized.go
@@ -13,9 +13,16 @@ package serialized
 // arbitrary values.
 type Object map[string]any
 
-// Get returns the value stored at key in o as type T. ok is false if key is
-// absent or the stored value is not a T, in which case the zero value of T is
-// returned.
+// Get returns the value stored at key in o as type T via a direct type
+// assertion. ok is false — and value is the zero value of T — if key is absent
+// or the stored value's concrete type is not exactly T.
+//
+// Because it asserts rather than converts, T must match the concrete type the
+// decoder produced. For plist/JSON input that is a scalar: string, bool, int64
+// or float64. Get does NOT handle the two composite cases that require
+// conversion, so use the dedicated accessors for those:
+//   - nested dictionaries decode as map[string]any, not Object — use Object.
+//   - arrays decode as []any, not []string — use StringSlice.
 func Get[T any](o Object, key string) (value T, ok bool) {
 	raw, exists := o[key]
 	if !exists {

--- a/xcodeproject/serialized/serialized.go
+++ b/xcodeproject/serialized/serialized.go
@@ -1,0 +1,97 @@
+// Package serialized provides typed, map-like accessors over the loosely-typed
+// maps produced when decoding Xcode's plist and pbxproj object graphs. A
+// serialized.Object wraps a map[string]any and lets callers read nested values
+// by key using the comma-ok idiom: each accessor returns the value and a bool
+// that reports whether a usable value of the requested type was present.
+//
+// A false result means either the key was absent or the stored value was not
+// of the requested type. Callers that need to tell those two cases apart can
+// check Has first.
+package serialized
+
+// Object is a decoded plist/pbxproj node: a set of string keys mapped to
+// arbitrary values.
+type Object map[string]any
+
+// Get returns the value stored at key in o as type T. ok is false if key is
+// absent or the stored value is not a T, in which case the zero value of T is
+// returned.
+func Get[T any](o Object, key string) (value T, ok bool) {
+	raw, exists := o[key]
+	if !exists {
+		return value, false
+	}
+	value, ok = raw.(T)
+	return value, ok
+}
+
+// Keys returns the object's keys in unspecified order.
+func (o Object) Keys() []string {
+	keys := make([]string, 0, len(o))
+	for key := range o {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// Has reports whether key is present, regardless of the stored value's type.
+func (o Object) Has(key string) bool {
+	_, ok := o[key]
+	return ok
+}
+
+// Value returns the raw value stored at key. ok mirrors Go map semantics: it is
+// false only when key is absent.
+func (o Object) Value(key string) (value any, ok bool) {
+	value, ok = o[key]
+	return value, ok
+}
+
+// Bool returns the bool stored at key. ok is false if key is absent or the
+// value is not a bool.
+func (o Object) Bool(key string) (bool, bool) {
+	return Get[bool](o, key)
+}
+
+// String returns the string stored at key. ok is false if key is absent or the
+// value is not a string.
+func (o Object) String(key string) (string, bool) {
+	return Get[string](o, key)
+}
+
+// Int64 returns the int64 stored at key. ok is false if key is absent or the
+// value is not an int64.
+func (o Object) Int64(key string) (int64, bool) {
+	return Get[int64](o, key)
+}
+
+// StringSlice returns the []string stored at key. The value must be a []any
+// whose every element is a string. ok is false if key is absent, the value is
+// not a []any, or any element is not a string.
+func (o Object) StringSlice(key string) ([]string, bool) {
+	casted, ok := Get[[]any](o, key)
+	if !ok {
+		return nil, false
+	}
+
+	slice := make([]string, 0, len(casted))
+	for _, v := range casted {
+		item, ok := v.(string)
+		if !ok {
+			return nil, false
+		}
+		slice = append(slice, item)
+	}
+
+	return slice, true
+}
+
+// Object returns the nested Object stored at key. The value must be a
+// map[string]any. ok is false if key is absent or the value is not a map.
+func (o Object) Object(key string) (Object, bool) {
+	casted, ok := Get[map[string]any](o, key)
+	if !ok {
+		return nil, false
+	}
+	return casted, true
+}

--- a/xcodeproject/serialized/serialized_test.go
+++ b/xcodeproject/serialized/serialized_test.go
@@ -186,3 +186,30 @@ func TestGet(t *testing.T) {
 		require.Equal(t, "", v)
 	}
 }
+
+// Get asserts, it does not convert: it only succeeds for the exact concrete
+// type the decoder produced (scalars). Composite values need the dedicated
+// accessors, which is what these cases guard against a naive "just use Get"
+// refactor of Object/StringSlice.
+func TestGet_compositesRequireDedicatedAccessors(t *testing.T) {
+	o := Object{
+		"dict":  map[string]any{"k": "v"}, // decoded nested dictionary
+		"array": []any{"a", "b"},          // decoded array
+	}
+
+	// Nested dicts are map[string]any, not the named Object type.
+	_, ok := Get[Object](o, "dict")
+	require.False(t, ok, "Get[Object] must not match a stored map[string]any")
+
+	obj, ok := o.Object("dict") // Object() converts
+	require.True(t, ok)
+	require.Equal(t, Object{"k": "v"}, obj)
+
+	// Arrays are []any, not []string.
+	_, ok = Get[[]string](o, "array")
+	require.False(t, ok, "Get[[]string] must not match a stored []any")
+
+	slice, ok := o.StringSlice("array") // StringSlice() casts element-wise
+	require.True(t, ok)
+	require.Equal(t, []string{"a", "b"}, slice)
+}

--- a/xcodeproject/serialized/serialized_test.go
+++ b/xcodeproject/serialized/serialized_test.go
@@ -1,0 +1,188 @@
+package serialized
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeys(t *testing.T) {
+	o := Object{"key": "value", "key1": "value", "key2": "value"}
+	keys := o.Keys()
+	require.Equal(t, 3, len(keys))
+	require.Contains(t, keys, "key")
+	require.Contains(t, keys, "key1")
+	require.Contains(t, keys, "key2")
+}
+
+func TestHas(t *testing.T) {
+	o := Object{"present": "value", "wrongType": 42}
+
+	require.True(t, o.Has("present"))
+	require.True(t, o.Has("wrongType"))
+	require.False(t, o.Has("missing"))
+}
+
+func TestValue(t *testing.T) {
+	o := Object{"key": "value"}
+
+	{
+		v, ok := o.Value("key")
+		require.True(t, ok)
+		require.Equal(t, "value", v)
+	}
+
+	{
+		v, ok := o.Value("not_existing_key")
+		require.False(t, ok)
+		require.Nil(t, v)
+	}
+}
+
+func TestBool(t *testing.T) {
+	o := Object{"key": true, "wrong": "not_a_bool"}
+
+	{
+		v, ok := o.Bool("key")
+		require.True(t, ok)
+		require.Equal(t, true, v)
+	}
+
+	{
+		v, ok := o.Bool("missing")
+		require.False(t, ok)
+		require.Equal(t, false, v)
+	}
+
+	{
+		v, ok := o.Bool("wrong")
+		require.False(t, ok)
+		require.Equal(t, false, v)
+	}
+}
+
+func TestString(t *testing.T) {
+	o := Object{"key": "value", "wrong": 42}
+
+	{
+		v, ok := o.String("key")
+		require.True(t, ok)
+		require.Equal(t, "value", v)
+	}
+
+	{
+		v, ok := o.String("missing")
+		require.False(t, ok)
+		require.Equal(t, "", v)
+	}
+
+	{
+		v, ok := o.String("wrong")
+		require.False(t, ok)
+		require.Equal(t, "", v)
+	}
+}
+
+func TestInt64(t *testing.T) {
+	o := Object{"key": int64(42), "wrong": "not_an_int"}
+
+	{
+		v, ok := o.Int64("key")
+		require.True(t, ok)
+		require.Equal(t, int64(42), v)
+	}
+
+	{
+		v, ok := o.Int64("missing")
+		require.False(t, ok)
+		require.Equal(t, int64(0), v)
+	}
+
+	{
+		v, ok := o.Int64("wrong")
+		require.False(t, ok)
+		require.Equal(t, int64(0), v)
+	}
+}
+
+func TestObject(t *testing.T) {
+	o := Object{"key": map[string]any{"object_key": "object_value"}, "wrong": "not_an_object"}
+
+	{
+		v, ok := o.Object("key")
+		require.True(t, ok)
+		require.Equal(t, Object{"object_key": "object_value"}, v)
+	}
+
+	{
+		v, ok := o.Object("missing")
+		require.False(t, ok)
+		require.Nil(t, v)
+	}
+
+	{
+		v, ok := o.Object("wrong")
+		require.False(t, ok)
+		require.Nil(t, v)
+	}
+}
+
+func TestStringSlice(t *testing.T) {
+	o := Object{
+		"buildConfigurations": []any{"13E76E3B1F4AC90A0028096E", "13E76E3C1F4AC90A0028096E"},
+		"notASlice":           "value",
+		"mixedElements":       []any{"a", 42},
+	}
+
+	{
+		v, ok := o.StringSlice("buildConfigurations")
+		require.True(t, ok)
+		require.Equal(t, []string{"13E76E3B1F4AC90A0028096E", "13E76E3C1F4AC90A0028096E"}, v)
+	}
+
+	{
+		v, ok := o.StringSlice("missing")
+		require.False(t, ok)
+		require.Nil(t, v)
+	}
+
+	{
+		v, ok := o.StringSlice("notASlice")
+		require.False(t, ok)
+		require.Nil(t, v)
+	}
+
+	{
+		v, ok := o.StringSlice("mixedElements")
+		require.False(t, ok)
+		require.Nil(t, v)
+	}
+}
+
+func TestGet(t *testing.T) {
+	o := Object{"str": "value", "num": int64(7)}
+
+	{
+		v, ok := Get[string](o, "str")
+		require.True(t, ok)
+		require.Equal(t, "value", v)
+	}
+
+	{
+		v, ok := Get[int64](o, "num")
+		require.True(t, ok)
+		require.Equal(t, int64(7), v)
+	}
+
+	{
+		v, ok := Get[string](o, "num")
+		require.False(t, ok)
+		require.Equal(t, "", v)
+	}
+
+	{
+		v, ok := Get[string](o, "missing")
+		require.False(t, ok)
+		require.Equal(t, "", v)
+	}
+}


### PR DESCRIPTION
Migrate the v1 package to v2 with some refactoring.

In the v1 version we used named errors (`KeyNotFoundError`, `TypeCastError`) which I removed as I found better ways for them. 

The `KeyNotFoundError` was replaced by a stdlib hashmap style check:
```
name, ok := raw.String("name")
if !ok { return X{}, fmt.Errorf("...: missing 'name'") }
```
The `ok` parameters returns if the key exists or not. This is heaviest use case in the v1 package.

The `TypeCastError` is a bit more cumbersome as now:
```
v, ok := o.Bool(key)
if !ok && o.Has(key) {
    return wrong type
}
```
We need to call the `Has` function to be certain of a type mismatch. But this use case was rare and felt like we could live with it based on the previous one becoming clearer.