### PR TITLE
[STEP-2526] Make errorfinder streaming and tee it off logio

### DIFF
--- a/errorfinder/errorfinder.go
+++ b/errorfinder/errorfinder.go
@@ -1,64 +1,142 @@
 package errorfinder
 
 import (
-	"bufio"
+	"bytes"
 	"strings"
+	"sync"
 )
 
-// FindXcodebuildErrors ...
-func FindXcodebuildErrors(out string) []string {
-	var errorLines []string       // single line errors with "error: " prefix
-	var xcodebuildErrors []string // multiline errors starting with "xcodebuild: error: " prefix
-	var nserrors []nsError        // single line NSErrors with schema: Error Domain=<domain> Code=<code> "<reason>" UserInfo=<user_info>
+// maxLineLength bounds how much of a line is held back while waiting for its newline. Error lines are short,
+// so a longer line is not one: it is skipped instead of buffered.
+const maxLineLength = 1024 * 1024
 
-	isXcodebuildError := false
-	var xcodebuildError string
+// Finder finds xcodebuild errors in a stream of log output.
+//
+// It is an io.Writer so that it can be teed off a log pipeline, and the writes do not have to be line aligned:
+// a partial line is held back until its newline arrives. Call Errors once the stream ended.
+type Finder struct {
+	mu sync.Mutex
 
-	scanner := bufio.NewScanner(strings.NewReader(out))
-	scanner.Split(bufio.ScanLines)
-	// xcodebuild echoes command lines well over the default 64KB token limit; one such line would make Scan
-	// fail and drop every error found so far.
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
+	pending  []byte // partial trailing line, held until its newline arrives
+	skipping bool   // the pending line grew past maxLineLength, the rest of it is dropped
 
-		if isXcodebuildError {
-			line = strings.TrimLeft(line, " ")
-			if strings.HasPrefix(line, "Reason: ") || strings.HasPrefix(line, "Recovery suggestion: ") {
-				xcodebuildError += "\n" + line
-				continue
-			} else {
-				xcodebuildErrors = append(xcodebuildErrors, xcodebuildError)
-				xcodebuildError = ""
-				isXcodebuildError = false
-			}
+	errorLines        []string  // single line errors with "error: " prefix
+	xcodebuildErrors  []string  // multiline errors starting with "xcodebuild: error: " prefix
+	nserrors          []nsError // single line NSErrors with schema: Error Domain=<domain> Code=<code> "<reason>" UserInfo=<user_info>
+	isXcodebuildError bool
+	xcodebuildError   string
+}
+
+// NewFinder returns a Finder ready to receive output.
+func NewFinder() *Finder {
+	return &Finder{}
+}
+
+// Write consumes the next chunk of output. It never fails and always reports the whole chunk as written, so it
+// can not interrupt an io.MultiWriter it is part of.
+func (f *Finder) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	n := len(p)
+	for len(p) > 0 {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			f.appendPending(p)
+			break
 		}
-
-		switch {
-		case strings.HasPrefix(line, "xcodebuild: error: "):
-			xcodebuildError = line
-			isXcodebuildError = true
-		case strings.HasPrefix(line, "error: ") || strings.Contains(line, " error: "):
-			errorLines = append(errorLines, line)
-		case strings.HasPrefix(line, "Error "):
-			if e := newNSError(line); e != nil {
-				nserrors = append(nserrors, *e)
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil
+		f.appendPending(p[:i])
+		f.finishLine()
+		p = p[i+1:]
 	}
 
-	if xcodebuildError != "" {
-		xcodebuildErrors = append(xcodebuildErrors, xcodebuildError)
+	return n, nil
+}
+
+// Errors returns the errors found so far. The current end of the output is treated as the end of a line (a last
+// line without a newline is processed, an open multiline error is closed), so it is safe to call more than once.
+func (f *Finder) Errors() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if len(f.pending) > 0 || f.skipping {
+		f.finishLine()
 	}
+	f.closeXcodebuildError()
 
 	// Regular error lines (line with 'error: ' prefix) seems to have
 	// NSError line pairs (same description) in some cases.
-	errorLines = intersection(errorLines, nserrors)
+	errorLines := intersection(f.errorLines, f.nserrors)
 
-	return append(errorLines, xcodebuildErrors...)
+	return append(errorLines, f.xcodebuildErrors...)
+}
+
+// FindXcodebuildErrors returns the xcodebuild errors found in out. See Finder for the streaming form.
+func FindXcodebuildErrors(out string) []string {
+	f := NewFinder()
+	_, _ = f.Write([]byte(out))
+
+	return f.Errors()
+}
+
+func (f *Finder) appendPending(b []byte) {
+	if f.skipping {
+		return
+	}
+	if len(f.pending)+len(b) > maxLineLength {
+		f.pending = f.pending[:0]
+		f.skipping = true
+
+		return
+	}
+	f.pending = append(f.pending, b...)
+}
+
+// finishLine feeds the completed pending line to the state machine. A skipped (overlong) line is not an error
+// line, but it still ends a multiline xcodebuild error, so it is consumed as an empty line.
+func (f *Finder) finishLine() {
+	line := ""
+	if !f.skipping {
+		line = string(f.pending)
+	}
+	f.pending = f.pending[:0]
+	f.skipping = false
+
+	f.consumeLine(line)
+}
+
+// consumeLine is one step of the line-oriented state machine.
+func (f *Finder) consumeLine(line string) {
+	if f.isXcodebuildError {
+		line = strings.TrimLeft(line, " ")
+		if strings.HasPrefix(line, "Reason: ") || strings.HasPrefix(line, "Recovery suggestion: ") {
+			f.xcodebuildError += "\n" + line
+
+			return
+		}
+		f.closeXcodebuildError()
+	}
+
+	switch {
+	case strings.HasPrefix(line, "xcodebuild: error: "):
+		f.xcodebuildError = line
+		f.isXcodebuildError = true
+	case strings.HasPrefix(line, "error: ") || strings.Contains(line, " error: "):
+		f.errorLines = append(f.errorLines, line)
+	case strings.HasPrefix(line, "Error "):
+		if e := newNSError(line); e != nil {
+			f.nserrors = append(f.nserrors, *e)
+		}
+	}
+}
+
+func (f *Finder) closeXcodebuildError() {
+	if !f.isXcodebuildError {
+		return
+	}
+	f.xcodebuildErrors = append(f.xcodebuildErrors, f.xcodebuildError)
+	f.xcodebuildError = ""
+	f.isXcodebuildError = false
 }
 
 func intersection(errorLines []string, nserrors []nsError) []string {

--- a/errorfinder/finder_test.go
+++ b/errorfinder/finder_test.go
@@ -1,0 +1,91 @@
+package errorfinder
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	regularError = `error: exportArchive: "watchkit-app.app" requires a provisioning profile.`
+	nsErrorLine  = `Error Domain=IDEProvisioningErrorDomain Code=9 ""watchkit-app.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="watchkit-app.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}`
+	// with the leading whitespace xcodebuild indents the continuation lines with
+	xcodebuildError = "xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.\n" +
+		"        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme\n" +
+		"        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform."
+)
+
+// streamOutput exercises every branch of the state machine, with a multiline error in the middle.
+var streamOutput = strings.Join([]string{
+	"Build settings from command line:",
+	regularError,
+	"",
+	nsErrorLine,
+	"CompileSwift normal arm64 /path/to/File.swift",
+	xcodebuildError,
+	"A bunch of nonsense",
+	" error: store upload failed",
+}, "\n")
+
+func writeInChunks(t *testing.T, f *Finder, in string, chunk int) {
+	for len(in) > 0 {
+		n := min(chunk, len(in))
+		written, err := f.Write([]byte(in[:n]))
+		require.NoError(t, err)
+		require.Equal(t, n, written)
+		in = in[n:]
+	}
+}
+
+func TestFinder_ChunkingDoesNotChangeTheResult(t *testing.T) {
+	want := FindXcodebuildErrors(streamOutput)
+	require.Len(t, want, 3, "fixture should yield the NSError-merged regular error, the store upload error and the xcodebuild error")
+
+	for _, chunk := range []int{1, 2, 7, 64, len(streamOutput)} {
+		t.Run(fmt.Sprintf("%d byte chunks", chunk), func(t *testing.T) {
+			f := NewFinder()
+			writeInChunks(t, f, streamOutput, chunk)
+
+			assert.Equal(t, want, f.Errors())
+		})
+	}
+}
+
+func TestFinder_ErrorsIsRepeatable(t *testing.T) {
+	f := NewFinder()
+	writeInChunks(t, f, streamOutput, len(streamOutput))
+
+	first := f.Errors()
+	assert.Equal(t, first, f.Errors())
+}
+
+func TestFinder_SkipsOverlongLines(t *testing.T) {
+	longLine := strings.Repeat("x", maxLineLength+1)
+	out := "error: first\n" + longLine + "\nerror: second\n"
+	want := []string{"error: first", "error: second"}
+
+	assert.Equal(t, want, FindXcodebuildErrors(out))
+
+	// in chunks as well, so the cap is hit in the middle of the line
+	f := NewFinder()
+	writeInChunks(t, f, out, 4096)
+	assert.Equal(t, want, f.Errors())
+}
+
+func TestFinder_OverlongLineEndsMultilineError(t *testing.T) {
+	out := "xcodebuild: error: testing failed\nReason: test again\n" +
+		strings.Repeat("x", maxLineLength+1) + "\n" +
+		"Recovery suggestion: not part of it\n"
+
+	assert.Equal(t, []string{"xcodebuild: error: testing failed\nReason: test again"}, FindXcodebuildErrors(out))
+}
+
+func TestFinder_TrailingLineWithoutNewline(t *testing.T) {
+	f := NewFinder()
+	writeInChunks(t, f, "nonsense\nerror: at the very end", 5)
+
+	assert.Equal(t, []string{"error: at the very end"}, f.Errors())
+}

--- a/logio/pipe_wiring.go
+++ b/logio/pipe_wiring.go
@@ -54,11 +54,10 @@ func (p *PipeWiring) Close() error {
 // input/outputs that an xcodebuild command and a logging tool needs when we are also
 // using a logging filter.
 //
-// filteredTees also receive the filtered (non-matching) output, that is xcodebuild's own
-// lines without the ones matching filter. They are written from a single goroutine, in
-// line fragments: a line longer than the filter's read buffer arrives in several writes,
-// the last of which ends with the newline.
-func SetupPipeWiring(filter *regexp.Regexp, filteredTees ...io.Writer) *PipeWiring {
+// tees also receive xcodebuild's complete output, both streams, as it arrives: in the
+// chunks os/exec copies, before the filter, from a single goroutine. A tee that needs
+// lines has to assemble them itself.
+func SetupPipeWiring(filter *regexp.Regexp, tees ...io.Writer) *PipeWiring {
 	// Create a buffer to store raw xcbuild output
 	rawXcbuild := bytes.NewBuffer(nil)
 	// Pipe filtered logs to tool
@@ -68,7 +67,7 @@ func SetupPipeWiring(filter *regexp.Regexp, filteredTees ...io.Writer) *PipeWiri
 	bufferedStdout := NewSink(os.Stdout)
 	// Add a buffer before tool input
 	toolInSink := NewSink(toolPipeW)
-	xcbuildLogs := io.MultiWriter(append([]io.Writer{rawXcbuild, toolInSink}, filteredTees...)...)
+	xcbuildLogs := io.MultiWriter(rawXcbuild, toolInSink)
 	// Create a filter for [Bitrise ...] prefixes
 	bitrisePrefixFilter := NewPrefixFilter(
 		filter,
@@ -76,14 +75,19 @@ func SetupPipeWiring(filter *regexp.Regexp, filteredTees ...io.Writer) *PipeWiri
 		xcbuildLogs,
 	)
 
+	// One value for both of xcodebuild's streams (the `2>&1` of the shell pipeline). os/exec
+	// merges the two streams onto one pipe, copied by one goroutine, only while cmd.Stdout and
+	// cmd.Stderr are the same value; that is what keeps the single-writer filter safe. Do not
+	// wrap the two fields separately, and do not split them into two filters.
+	xcbuildOut := io.Writer(bitrisePrefixFilter)
+	if len(tees) > 0 {
+		xcbuildOut = io.MultiWriter(append([]io.Writer{bitrisePrefixFilter}, tees...)...)
+	}
+
 	return &PipeWiring{
 		XcbuildRawout: rawXcbuild,
-		// Deliberately the same writer for both streams (the `2>&1` of the shell pipeline). os/exec
-		// merges the two streams onto one pipe, copied by one goroutine, only while cmd.Stdout and
-		// cmd.Stderr are the same value; that is what keeps the single-writer filter safe. Do not
-		// wrap them separately, and do not split them into two filters.
-		XcbuildStdout: bitrisePrefixFilter,
-		XcbuildStderr: bitrisePrefixFilter,
+		XcbuildStdout: xcbuildOut,
+		XcbuildStderr: xcbuildOut,
 		ToolStdin:     toolPipeR,
 		ToolStdout:    os.Stdout,
 		ToolStderr:    os.Stderr,

--- a/logio/pipe_wiring.go
+++ b/logio/pipe_wiring.go
@@ -53,7 +53,12 @@ func (p *PipeWiring) Close() error {
 // SetupPipeWiring creates a new PipeWiring instance that contains the usual
 // input/outputs that an xcodebuild command and a logging tool needs when we are also
 // using a logging filter.
-func SetupPipeWiring(filter *regexp.Regexp) *PipeWiring {
+//
+// filteredTees also receive the filtered (non-matching) output, that is xcodebuild's own
+// lines without the ones matching filter. They are written from a single goroutine, in
+// line fragments: a line longer than the filter's read buffer arrives in several writes,
+// the last of which ends with the newline.
+func SetupPipeWiring(filter *regexp.Regexp, filteredTees ...io.Writer) *PipeWiring {
 	// Create a buffer to store raw xcbuild output
 	rawXcbuild := bytes.NewBuffer(nil)
 	// Pipe filtered logs to tool
@@ -63,7 +68,7 @@ func SetupPipeWiring(filter *regexp.Regexp) *PipeWiring {
 	bufferedStdout := NewSink(os.Stdout)
 	// Add a buffer before tool input
 	toolInSink := NewSink(toolPipeW)
-	xcbuildLogs := io.MultiWriter(rawXcbuild, toolInSink)
+	xcbuildLogs := io.MultiWriter(append([]io.Writer{rawXcbuild, toolInSink}, filteredTees...)...)
 	// Create a filter for [Bitrise ...] prefixes
 	bitrisePrefixFilter := NewPrefixFilter(
 		filter,
@@ -73,6 +78,10 @@ func SetupPipeWiring(filter *regexp.Regexp) *PipeWiring {
 
 	return &PipeWiring{
 		XcbuildRawout: rawXcbuild,
+		// Deliberately the same writer for both streams (the `2>&1` of the shell pipeline). os/exec
+		// merges the two streams onto one pipe, copied by one goroutine, only while cmd.Stdout and
+		// cmd.Stderr are the same value; that is what keeps the single-writer filter safe. Do not
+		// wrap them separately, and do not split them into two filters.
 		XcbuildStdout: bitrisePrefixFilter,
 		XcbuildStderr: bitrisePrefixFilter,
 		ToolStdin:     toolPipeR,

--- a/logio/pipe_wiring_test.go
+++ b/logio/pipe_wiring_test.go
@@ -41,7 +41,7 @@ func TestSetupPipeWiring_XcbuildStreamsShareOneWriter(t *testing.T) {
 	}
 }
 
-func TestSetupPipeWiring_TeesReceiveTheFilteredOutput(t *testing.T) {
+func TestSetupPipeWiring_TeesReceiveTheCompleteOutput(t *testing.T) {
 	tee := &safeBuffer{}
 	sut := logio.SetupPipeWiring(regexp.MustCompile(`^\[Bitrise.*\].*`), tee)
 	go func() { _, _ = io.Copy(io.Discard, sut.ToolStdin) }()
@@ -53,6 +53,9 @@ func TestSetupPipeWiring_TeesReceiveTheFilteredOutput(t *testing.T) {
 
 	_ = sut.Close()
 
-	assert.Equal(t, msg1+msg4, tee.String(), "the tee gets xcodebuild's own lines, not the Bitrise ones")
+	assert.Equal(t, msg1+msg2+msg3+msg4, tee.String(), "the tee gets everything xcodebuild wrote, on either stream, before filtering")
 	assert.Equal(t, msg1+msg4, sut.XcbuildRawout.String())
+	if sut.XcbuildStdout != sut.XcbuildStderr {
+		t.Fatal("with a tee the two streams must still be the same writer")
+	}
 }

--- a/logio/pipe_wiring_test.go
+++ b/logio/pipe_wiring_test.go
@@ -20,11 +20,39 @@ func TestPipeWiring(t *testing.T) {
 
 	_, _ = sut.XcbuildStdout.Write([]byte(msg1))
 	_, _ = sut.XcbuildStdout.Write([]byte(msg2))
-	_, _ = sut.XcbuildStdout.Write([]byte(msg3))
-	_, _ = sut.XcbuildStdout.Write([]byte(msg4))
+	_, _ = sut.XcbuildStderr.Write([]byte(msg3))
+	_, _ = sut.XcbuildStderr.Write([]byte(msg4))
 
 	_ = sut.Close()
 
 	assert.Equal(t, msg1+msg4, sut.XcbuildRawout.String())
 	assert.Equal(t, msg1+msg4, out.Messages())
+}
+
+func TestSetupPipeWiring_XcbuildStreamsShareOneWriter(t *testing.T) {
+	sut := logio.SetupPipeWiring(regexp.MustCompile(`^\[Bitrise.*\].*`))
+	defer func() { _ = sut.Close() }()
+
+	// == on purpose: os/exec merges the two streams onto one pipe and one copy goroutine only while the two values
+	// are equal, which is what keeps the single-writer filter safe. assert.Equal falls back to reflect.DeepEqual,
+	// which would also accept two distinct wrappers around the same filter.
+	if sut.XcbuildStdout != sut.XcbuildStderr {
+		t.Fatal("XcbuildStdout and XcbuildStderr must be the same writer")
+	}
+}
+
+func TestSetupPipeWiring_TeesReceiveTheFilteredOutput(t *testing.T) {
+	tee := &safeBuffer{}
+	sut := logio.SetupPipeWiring(regexp.MustCompile(`^\[Bitrise.*\].*`), tee)
+	go func() { _, _ = io.Copy(io.Discard, sut.ToolStdin) }()
+
+	_, _ = sut.XcbuildStdout.Write([]byte(msg1))
+	_, _ = sut.XcbuildStdout.Write([]byte(msg2))
+	_, _ = sut.XcbuildStderr.Write([]byte(msg3))
+	_, _ = sut.XcbuildStderr.Write([]byte(msg4))
+
+	_ = sut.Close()
+
+	assert.Equal(t, msg1+msg4, tee.String(), "the tee gets xcodebuild's own lines, not the Bitrise ones")
+	assert.Equal(t, msg1+msg4, sut.XcbuildRawout.String())
 }

--- a/logio/prefix_filter.go
+++ b/logio/prefix_filter.go
@@ -2,22 +2,31 @@ package logio
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"regexp"
 	"sync"
 )
 
+// readBufferSize is the size of the line fragments a longer line is forwarded in.
+const readBufferSize = 64 * 1024
+
 // PrefixFilter intercept writes: when the message has a prefix that matches a
 // regexp it writes into the `Matching` sink, otherwise to the `Filtered` sink.
+//
+// PrefixFilter is not safe for concurrent use: Write buffers into a bufio.Writer, and
+// it expects a single writer. Handing the same PrefixFilter to both exec.Cmd.Stdout and
+// exec.Cmd.Stderr satisfies that, os/exec copies both streams with one goroutine then.
 //
 // Note: Callers are responsible for closing `Matching` and `Filtered` Sinks
 type PrefixFilter struct {
 	prefixRegexp *regexp.Regexp
 
 	// internal buffered middleman between xcbuild and scan
-	filterInput bufio.ReadWriter
+	filterInput *bufio.Writer
 	pipeW       *io.PipeWriter
+	pipeR       *io.PipeReader
 
 	Matching *Sink
 	Filtered io.Writer
@@ -51,7 +60,6 @@ func (p *PrefixFilter) ScannerError() <-chan error { return p.scannerError }
 //
 // Note: Callers are responsible for closing intercepted and target writers that implement io.Closer
 func NewPrefixFilter(prefixRegexp *regexp.Regexp, matching *Sink, filtered io.Writer) *PrefixFilter {
-	// This is the backing field of the bufio.ReadWriter
 	pipeR, pipeW := io.Pipe()
 	messageLost := make(chan error, 1)
 	done := make(chan struct{}, 1)
@@ -59,8 +67,9 @@ func NewPrefixFilter(prefixRegexp *regexp.Regexp, matching *Sink, filtered io.Wr
 
 	filter := &PrefixFilter{
 		prefixRegexp: prefixRegexp,
-		filterInput:  *bufio.NewReadWriter(bufio.NewReader(pipeR), bufio.NewWriter(pipeW)),
+		filterInput:  bufio.NewWriter(pipeW),
 		pipeW:        pipeW,
+		pipeR:        pipeR,
 		closeOnce:    sync.Once{},
 		messageLost:  messageLost,
 		done:         done,
@@ -74,6 +83,7 @@ func NewPrefixFilter(prefixRegexp *regexp.Regexp, matching *Sink, filtered io.Wr
 }
 
 // Write implements io.Writer. It writes into an internal pipe which the interceptor goroutine consumes.
+// It must not be called concurrently, see PrefixFilter.
 func (p *PrefixFilter) Write(data []byte) (int, error) {
 	return p.filterInput.Write(data)
 }
@@ -104,6 +114,9 @@ func (p *PrefixFilter) Close() error {
 // run reads lines (and partial final chunk) and writes them.
 func (p *PrefixFilter) run() {
 	defer func() {
+		// With the reader gone a writer parked in Write would block forever, so unblock it.
+		_ = p.pipeR.Close()
+
 		// Signal done and close signaling channels
 		p.done <- struct{}{}
 		close(p.done)
@@ -111,33 +124,45 @@ func (p *PrefixFilter) run() {
 		close(p.scannerError)
 	}()
 
-	// Use a scanner but with a large buffer to handle long lines.
-	scanner := bufio.NewScanner(p.filterInput)
-	const maxTokenSize = 10 * 1024 * 1024
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, maxTokenSize)
-
-	for scanner.Scan() {
-		line := scanner.Text() // note: newline removed
-		// re-append newline to preserve same output format
-		logLine := line + "\n"
-
-		if p.prefixRegexp.MatchString(line) {
-			if _, err := p.Matching.Write([]byte(logLine)); err != nil {
-				p.reportMessageLost(err)
+	// A line longer than the buffer is forwarded in fragments rather than buffered whole (a
+	// Scanner would give up on it and stop). The destination is picked on the first fragment,
+	// the prefix regexp is anchored so that is enough, and kept until the newline.
+	reader := bufio.NewReaderSize(p.pipeR, readBufferSize)
+	var dst io.Writer
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(fragment) > 0 {
+			if dst == nil {
+				dst = p.Filtered
+				if p.prefixRegexp.Match(bytes.TrimSuffix(fragment, []byte{'\n'})) {
+					dst = p.Matching
+				}
 			}
-		} else {
-			if _, err := p.Filtered.Write([]byte(logLine)); err != nil {
-				p.reportMessageLost(err)
+			// Copy: fragment is a view into the reader's buffer, and Sink keeps what it is given.
+			logLine := bytes.Clone(fragment)
+			if err == io.EOF {
+				// re-append newline to the partial final chunk to preserve same output format
+				logLine = append(logLine, '\n')
+			}
+			if _, werr := dst.Write(logLine); werr != nil {
+				p.reportMessageLost(werr)
+			}
+			if logLine[len(logLine)-1] == '\n' {
+				dst = nil
 			}
 		}
-	}
 
-	// handle any scanner error
-	if err := scanner.Err(); err != nil {
-		select {
-		case p.scannerError <- err:
+		switch err {
+		case nil, bufio.ErrBufferFull:
+			continue
+		case io.EOF:
+			return
 		default:
+			select {
+			case p.scannerError <- err:
+			default:
+			}
+			return
 		}
 	}
 }

--- a/logio/prefix_filter_robustness_test.go
+++ b/logio/prefix_filter_robustness_test.go
@@ -1,0 +1,107 @@
+//nolint:errcheck
+package logio_test
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bitrise-io/go-xcode/v2/logio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A line twice the size of the buffer the old bufio.Scanner gave up at; giving up meant everything after it was lost
+// and, with nothing reading the pipe any more, the next Write blocked forever.
+func TestPrefixFilter_LongLineIsForwardedNotDropped(t *testing.T) {
+	re := regexp.MustCompile(`^\[Bitrise.*\].*`)
+	matching := &safeBuffer{}
+	matchingSink := logio.NewSink(matching)
+	rest := &safeBuffer{}
+
+	sut := logio.NewPrefixFilter(re, matchingSink, rest)
+
+	longLine := strings.Repeat("x", 20*1024*1024) + "\n"
+	_, _ = sut.Write([]byte(longLine))
+	_, _ = sut.Write([]byte(msg2))
+	_, _ = sut.Write([]byte(msg1))
+
+	require.NoError(t, sut.Close())
+	<-sut.Done()
+	require.NoError(t, matchingSink.Close())
+
+	assert.Equal(t, longLine+msg1, rest.String())
+	assert.Equal(t, msg2, matching.String())
+	select {
+	case err := <-sut.ScannerError():
+		assert.NoError(t, err)
+	default:
+	}
+}
+
+// Nothing in production drains MessageLost, so a blocking send there stalled the scanner on the second lost message.
+func TestPrefixFilter_LostMessagesDoNotStallTheFilter(t *testing.T) {
+	re := regexp.MustCompile(`^\[Bitrise.*\].*`)
+	matchingSink := logio.NewSink(&safeBuffer{})
+	failing := &failingWriter{}
+
+	sut := logio.NewPrefixFilter(re, matchingSink, failing)
+
+	const lines = 100
+	for i := 0; i < lines; i++ {
+		_, _ = sut.Write([]byte(msg1))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = sut.Close()
+		<-sut.Done()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("filter stalled on lost messages")
+	}
+
+	assert.EqualValues(t, lines, failing.calls.Load(), "every line should still have been offered to the destination")
+	assert.Error(t, <-sut.MessageLost(), "the first lost message is reported")
+	_, more := <-sut.MessageLost()
+	assert.False(t, more, "the rest are dropped and the channel is closed")
+}
+
+// --------------------------------
+// Helpers
+// --------------------------------
+
+// safeBuffer is a bytes.Buffer that can be written by a Sink's flusher goroutine and read by the test.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+type failingWriter struct {
+	calls atomic.Int32
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	w.calls.Add(1)
+	return 0, errors.New("destination gone")
+}

--- a/logio/prefix_filter_smallwrites_bench_test.go
+++ b/logio/prefix_filter_smallwrites_bench_test.go
@@ -1,0 +1,32 @@
+package logio_test
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"testing"
+
+	"github.com/bitrise-io/go-xcode/v2/logio"
+)
+
+// BenchmarkPrefixFilterSmallWrites is the NSUnbufferedIO=YES shape: many ~100 byte lines, one Write each, then a
+// full drain. Close and Done are inside the timed region so the whole write-and-drain cost is measured.
+func BenchmarkPrefixFilterSmallWrites(b *testing.B) {
+	re := regexp.MustCompile(`^\[Bitrise.*\].*`)
+	lines := make([][]byte, 0, 2*b.N)
+	for i := 0; i < b.N; i++ {
+		lines = append(lines,
+			fmt.Appendf(nil, "CompileSwift normal arm64 /Users/vagrant/git/App/Sources/File%d.swift (in target 'App')\n", i),
+			fmt.Appendf(nil, "[Bitrise Build Cache] hit for compilation unit %d\n", i))
+	}
+
+	b.ResetTimer()
+	matching := logio.NewSink(io.Discard)
+	sut := logio.NewPrefixFilter(re, matching, logio.NewSink(io.Discard))
+	for _, line := range lines {
+		_, _ = sut.Write(line)
+	}
+	_ = sut.Close()
+	<-sut.Done()
+	_ = matching.Close()
+}

--- a/xcodecommand/errors.go
+++ b/xcodecommand/errors.go
@@ -5,24 +5,22 @@ import (
 	"os/exec"
 
 	"github.com/bitrise-io/go-utils/v2/command"
-	"github.com/bitrise-io/go-xcode/v2/errorfinder"
 )
 
-// attachXcodebuildErrors re-wraps a failed xcodebuild command's error with the error lines found in its output,
-// as go-utils/command does when given an ErrorFinder. The lines come in FindXcodebuildErrors' order (regular
+// attachXcodebuildErrors re-wraps a failed xcodebuild command's error with the error lines an errorfinder.Finder found
+// in its output, as go-utils/command does when given an ErrorFinder. The lines come in the finder's order (regular
 // "error:" lines first, "xcodebuild: error:" blocks last) rather than in output order.
 //
 // The runners must not use command.Opts.ErrorFinder: with it set, go-utils wraps Stdout and Stderr in two separate
 // io.MultiWriters. os/exec merges the two streams onto one pipe and one copy goroutine only while
 // cmd.Stdout == cmd.Stderr, so the wrapping hands the shared, single-writer output (PrefixFilter, bytes.Buffer) to
-// two goroutines and corrupts it. Collecting the errors from the output afterwards keeps the single writer, and
-// sees whole lines instead of arbitrary chunks. With xcbeautify and xcpretty that output is the filtered raw log,
-// so a `[Bitrise ...]` prefixed line is not scanned.
-func attachXcodebuildErrors(err error, printableCmdArgs string, rawOut []byte) error {
+// two goroutines and corrupts it. A Finder teed off that single shared writer sees the complete output of both
+// streams, like the go-utils collector did, and assembles the lines itself.
+func attachXcodebuildErrors(err error, printableCmdArgs string, errorLines []string) error {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		return err
 	}
 
-	return command.NewExitStatusError(printableCmdArgs, exitErr, errorfinder.FindXcodebuildErrors(string(rawOut)))
+	return command.NewExitStatusError(printableCmdArgs, exitErr, errorLines)
 }

--- a/xcodecommand/runner_test.go
+++ b/xcodecommand/runner_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const xcodebuildFixture = `Build settings from command line:
-[Bitrise Analytics] a Bitrise line that happens to contain error: nope
+[Bitrise Build Cache] error: failed to download cache archive: connection reset
 CompileSwift normal arm64 /path/to/File.swift
 error: exportArchive: "code-sign-test.app" requires a provisioning profile.
 xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
@@ -65,7 +65,8 @@ func TestXcbeautifyRunner_Run(t *testing.T) {
 	assert.Contains(t, string(out.RawOut), "CompileSwift")
 	assert.NotContains(t, string(out.RawOut), "[Bitrise Analytics]", "Bitrise's own lines go to the console, not the raw output")
 	assertReportsErrors(t, err, wantErrorLines)
-	assert.NotContains(t, err.Error(), "nope", "only xcodebuild's own output is scanned for errors")
+	assert.Contains(t, err.Error(), "[Bitrise Build Cache] error: failed to download cache archive",
+		"Bitrise's own lines are scanned as well, as the go-utils collector did")
 }
 
 func TestRawXcodeCommandRunner_Run(t *testing.T) {

--- a/xcodecommand/runner_test.go
+++ b/xcodecommand/runner_test.go
@@ -1,0 +1,123 @@
+package xcodecommand
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/v2/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const xcodebuildFixture = `Build settings from command line:
+[Bitrise Analytics] a Bitrise line that happens to contain error: nope
+CompileSwift normal arm64 /path/to/File.swift
+error: exportArchive: "code-sign-test.app" requires a provisioning profile.
+xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform
+** TEST FAILED **
+`
+
+var wantErrorLines = []string{
+	`error: exportArchive: "code-sign-test.app" requires a provisioning profile.`,
+	"xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.\n" +
+		"Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme\n" +
+		"Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform",
+}
+
+func TestXcbeautifyRunner_Run(t *testing.T) {
+	var opts *command.Opts
+	failure := command.NewExitStatusError("xcodebuild test", exitError(t, 65), nil)
+
+	build := new(mocks.Command)
+	build.On("PrintableCommandArgs").Return("xcodebuild test")
+	build.On("Start").Return(nil)
+	build.On("Wait").Run(func(mock.Arguments) {
+		// os/exec copies the child's output between Start and Wait
+		_, _ = io.WriteString(opts.Stdout, xcodebuildFixture)
+	}).Return(failure)
+
+	tool := new(mocks.Command)
+	tool.On("PrintableCommandArgs").Return(xcbeautify)
+	tool.On("Start").Return(nil)
+	tool.On("Wait").Return(nil)
+
+	factory := new(mocks.CommandFactory)
+	factory.On("Create", "xcodebuild", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		opts = args.Get(2).(*command.Opts)
+	}).Return(build)
+	factory.On("Create", xcbeautify, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		// xcbeautify would read its stdin; drain it so the pipeline does not stall
+		go func() { _, _ = io.Copy(io.Discard, args.Get(2).(*command.Opts).Stdin) }()
+	}).Return(tool)
+
+	out, err := NewXcbeautifyRunner(log.NewLogger(), factory).Run("", []string{"test"}, nil)
+
+	assertSingleWriter(t, opts)
+	assert.Equal(t, 65, out.ExitCode)
+	assert.Contains(t, string(out.RawOut), "CompileSwift")
+	assert.NotContains(t, string(out.RawOut), "[Bitrise Analytics]", "Bitrise's own lines go to the console, not the raw output")
+	assertReportsErrors(t, err, wantErrorLines)
+	assert.NotContains(t, err.Error(), "nope", "only xcodebuild's own output is scanned for errors")
+}
+
+func TestRawXcodeCommandRunner_Run(t *testing.T) {
+	var opts *command.Opts
+	failure := command.NewExitStatusError("xcodebuild test", exitError(t, 65), nil)
+
+	build := new(mocks.Command)
+	build.On("PrintableCommandArgs").Return("xcodebuild test")
+	build.On("RunAndReturnExitCode").Run(func(mock.Arguments) {
+		_, _ = io.WriteString(opts.Stdout, xcodebuildFixture)
+	}).Return(65, failure)
+
+	factory := new(mocks.CommandFactory)
+	factory.On("Create", "xcodebuild", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		opts = args.Get(2).(*command.Opts)
+	}).Return(build)
+
+	out, err := NewRawCommandRunner(log.NewLogger(), factory).Run("", []string{"test"}, nil)
+
+	assertSingleWriter(t, opts)
+	assert.Equal(t, 65, out.ExitCode)
+	assert.Equal(t, xcodebuildFixture, string(out.RawOut))
+	assertReportsErrors(t, err, wantErrorLines)
+}
+
+// assertSingleWriter pins the topology the runners rely on: os/exec merges xcodebuild's stdout and stderr onto one
+// pipe with one copy goroutine only while cmd.Stdout == cmd.Stderr, and an ErrorFinder would make go-utils wrap the
+// two separately (see attachXcodebuildErrors).
+func assertSingleWriter(t *testing.T, opts *command.Opts) {
+	t.Helper()
+	require.NotNil(t, opts, "xcodebuild should have been created")
+	assert.Nil(t, opts.ErrorFinder, "an ErrorFinder splits the streams into two writers")
+	// == on purpose, assert.Equal (reflect.DeepEqual) would also accept two distinct wrappers around the same writer
+	if opts.Stdout != opts.Stderr {
+		t.Fatal("xcodebuild's Stdout and Stderr must be the same writer")
+	}
+}
+
+func assertReportsErrors(t *testing.T, err error, lines []string) {
+	t.Helper()
+	require.Error(t, err)
+	var exitStatusErr *command.ExitStatusError
+	require.True(t, errors.As(err, &exitStatusErr), "the error should still be an ExitStatusError: %v", err)
+	for _, line := range lines {
+		assert.Contains(t, err.Error(), line)
+	}
+}
+
+func exitError(t *testing.T, code int) *exec.ExitError {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr))
+	return exitErr
+}

--- a/xcodecommand/xcbeautify.go
+++ b/xcodecommand/xcbeautify.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/v2/errorfinder"
 	"github.com/bitrise-io/go-xcode/v2/logio"
 	version "github.com/hashicorp/go-version"
 )
@@ -32,7 +33,8 @@ func NewXcbeautifyRunner(logger log.Logger, commandFactory command.Factory) Runn
 
 // Run runs xcodebuild using xcbeautify as an output formatter
 func (c *XcbeautifyRunner) Run(workDir string, xcodebuildArgs []string, xcbeautifyArgs []string) (Output, error) {
-	loggingIO := logio.SetupPipeWiring(regexp.MustCompile(`^\[Bitrise.*\].*`))
+	errFinder := errorfinder.NewFinder()
+	loggingIO := logio.SetupPipeWiring(regexp.MustCompile(`^\[Bitrise.*\].*`), errFinder)
 
 	// For parallel and concurrent destination testing, it helps to use unbuffered I/O for stdout and to redirect stderr to stdout.
 	// NSUnbufferedIO=YES xcodebuild [args] 2>&1 | xcbeautify
@@ -87,7 +89,7 @@ func (c *XcbeautifyRunner) Run(workDir string, xcodebuildArgs []string, xcbeauti
 	}
 
 	if err != nil {
-		err = attachXcodebuildErrors(err, buildCmd.PrintableCommandArgs(), loggingIO.XcbuildRawout.Bytes())
+		err = attachXcodebuildErrors(err, buildCmd.PrintableCommandArgs(), errFinder.Errors())
 	}
 
 	return Output{

--- a/xcodecommand/xcodebuild_only.go
+++ b/xcodecommand/xcodebuild_only.go
@@ -2,11 +2,13 @@ package xcodecommand
 
 import (
 	"bytes"
+	"io"
 	"time"
 
 	"github.com/bitrise-io/go-utils/progress"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/v2/errorfinder"
 	version "github.com/hashicorp/go-version"
 )
 
@@ -34,11 +36,14 @@ func (c *RawXcodeCommandRunner) Run(workDir string, args []string, _ []string) (
 		exitCode  int
 	)
 
-	// Stdout and Stderr share one buffer on purpose: os/exec then uses a single pipe and copy goroutine, so the
-	// (not goroutine-safe) bytes.Buffer has one writer. No ErrorFinder for the same reason, see attachXcodebuildErrors.
+	// Stdout and Stderr share one writer on purpose: os/exec then uses a single pipe and copy goroutine, so the
+	// (not goroutine-safe) buffer and finder have one writer. No ErrorFinder for the same reason, see
+	// attachXcodebuildErrors.
+	errFinder := errorfinder.NewFinder()
+	out := io.MultiWriter(&outBuffer, errFinder)
 	command := c.commandFactory.Create("xcodebuild", args, &command.Opts{
-		Stdout: &outBuffer,
-		Stderr: &outBuffer,
+		Stdout: out,
+		Stderr: out,
 		Env:    unbufferedIOEnv,
 		Dir:    workDir,
 	})
@@ -50,7 +55,7 @@ func (c *RawXcodeCommandRunner) Run(workDir string, args []string, _ []string) (
 	})
 
 	if err != nil {
-		err = attachXcodebuildErrors(err, command.PrintableCommandArgs(), outBuffer.Bytes())
+		err = attachXcodebuildErrors(err, command.PrintableCommandArgs(), errFinder.Errors())
 	}
 
 	return Output{

--- a/xcodecommand/xcpretty.go
+++ b/xcodecommand/xcpretty.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/bitrise-io/go-xcode/v2/errorfinder"
 	"github.com/bitrise-io/go-xcode/v2/logio"
 )
 
@@ -39,7 +40,8 @@ func NewXcprettyCommandRunner(logger log.Logger, commandFactory command.Factory,
 
 // Run runs xcodebuild using xcpretty as a log formatter
 func (c *XcprettyCommandRunner) Run(workDir string, xcodebuildArgs []string, xcprettyArgs []string) (Output, error) {
-	loggingIO := logio.SetupPipeWiring(regexp.MustCompile(`^\[Bitrise.*\].*`))
+	errFinder := errorfinder.NewFinder()
+	loggingIO := logio.SetupPipeWiring(regexp.MustCompile(`^\[Bitrise.*\].*`), errFinder)
 
 	c.cleanOutputFile(xcprettyArgs)
 
@@ -93,7 +95,7 @@ func (c *XcprettyCommandRunner) Run(workDir string, xcodebuildArgs []string, xcp
 	}
 
 	if err != nil {
-		err = attachXcodebuildErrors(err, buildCmd.PrintableCommandArgs(), loggingIO.XcbuildRawout.Bytes())
+		err = attachXcodebuildErrors(err, buildCmd.PrintableCommandArgs(), errFinder.Errors())
 	}
 
 	return Output{


### PR DESCRIPTION
**Stacked PR 2/2** — base is `STEP-2526-logio-race` (#346, the minimal fix). This one carries the proper design on top; the diff shown here is only the streaming commit. Jira: [STEP-2526](https://bitrise.atlassian.net/browse/STEP-2526).

## What this does

#346 removed `ErrorFinder` from the runners and scans the drained raw output with `FindXcodebuildErrors`. That works, but it copies the whole log to do it, on xcbeautify/xcpretty it only sees the *filtered* log (no `[Bitrise …]` lines — review finding), and `FindXcodebuildErrors` on chunks was the design flaw in the first place: it forced error collection into the byte streams (the panic) and bisected lines at chunk boundaries. This PR moves error finding onto a streaming `Finder` that sees the complete output and assembles lines itself.

- **`errorfinder.Finder`** — an `io.Writer` form of the same line-oriented state machine (the per-line `switch` verbatim), fed incrementally. Manual `\n` splitting, no `bufio.Scanner`; lines over 1MB are *skipped*, not truncated — a truncated command line can look like an error. `FindXcodebuildErrors` is now a thin wrapper over it, and the existing suite passes unchanged.
- **`logio.SetupPipeWiring(filter, tees ...io.Writer)`** — variadic, source-compatible. Tees receive xcodebuild's **complete** output, both streams, *in front of* the filter, as one `io.MultiWriter` shared by both `exec.Cmd` fields — so `cmd.Stdout == cmd.Stderr` still holds and exec keeps one copy goroutine. That is exactly what go-utils' collector used to see. logio gains no dependency on `errorfinder`; the invariant is documented where the shared value is built.
- **Runners** pass a `Finder` as the tee and take `finder.Errors()` after `CloseFilter()`. The raw runner shares **one** `io.MultiWriter(&outBuffer, finder)` between both streams the same way. No whole-log copy, `errorCollector` off the path entirely, and error attribution is identical across the three formatters again.
- **`PrefixFilter.run()` read side** — `bufio.Reader.ReadSlice` fragment loop. The 10MB `Scanner` it replaces stopped permanently on a longer line, lost everything after it, and left exec's copy goroutine blocked on a pipe nobody read — the step hung. Fragments are routed by the anchored regexp on the first one and forwarded as they come (`bytes.Clone`d — `Sink` retains what it is given). `pipeR.Close()` in the `defer` turns any early exit into a failure rather than a hang.

The write path — `bufio.Writer`, sinks, #295's close ordering — is still untouched.

## Tests

- `Finder`: identical `Errors()` for 1/2/7/64-byte chunking vs one shot; `Errors()` repeatable; >1MB line between two errors; overlong line closes a multiline block; trailing line without newline.
- `logio`: `XcbuildStdout == XcbuildStderr` with the `==` operator (`assert.Equal`'s `DeepEqual` would accept two distinct wrappers); tee gets the complete output and both fields stay one value; `TestPipeWiring` writes to both fields; 20MB line through `PrefixFilter` (hung before); 100 lost messages don't stall the filter (hung before).
- `xcodecommand`: mock-factory runner tests (xcbeautify + raw) asserting no `ErrorFinder`, stream identity, and that `Run`'s error carries the `error:` line, a `[Bitrise Build Cache] error:` line from the other branch, and the multi-line `xcodebuild: error:` block intact — there was no runner test calling `Run()` before.
- `go test -race` green on all three packages; full `go test ./...` green.
- `BenchmarkPrefixFilterSmallWrites` (NSUnbufferedIO shape, drain inside the timed region): 2.4–2.5 µs/op, 12 allocs vs 2.5–2.6 µs/op, 16 allocs on master.

## Behaviour notes

- Multi-line `xcodebuild: error:` / `Reason:` / `Recovery suggestion:` blocks are no longer split at 32KB chunk boundaries.
- `\r\n` now passes through as-is (`ScanLines` used to drop the `\r`).
- All three runners scan the complete output, Bitrise's own lines included — same as pre-PR go-utils behaviour, and unlike #346, which on xcbeautify/xcpretty scans only the filtered raw log.

## Follow-ups (separate tickets)

`xcresult3/xcresulttool.go` shares `combinedBuffer` between two *different* MultiWriters (same class of race, not covered); go-utils `wrapOutputs` should preserve stream identity and `errorCollector` needs a mutex for every other caller; `Sink.Push` silently drops on its 1s timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2526]: https://bitrise.atlassian.net/browse/STEP-2526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ