### PR TITLE
[STEP-2526] logio: stop handing the PrefixFilter to two goroutines

### DIFF
--- a/errorfinder/errorfinder.go
+++ b/errorfinder/errorfinder.go
@@ -16,6 +16,9 @@ func FindXcodebuildErrors(out string) []string {
 
 	scanner := bufio.NewScanner(strings.NewReader(out))
 	scanner.Split(bufio.ScanLines)
+	// xcodebuild echoes command lines well over the default 64KB token limit; one such line would make Scan
+	// fail and drop every error found so far.
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 

--- a/logio/prefix_filter.go
+++ b/logio/prefix_filter.go
@@ -37,7 +37,8 @@ func (p *PrefixFilter) Done() <-chan struct{} { return p.done }
 
 // MessageLost returns a channel on which the user can observe if there were
 // messages lost. The channel has a buffer of one to prevent early unreceived
-// messages or late subscriptions to the channel.
+// messages or late subscriptions to the channel. Only the first lost message
+// is reported, later ones are dropped rather than blocking the filter.
 func (p *PrefixFilter) MessageLost() <-chan error { return p.messageLost }
 
 // ScannerError returns a channel on which the user can observe if there were
@@ -122,17 +123,29 @@ func (p *PrefixFilter) run() {
 
 		if p.prefixRegexp.MatchString(line) {
 			if _, err := p.Matching.Write([]byte(logLine)); err != nil {
-				p.messageLost <- fmt.Errorf("intercepting message: %w", err)
+				p.reportMessageLost(err)
 			}
 		} else {
 			if _, err := p.Filtered.Write([]byte(logLine)); err != nil {
-				p.messageLost <- fmt.Errorf("intercepting message: %w", err)
+				p.reportMessageLost(err)
 			}
 		}
 	}
 
 	// handle any scanner error
 	if err := scanner.Err(); err != nil {
-		p.scannerError <- err
+		select {
+		case p.scannerError <- err:
+		default:
+		}
+	}
+}
+
+// reportMessageLost reports err on the MessageLost channel without blocking. Nothing is required to drain
+// the channel, and a blocking send here would stop the scanner, block every Write and hang the command.
+func (p *PrefixFilter) reportMessageLost(err error) {
+	select {
+	case p.messageLost <- fmt.Errorf("intercepting message: %w", err):
+	default:
 	}
 }

--- a/logio/prefix_filter.go
+++ b/logio/prefix_filter.go
@@ -37,8 +37,9 @@ func (p *PrefixFilter) Done() <-chan struct{} { return p.done }
 
 // MessageLost returns a channel on which the user can observe if there were
 // messages lost. The channel has a buffer of one to prevent early unreceived
-// messages or late subscriptions to the channel. Only the first lost message
-// is reported, later ones are dropped rather than blocking the filter.
+// messages or late subscriptions to the channel. Reports never block: a lost
+// message is reported if the previous report has been received already, and
+// dropped otherwise.
 func (p *PrefixFilter) MessageLost() <-chan error { return p.messageLost }
 
 // ScannerError returns a channel on which the user can observe if there were

--- a/xcodecommand/errors.go
+++ b/xcodecommand/errors.go
@@ -9,13 +9,15 @@ import (
 )
 
 // attachXcodebuildErrors re-wraps a failed xcodebuild command's error with the error lines found in its output,
-// the same way go-utils/command does when given an ErrorFinder.
+// as go-utils/command does when given an ErrorFinder. The lines come in FindXcodebuildErrors' order (regular
+// "error:" lines first, "xcodebuild: error:" blocks last) rather than in output order.
 //
 // The runners must not use command.Opts.ErrorFinder: with it set, go-utils wraps Stdout and Stderr in two separate
 // io.MultiWriters. os/exec merges the two streams onto one pipe and one copy goroutine only while
 // cmd.Stdout == cmd.Stderr, so the wrapping hands the shared, single-writer output (PrefixFilter, bytes.Buffer) to
-// two goroutines and corrupts it. Collecting the errors from the complete output afterwards keeps the single writer,
-// and sees whole lines instead of arbitrary chunks.
+// two goroutines and corrupts it. Collecting the errors from the output afterwards keeps the single writer, and
+// sees whole lines instead of arbitrary chunks. With xcbeautify and xcpretty that output is the filtered raw log,
+// so a `[Bitrise ...]` prefixed line is not scanned.
 func attachXcodebuildErrors(err error, printableCmdArgs string, rawOut []byte) error {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {

--- a/xcodecommand/errors.go
+++ b/xcodecommand/errors.go
@@ -1,0 +1,26 @@
+package xcodecommand
+
+import (
+	"errors"
+	"os/exec"
+
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-xcode/v2/errorfinder"
+)
+
+// attachXcodebuildErrors re-wraps a failed xcodebuild command's error with the error lines found in its output,
+// the same way go-utils/command does when given an ErrorFinder.
+//
+// The runners must not use command.Opts.ErrorFinder: with it set, go-utils wraps Stdout and Stderr in two separate
+// io.MultiWriters. os/exec merges the two streams onto one pipe and one copy goroutine only while
+// cmd.Stdout == cmd.Stderr, so the wrapping hands the shared, single-writer output (PrefixFilter, bytes.Buffer) to
+// two goroutines and corrupts it. Collecting the errors from the complete output afterwards keeps the single writer,
+// and sees whole lines instead of arbitrary chunks.
+func attachXcodebuildErrors(err error, printableCmdArgs string, rawOut []byte) error {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return err
+	}
+
+	return command.NewExitStatusError(printableCmdArgs, exitErr, errorfinder.FindXcodebuildErrors(string(rawOut)))
+}

--- a/xcodecommand/xcbeautify.go
+++ b/xcodecommand/xcbeautify.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/bitrise-io/go-xcode/v2/errorfinder"
 	"github.com/bitrise-io/go-xcode/v2/logio"
 	version "github.com/hashicorp/go-version"
 )
@@ -37,12 +36,12 @@ func (c *XcbeautifyRunner) Run(workDir string, xcodebuildArgs []string, xcbeauti
 
 	// For parallel and concurrent destination testing, it helps to use unbuffered I/O for stdout and to redirect stderr to stdout.
 	// NSUnbufferedIO=YES xcodebuild [args] 2>&1 | xcbeautify
+	// No ErrorFinder: it would give Stdout and Stderr separate wrappers and the filter two writers, see attachXcodebuildErrors.
 	buildCmd := c.commandFactory.Create("xcodebuild", xcodebuildArgs, &command.Opts{
-		Stdout:      loggingIO.XcbuildStdout,
-		Stderr:      loggingIO.XcbuildStderr,
-		Env:         unbufferedIOEnv,
-		Dir:         workDir,
-		ErrorFinder: errorfinder.FindXcodebuildErrors,
+		Stdout: loggingIO.XcbuildStdout,
+		Stderr: loggingIO.XcbuildStderr,
+		Env:    unbufferedIOEnv,
+		Dir:    workDir,
 	})
 
 	beautifyCmd := c.commandFactory.Create(xcbeautify, xcbeautifyArgs, &command.Opts{
@@ -85,6 +84,10 @@ func (c *XcbeautifyRunner) Run(workDir string, xcodebuildArgs []string, xcbeauti
 	// Closing the filter to ensure all output is flushed and processed
 	if err := loggingIO.CloseFilter(); err != nil {
 		c.logger.Warnf("logging IO failure, error: %s", err)
+	}
+
+	if err != nil {
+		err = attachXcodebuildErrors(err, buildCmd.PrintableCommandArgs(), loggingIO.XcbuildRawout.Bytes())
 	}
 
 	return Output{

--- a/xcodecommand/xcodebuild_only.go
+++ b/xcodecommand/xcodebuild_only.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bitrise-io/go-utils/progress"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
-	"github.com/bitrise-io/go-xcode/v2/errorfinder"
 	version "github.com/hashicorp/go-version"
 )
 
@@ -35,12 +34,13 @@ func (c *RawXcodeCommandRunner) Run(workDir string, args []string, _ []string) (
 		exitCode  int
 	)
 
+	// Stdout and Stderr share one buffer on purpose: os/exec then uses a single pipe and copy goroutine, so the
+	// (not goroutine-safe) bytes.Buffer has one writer. No ErrorFinder for the same reason, see attachXcodebuildErrors.
 	command := c.commandFactory.Create("xcodebuild", args, &command.Opts{
-		Stdout:      &outBuffer,
-		Stderr:      &outBuffer,
-		Env:         unbufferedIOEnv,
-		Dir:         workDir,
-		ErrorFinder: errorfinder.FindXcodebuildErrors,
+		Stdout: &outBuffer,
+		Stderr: &outBuffer,
+		Env:    unbufferedIOEnv,
+		Dir:    workDir,
 	})
 
 	c.logger.TPrintf("$ %s", command.PrintableCommandArgs())
@@ -48,6 +48,10 @@ func (c *RawXcodeCommandRunner) Run(workDir string, args []string, _ []string) (
 	progress.SimpleProgress(".", time.Minute, func() {
 		exitCode, err = command.RunAndReturnExitCode()
 	})
+
+	if err != nil {
+		err = attachXcodebuildErrors(err, command.PrintableCommandArgs(), outBuffer.Bytes())
+	}
 
 	return Output{
 		RawOut:   outBuffer.Bytes(),

--- a/xcodecommand/xcpretty.go
+++ b/xcodecommand/xcpretty.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
-	"github.com/bitrise-io/go-xcode/v2/errorfinder"
 	"github.com/bitrise-io/go-xcode/v2/logio"
 )
 
@@ -44,12 +43,12 @@ func (c *XcprettyCommandRunner) Run(workDir string, xcodebuildArgs []string, xcp
 
 	c.cleanOutputFile(xcprettyArgs)
 
+	// No ErrorFinder: it would give Stdout and Stderr separate wrappers and the filter two writers, see attachXcodebuildErrors.
 	buildCmd := c.commandFactory.Create("xcodebuild", xcodebuildArgs, &command.Opts{
-		Stdout:      loggingIO.XcbuildStdout,
-		Stderr:      loggingIO.XcbuildStderr,
-		Env:         unbufferedIOEnv,
-		Dir:         workDir,
-		ErrorFinder: errorfinder.FindXcodebuildErrors,
+		Stdout: loggingIO.XcbuildStdout,
+		Stderr: loggingIO.XcbuildStderr,
+		Env:    unbufferedIOEnv,
+		Dir:    workDir,
 	})
 
 	prettyCmd := c.commandFactory.Create("xcpretty", xcprettyArgs, &command.Opts{
@@ -91,6 +90,10 @@ func (c *XcprettyCommandRunner) Run(workDir string, xcodebuildArgs []string, xcp
 	// Closing the filter to ensure all output is flushed and processed
 	if err := loggingIO.CloseFilter(); err != nil {
 		c.logger.Warnf("logging IO failure, error: %s", err)
+	}
+
+	if err != nil {
+		err = attachXcodebuildErrors(err, buildCmd.PrintableCommandArgs(), loggingIO.XcbuildRawout.Bytes())
 	}
 
 	return Output{


### PR DESCRIPTION
Fixes the `PrefixFilter` panic (`slice bounds out of range [:4179] with capacity 4096`) that fails Xcode test/archive builds whose work already succeeded.

Root cause: two parallel writers (forwarding stdout and stderr) end up in a single unsynchronized writer (https://claude.ai/code/artifact/8d301781-87c4-4a79-b6dd-292cfcde302e)

```
Opts.ErrorFinder != nil
  → go-utils wrapOutputs: cmd.Stdout = io.MultiWriter(collector, filter)  ┐ two distinct
                          cmd.Stderr = io.MultiWriter(collector, filter)  ┘ *multiWriter values
  → exec: interfaceEqual(Stderr, Stdout) == false → two pipes, two io.Copy goroutines
  → both call filter.Write → unlocked bufio.Writer → b.n drifts past len(buf) → Flush panics
```

Adding mutexes in logio may help. Hpwever an other complication is that ErrorFinder works on a byte buffer instead of a stream. Chose to convert ErrorFinder to a stream in the next PR, this is a stopgap solution until that.



## What this does

- Remove `ErrorFinder` from the three runners. `wrapOutputs` then returns early, both fields stay the identical writer, exec keeps one goroutine, and the buffer has the single writer it was built for. Nothing about the `bufio.Writer`, the sinks or #295's close ordering changes.
- After `CloseFilter()` (which waits for the drain), find the errors on the raw output and re-wrap with `command.NewExitStatusError` — same error lines as before, `errors.As` keeps working via `Unwrap()`. One shared helper, `attachXcodebuildErrors`, for all three runners.
- Lift `FindXcodebuildErrors`' default 64KB scanner cap to 10MB. On a longer line it **returned `nil`**, dropping every error found so far; go-utils' 32KB chunking was masking it, and xcodebuild routinely echoes 64KB+ `swiftc`/`clang` command lines.
- Make `messageLost`/`scannerError` sends non-blocking. Nothing in production drains them, and the second lost message used to stall the scanner, block every `Write`, and **hang the step**.

Cost of this step: one `string(rawOut)` copy, paid only on failing builds. #347 removes it.


## Behaviour differences

- The finder sees the output as a whole, so multi-line `xcodebuild: error:` blocks stop being bisected at 32KB chunk boundaries.
- The reported lines come in `FindXcodebuildErrors`' order — regular `error:` lines first, `xcodebuild: error:` blocks last. Pre-PR the order followed chunk timing; the set of lines is unchanged.
- **Known limitation, fixed in #347:** with xcbeautify/xcpretty the finder scans the *filtered* raw log, which does not contain `[Bitrise …]`-prefixed lines. An `error:` reported there by the Build Cache wrapper (e.g. `[Bitrise Build Cache] error: failed to download cache archive`) is not attached to the step error on those formatters, where pre-PR it was. The raw formatter is unaffected. #347 feeds the finder the complete stream on all three.

## Release

Can be tagged `v2.0.0-alpha.86` on its own; re-vendor `steps-xcode-test` (where the panics were observed), `steps-xcode-archive`, `steps-xcode-build-for-test` — the vendored copy is what runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2526]: https://bitrise.atlassian.net/browse/STEP-2526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ